### PR TITLE
Annotation polymorphism with Interfaces

### DIFF
--- a/src/de/caluga/morphium/AnnotationAndReflectionHelper.java
+++ b/src/de/caluga/morphium/AnnotationAndReflectionHelper.java
@@ -1,5 +1,6 @@
 package de.caluga.morphium;
 
+import com.sun.org.apache.bcel.internal.generic.NEW;
 import de.caluga.morphium.annotations.*;
 import de.caluga.morphium.annotations.caching.AsyncWrites;
 import de.caluga.morphium.annotations.caching.WriteBuffer;
@@ -86,6 +87,19 @@ public class AnnotationAndReflectionHelper {
             }
             z = z.getSuperclass();
             if (z == null) break;
+        }
+
+        Queue<Class<?>> interfaces = new LinkedList<>();
+        for (Class<?> anInterface : cls.getInterfaces()) {
+            interfaces.add(anInterface);
+        }
+        while(!interfaces.isEmpty()) {
+            Class<?> iface = interfaces.poll();
+            if(iface.isAnnotationPresent(anCls))
+                return iface.getAnnotation(anCls);
+            for (Class<?> anInterface : iface.getInterfaces()) {
+                interfaces.add(anInterface);
+            }
         }
         return null;
     }

--- a/src/de/caluga/morphium/AnnotationAndReflectionHelper.java
+++ b/src/de/caluga/morphium/AnnotationAndReflectionHelper.java
@@ -1,6 +1,5 @@
 package de.caluga.morphium;
 
-import com.sun.org.apache.bcel.internal.generic.NEW;
 import de.caluga.morphium.annotations.*;
 import de.caluga.morphium.annotations.caching.AsyncWrites;
 import de.caluga.morphium.annotations.caching.WriteBuffer;

--- a/test/de/caluga/test/mongo/suite/InterfacePolymorphismTest.java
+++ b/test/de/caluga/test/mongo/suite/InterfacePolymorphismTest.java
@@ -1,0 +1,81 @@
+package de.caluga.test.mongo.suite;
+
+import de.caluga.morphium.MorphiumSingleton;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.annotations.caching.NoCache;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: bfsmith
+ * Date: 30.03.15
+ * Test interface polymorphism mechanism in Morphium
+ */
+public class InterfacePolymorphismTest extends MongoTest {
+    @Test
+    public void polymorphTest() throws Exception {
+        MorphiumSingleton.get().dropCollection(IfaceTestType.class);
+        IfaceTestType ifaceTestType = new IfaceTestType();
+        ifaceTestType.setName("A Complex Type");
+        ifaceTestType.setPolyTest(new SubClass(11));
+        MorphiumSingleton.get().store(ifaceTestType);
+
+        assert (MorphiumSingleton.get().createQueryFor(IfaceTestType.class).countAll() == 2);
+        List<IfaceTestType> lst = MorphiumSingleton.get().createQueryFor(IfaceTestType.class).asList();
+        for (IfaceTestType tst : lst) {
+            log.info("Class " + tst.getClass().toString());
+        }
+    }
+
+    @Entity
+    public class IfaceTestType {
+        @Id
+        private ObjectId id;
+        private String name;
+        private IPolyTest polyTest;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public IPolyTest getPolyTest() {
+            return polyTest;
+        }
+
+        public void setPolyTest(IPolyTest polyTest) {
+            this.polyTest = polyTest;
+        }
+    }
+
+    @Entity(polymorph = true)
+    @NoCache
+    public static interface IPolyTest {
+        int getNumber();
+    }
+
+    public static class SubClass implements IPolyTest {
+        private int number;
+
+        private SubClass() {}
+
+        public SubClass(int num) {
+            number = num;
+        }
+
+        public int getNumber() {
+            return number;
+        }
+
+        public void setNumber(int number) {
+            this.number = number;
+        }
+    }
+}


### PR DESCRIPTION
I noticed annotations on Interfaces weren't being inherited.  The polymorphism support only followed classes (abstract and concrete). This change adds support for inheriting Annotations from interfaces.  I added a test for the functionality comparable to your PolymorphismTest.