### PR TITLE
Support lists of objects with provided custom mapper

### DIFF
--- a/src/de/caluga/morphium/ObjectMapperImpl.java
+++ b/src/de/caluga/morphium/ObjectMapperImpl.java
@@ -15,6 +15,7 @@ import java.io.*;
 import java.lang.reflect.*;
 import java.math.BigInteger;
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * User: Stpehan Bösebeck
@@ -688,9 +689,18 @@ public class ObjectMapperImpl implements ObjectMapper {
 //                    List lst = new ArrayList<Object>();
 //                    lst.add(value);
 //                    morphium.firePostLoad(lst);
+                } else if (hasCustomMapper(fld.getType())) {
+                	if (valueFromDb instanceof Map)
+                		value = unmarshall(fld.getType(), (HashMap<String, Object>) valueFromDb);
+                	else
+                		value = customMapper.get(fld.getType()).unmarshall(valueFromDb);
                 } else if (Map.class.isAssignableFrom(fld.getType())) {
                     Map<String, Object> map = (Map<String, Object>) valueFromDb;
-                    value = createMap(map);
+                    Map toFill = new HashMap();
+                    if (map != null) {
+                        fillMap((ParameterizedType) fld.getGenericType(), map, toFill, ret);
+                    }
+                    value = toFill;
                 } else if (Collection.class.isAssignableFrom(fld.getType()) || fld.getType().isArray()) {
 
                     List lst = new ArrayList();
@@ -732,7 +742,30 @@ public class ObjectMapperImpl implements ObjectMapper {
                     } else {
                         List<Map<String, Object>> l = (List<Map<String, Object>>) valueFromDb;
                         if (l != null) {
-                            fillList(fld, l, lst, ret);
+                        	// type is List<?> or ?[]
+                       	 	ParameterizedType type;
+                            if (fld.getGenericType() instanceof ParameterizedType)
+                            	type = (ParameterizedType) fld.getGenericType();
+                            else
+                            	// a real array! time to create a custom parameterized type!
+	                           	type = new ParameterizedType() {
+										
+										@Override
+										public Type getRawType() {
+											return Array.class;
+										}
+										
+										@Override
+										public Type getOwnerType() {
+											return null;
+										}
+										
+										@Override
+										public Type[] getActualTypeArguments() {
+											return new Type[]{fld.getType().getComponentType()};
+										}
+									};
+                        	fillList(fld, fld.getAnnotation(Reference.class), type, l, lst, ret);
                         }
                     }
                     if (fld.getType().isArray()) {
@@ -816,9 +849,7 @@ public class ObjectMapperImpl implements ObjectMapper {
                 } else {
                     if (fld.getType().isEnum()) {
                         value = Enum.valueOf((Class<? extends Enum>) fld.getType(), (String) valueFromDb);
-                    } else if (hasCustomMapper(fld.getType())) {
-                        value = customMapper.get(fld.getType()).unmarshall(valueFromDb);
-                    } else {
+                    } else  {
                         value = valueFromDb;
                     }
                 }
@@ -868,96 +899,63 @@ public class ObjectMapperImpl implements ObjectMapper {
         Map retMap = new HashMap(dbObject);
         if (dbObject != null) {
             for (String n : dbObject.keySet()) {
-
-                if (dbObject.get(n) instanceof Map) {
-                    Object val = dbObject.get(n);
-                    if (((Map<String, Object>) val).containsKey("class_name") || ((Map<String, Object>) val).containsKey("className")) {
-                        //Entity to map!
-                        String cn = (String) ((Map<String, Object>) val).get("class_name");
-                        if (cn == null) {
-                            cn = (String) ((Map<String, Object>) val).get("className");
-                        }
-                        try {
-                            Class ecls = Class.forName(cn);
-                            Object obj = unmarshall(ecls, (HashMap<String, Object>) dbObject.get(n));
-                            if (obj != null) retMap.put(n, obj);
-                        } catch (ClassNotFoundException e) {
-                            throw new RuntimeException(e);
-                        }
-                    } else if (((Map<String, Object>) val).containsKey("_b64data")) {
-                        String d = (String) ((Map<String, Object>) val).get("_b64data");
-                        BASE64Decoder dec = new BASE64Decoder();
-                        ObjectInputStream in = null;
-                        try {
-                            in = new ObjectInputStream(new ByteArrayInputStream(dec.decodeBuffer(d)));
-                            Object read = in.readObject();
-                            retMap.put(n, read);
-                        } catch (IOException | ClassNotFoundException e) {
-                            throw new RuntimeException(e);
-                        }
-
-                    } else {
-                        //maybe a map of maps? --> recurse
-                        retMap.put(n, createMap((Map<String, Object>) val));
-                    }
-                } else if (dbObject.get(n) instanceof List) {
-                    List<Map<String, Object>> lst = (List<Map<String, Object>>) dbObject.get(n);
-                    List mapValue = createList(lst);
-                    retMap.put(n, mapValue);
-                }
+            	retMap.put(n, unmarshallInternal(dbObject.get(n)));
             }
         } else {
             retMap = null;
         }
         return retMap;
     }
+    
+    private Object unmarshallInternal(Object val) {
+    	if (val instanceof Map) {
+	    	Map<String, Object> mapVal = (Map<String, Object>) val;
+            if (mapVal.containsKey("class_name") || mapVal.containsKey("className")) {
+                //Entity to map!
+                String cn = (String) mapVal.get("class_name");
+                if (cn == null) cn = (String) mapVal.get("className");
+                try {
+                    Class ecls = Class.forName(cn);
+                    Object obj = unmarshall(ecls, mapVal);
+                    if (obj != null) return obj;
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (mapVal.containsKey("_b64data") || mapVal.containsKey("b64Data")) {
+                String d = (String) mapVal.get("_b64data");
+                if (d == null) d = (String) mapVal.get("b64Data");
+                BASE64Decoder dec = new BASE64Decoder();
+                ObjectInputStream in = null;
+                try {
+                    in = new ObjectInputStream(new ByteArrayInputStream(dec.decodeBuffer(d)));
+                    Object read = in.readObject();
+                    return read;
+                } catch (IOException | ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                //maybe a normal map --> recurse
+                return createMap(mapVal);
+            }
+        } else if (val instanceof List) {
+            List<Map<String, Object>> lst = (List<Map<String, Object>>) val;
+            List mapValue = createList(lst);
+            return mapValue;
+        }
+	    return val;
+    }
 
     private List createList(List<Map<String, Object>> lst) {
         List mapValue = new ArrayList();
         for (Object li : lst) {
-            if (li instanceof Map) {
-                if (((Map<String, Object>) li).containsKey("class_name") || ((Map<String, Object>) li).containsKey("className")) {
-                    String cn = (String) ((Map<String, Object>) li).get("class_name");
-                    if (cn == null) {
-                        cn = (String) ((Map<String, Object>) li).get("className");
-                    }
-                    try {
-                        Class ecls = Class.forName(cn);
-                        Object obj = unmarshall(ecls, (HashMap<String, Object>) li);
-                        if (obj != null) mapValue.add(obj);
-                    } catch (ClassNotFoundException e) {
-                        throw new RuntimeException(e);
-                    }
-                } else if (((Map<String, Object>) li).containsKey("_b64data")) {
-                    String d = (String) ((Map<String, Object>) li).get("_b64data");
-                    BASE64Decoder dec = new BASE64Decoder();
-                    ObjectInputStream in = null;
-                    try {
-                        in = new ObjectInputStream(new ByteArrayInputStream(dec.decodeBuffer(d)));
-                        Object read = in.readObject();
-                        mapValue.add(read);
-                    } catch (IOException | ClassNotFoundException e) {
-                        throw new RuntimeException(e);
-                    }
-
-                } else {
-
-
-                    mapValue.add(createMap((Map<String, Object>) li));
-                }
-            } else if (li instanceof List) {
-                mapValue.add(createList((List<Map<String, Object>>) li));
-            } else {
-                mapValue.add(li);
-            }
+            mapValue.add(unmarshallInternal(li));
         }
         return mapValue;
     }
-
+    
     @SuppressWarnings({"unchecked", "ConstantConditions"})
-    private void fillList(Field forField, List<Map<String, Object>> fromDB, List toFillIn, Object containerEntity) {
-        if (forField.isAnnotationPresent(Reference.class)) {
-            Reference ref = forField.getAnnotation(Reference.class);
+    private void fillList(Field forField, Reference ref, ParameterizedType listType, List<Map<String, Object>> fromDB, List toFillIn, Object containerEntity) {
+        if (ref != null) {
             for (Map<String, Object> obj : fromDB) {
                 if (obj == null) {
                     toFillIn.add(null);
@@ -987,55 +985,41 @@ public class ObjectMapperImpl implements ObjectMapper {
             return;
         }
         for (Object val : fromDB) {
-            if (val instanceof Map) {
-                if (((Map<String, Object>) val).containsKey("class_name") || ((Map<String, Object>) val).containsKey("className")) {
-                    //Entity to map!
-                    String cn = (String) ((Map<String, Object>) val).get("class_name");
-                    if (cn == null) {
-                        cn = (String) ((Map<String, Object>) val).get("className");
+        	if (val instanceof Map) {
+                if (listType != null) {    
+                	//have a list of something
+                	if (listType.getActualTypeArguments()[0] instanceof Class) {
+                		Class cls = (Class) listType.getActualTypeArguments()[0];
+                    
+	                	Entity entity = annotationHelper.getAnnotationFromHierarchy(cls, Entity.class); //(Entity) sc.getAnnotation(Entity.class);
+	                    Embedded embedded = annotationHelper.getAnnotationFromHierarchy(cls, Embedded.class);//(Embedded) sc.getAnnotation(Embedded.class);
+	                    if (entity != null || embedded != null || hasCustomMapper(cls)) {
+	                        toFillIn.add(unmarshall(cls, (Map<String, Object>) val));
+	                        continue;
+	                    }
+                	}
+                	// that is an actual map!
+                	else {
+    	            	HashMap mp = new HashMap();
+    	            	fillMap((ParameterizedType) listType.getActualTypeArguments()[0], (Map<String, Object>) val, mp, containerEntity);
+    	            	toFillIn.add(mp);
+    	            	continue;
                     }
-                    try {
-                        Class ecls = Class.forName(cn);
-                        Object um = unmarshall(ecls, (HashMap<String, Object>) val);
-                        if (um != null) toFillIn.add(um);
-                    } catch (ClassNotFoundException e) {
-                        throw new RuntimeException(e);
-                    }
-                } else if (((Map<String, Object>) val).containsKey("_b64data")) {
-                    String d = (String) ((Map<String, Object>) val).get("_b64data");
-                    if (d == null) d = (String) ((Map<String, Object>) val).get("b64Data");
-                    BASE64Decoder dec = new BASE64Decoder();
-                    ObjectInputStream in = null;
-                    try {
-                        in = new ObjectInputStream(new ByteArrayInputStream(dec.decodeBuffer(d)));
-                        Object read = in.readObject();
-                        toFillIn.add(read);
-                    } catch (IOException | ClassNotFoundException e) {
-                        throw new RuntimeException(e);
-                    }
-
-                } else {
-
-                    if (forField != null && forField.getGenericType() instanceof ParameterizedType) {
-                        //have a list of something
-                        ParameterizedType listType = (ParameterizedType) forField.getGenericType();
-                        while (listType.getActualTypeArguments()[0] instanceof ParameterizedType) {
-                            listType = (ParameterizedType) listType.getActualTypeArguments()[0];
-                        }
-                        Class cls = (Class) listType.getActualTypeArguments()[0];
-                        Entity entity = annotationHelper.getAnnotationFromHierarchy(cls, Entity.class); //(Entity) sc.getAnnotation(Entity.class);
-                        Embedded embedded = annotationHelper.getAnnotationFromHierarchy(cls, Embedded.class);//(Embedded) sc.getAnnotation(Embedded.class);
-                        if (hasCustomMapper(cls) || entity != null || embedded != null)
-                            val = unmarshall(cls, (Map<String, Object>) val);
-                    }
-                    //Probably an "normal" map
-                    toFillIn.add(val);
+                }
+                else {
+	            	HashMap mp = new HashMap();
+	            	fillMap((ParameterizedType) listType.getActualTypeArguments()[0], (Map<String, Object>) val, mp, containerEntity);
+	            	toFillIn.add(mp);
+	            	continue;
                 }
             } else if (val instanceof MorphiumId) {
-                if (forField.getGenericType() instanceof ParameterizedType) {
+                if (listType != null) {
                     //have a list of something
-                    ParameterizedType listType = (ParameterizedType) forField.getGenericType();
-                    Class cls = (Class) listType.getActualTypeArguments()[0];
+                	Class cls;
+                	if (listType.getActualTypeArguments()[0] instanceof ParameterizedType)
+                		cls = (Class) ((ParameterizedType) listType.getActualTypeArguments()[0]).getRawType();
+                	else
+                		cls = (Class) listType.getActualTypeArguments()[0];
                     Query q = morphium.createQueryFor(cls);
                     q = q.f(annotationHelper.getFields(cls, Id.class).get(0)).eq(val);
                     toFillIn.add(q.get());
@@ -1043,44 +1027,79 @@ public class ObjectMapperImpl implements ObjectMapper {
                     log.warn("Cannot de-reference to unknown collection - trying to add Object only");
                     toFillIn.add(val);
                 }
-
+                continue;
             } else if (val instanceof List) {
                 //list in list
                 ArrayList lt = new ArrayList();
-                fillList(forField, (List<Map<String, Object>>) val, lt, containerEntity);
+                fillList(forField, ref, (ParameterizedType) listType.getActualTypeArguments()[0], (List<Map<String, Object>>) val, lt, containerEntity);
                 toFillIn.add(lt);
-//            } else if (val instanceof DBRef) {
-//                try {
-//                    DBRef ref = (DBRef) val;
-//                    Object id = ref.getId();
-//                    Class clz = Class.forName(ref.getCollectionName());
-//                    List<String> idFlds = annotationHelper.getFields(clz, Id.class);
-//                    Reference reference = forField != null ? forField.getAnnotation(Reference.class) : null;
-//
-//                    if (reference != null && reference.lazyLoading()) {
-//                        if (idFlds.isEmpty())
-//                            throw new IllegalArgumentException("Referenced object does not have an ID? Is it an Entity?");
-//                        toFillIn.add(morphium.createLazyLoadedEntity(clz, id, containerEntity, forField.getName()));
-//                    } else {
-//                        try {
-//                            morphium.fireWouldDereference(containerEntity, forField.getName(), id, clz, false);
-//                            Query q = morphium.createQueryFor(clz);
-//                            q = q.f(idFlds.get(0)).eq(id);
-//                            Object e = q.get();
-//                            toFillIn.add(e);
-//                            morphium.fireDidDereference(containerEntity, forField.getName(), e, false);
-//                        } catch (MorphiumAccessVetoException e1) {
-//                            log.info("Not de-referencing due to veto exception from Listeiner", e1);
-//                        }
-//                    }
-//                } catch (ClassNotFoundException e) {
-//                    throw new RuntimeException(e);
-//                }
+                continue;
 
-            } else {
-                toFillIn.add(val);
             }
+            toFillIn.add(unmarshallInternal(val));
         }
     }
+    
+    
+    @SuppressWarnings({"unchecked", "ConstantConditions"})
+    private void fillMap(ParameterizedType mapType, Map<String, Object> fromDB, Map toFillIn, Object containerEntity) {
+        for (Entry<String, Object> entry : fromDB.entrySet()) {
+        	String key = entry.getKey();
+        	Object val = entry.getValue();
+            if (val instanceof Map) {
+                if (mapType != null) {    
+                	//have a list of something
+                	
+                	if (mapType.getActualTypeArguments()[1] instanceof Class) {
+                		Class cls = (Class) mapType.getActualTypeArguments()[1];
+	                    
+	                    Entity entity = annotationHelper.getAnnotationFromHierarchy(cls, Entity.class); //(Entity) sc.getAnnotation(Entity.class);
+	                    Embedded embedded = annotationHelper.getAnnotationFromHierarchy(cls, Embedded.class);//(Embedded) sc.getAnnotation(Embedded.class);
+	                    if (entity != null || embedded != null || hasCustomMapper(cls)) {
+	                    	toFillIn.put(key, unmarshall(cls, (Map<String, Object>) val));
+	                        continue;
+	                    }
+                	}
+                	// this is an actual map
+                	else {
+                    	HashMap mp = new HashMap();
+                    	fillMap((ParameterizedType) mapType.getActualTypeArguments()[1], (Map<String, Object>) val, mp, containerEntity);
+                    	toFillIn.put(key, mp);
+                    	continue;
+                    }
+                }
+                else {
+                	HashMap mp = new HashMap();
+                	fillMap((ParameterizedType) mapType.getActualTypeArguments()[1], (Map<String, Object>) val, mp, containerEntity);
+                	toFillIn.put(key, mp);
+                	continue;
+                }
+            
+            } else if (val instanceof MorphiumId) {
+                if (mapType != null) {
+                    //have a list of something
+                	Class cls;
+                	if (mapType.getActualTypeArguments()[1] instanceof ParameterizedType)
+                		cls = (Class) ((ParameterizedType) mapType.getActualTypeArguments()[1]).getRawType();
+                	else
+                		cls = (Class) mapType.getActualTypeArguments()[1];
+                    Query q = morphium.createQueryFor(cls);
+                    q = q.f(annotationHelper.getFields(cls, Id.class).get(0)).eq(val);
+                    toFillIn.put(key, q.get());
+                } else {
+                    log.warn("Cannot de-reference to unknown collection - trying to add Object only");
+                    toFillIn.put(key, val);
+                }
+                continue;
+            } else if (val instanceof List) {
+                //list in list
+                ArrayList lt = new ArrayList();
+                fillList(null, null, (ParameterizedType) mapType.getActualTypeArguments()[1], (List<Map<String, Object>>) val, lt, containerEntity);
+                toFillIn.put(key, lt);
+                continue;
 
+            }
+            toFillIn.put(key, unmarshallInternal(val));
+        }
+    }
 }

--- a/src/de/caluga/morphium/ObjectMapperImpl.java
+++ b/src/de/caluga/morphium/ObjectMapperImpl.java
@@ -1025,7 +1025,7 @@ public class ObjectMapperImpl implements ObjectMapper {
                         Class cls = (Class) listType.getActualTypeArguments()[0];
                         Entity entity = annotationHelper.getAnnotationFromHierarchy(cls, Entity.class); //(Entity) sc.getAnnotation(Entity.class);
                         Embedded embedded = annotationHelper.getAnnotationFromHierarchy(cls, Embedded.class);//(Embedded) sc.getAnnotation(Embedded.class);
-                        if (entity != null || embedded != null)
+                        if (hasCustomMapper(cls) || entity != null || embedded != null)
                             val = unmarshall(cls, (Map<String, Object>) val);
                     }
                     //Probably an "normal" map

--- a/test/de/caluga/test/mongo/suite/CustomMapperTest.java
+++ b/test/de/caluga/test/mongo/suite/CustomMapperTest.java
@@ -1,0 +1,196 @@
+package de.caluga.test.mongo.suite;
+
+import de.caluga.morphium.annotations.ReadPreferenceLevel;
+import de.caluga.morphium.query.Query;
+import de.caluga.test.mongo.suite.MongoTest;
+import de.caluga.test.mongo.suite.data.CustomMappedObject;
+import de.caluga.test.mongo.suite.data.EmbeddedObject;
+import de.caluga.test.mongo.suite.data.UncachedObject;
+import de.caluga.test.mongo.suite.data.CustomMappedObjectMapper;
+import de.caluga.test.mongo.suite.data.ObjectWithCustomMappedObject;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * User: Stephan Bösebeck
+ * Date: 28.05.12
+ * Time: 17:17
+ * <p/>
+ */
+@SuppressWarnings("AssertWithSideEffects")
+public class CustomMapperTest extends MongoTest {
+
+	private final int count = 2;
+	
+    @Test
+    public void customMappedObjectTest() throws Exception {
+    	morphium.registerTypeMapper(CustomMappedObject.class, new CustomMappedObjectMapper());
+    	morphium.dropCollection(ObjectWithCustomMappedObject.class);
+    	
+    	ObjectWithCustomMappedObject containingObject = new ObjectWithCustomMappedObject();
+        
+        List<CustomMappedObject> list = new ArrayList<>();
+        Map<String, CustomMappedObject> map = new HashMap<>();
+        
+        mockupContainerObject(containingObject, list, map);
+        
+        morphium.store(containingObject);
+        
+        Query<ObjectWithCustomMappedObject> q = morphium.createQueryFor(ObjectWithCustomMappedObject.class).f("id").eq(containingObject.getId());
+        q.setReadPreferenceLevel(ReadPreferenceLevel.PRIMARY);
+        ObjectWithCustomMappedObject readContainingObject = q.get();   
+        
+        assert (readContainingObject != null) : "Error - not found?";
+
+        assert (readContainingObject.getCustomMappedObject() != null) : "Custom mapped object null?";
+        assert (readContainingObject.getCustomMappedObjectList() != null) : "List of custom mapped object null?";
+        assert (readContainingObject.getCustomMappedObjectMap() != null) : "Map with custom mapped object null?";
+        
+        assert (readContainingObject.getCustomMappedObjectList().size() == count) : "List of custom mapped objects has wrong size?";
+        assert (readContainingObject.getCustomMappedObjectMap().size() == count) : "Map with custom mapped objects as value has wrong size?";
+        
+        assert (readContainingObject.getCustomMappedObject().equals(containingObject.getCustomMappedObject())) : "Single custom mapped objects differ?";
+        
+        for (int i = 0; i < count; i++) {
+        	CustomMappedObject referenceObject = containingObject.getCustomMappedObjectList().get(i);
+        	
+        	assert (readContainingObject.getCustomMappedObjectList().get(i) != null) : "Custom mapped object in list missing? - " + i;
+        	assert (readContainingObject.getCustomMappedObjectList().get(i).equals(referenceObject)) : "Custom mapped objects in list differ? - " + i;
+            assert (readContainingObject.getCustomMappedObjectMap().get(referenceObject.getName()).equals(map.get(referenceObject.getName()))) : "Custom mapped objects in map differ? - " + i;
+        }
+
+        morphium.deregisterTypeMapper(CustomMappedObject.class);
+    }
+    
+    private void mockupContainerObject(
+			ObjectWithCustomMappedObject containingObject,
+			List<CustomMappedObject> list,
+			Map<String, CustomMappedObject> map) {
+    	CustomMappedObject singleCustomMappedObject = new CustomMappedObject();
+        singleCustomMappedObject.setName("customMapped");
+        singleCustomMappedObject.setValue("single");
+        singleCustomMappedObject.setIntValue(-1);
+        
+        for (int i = 0; i < count; i++) {
+        	CustomMappedObject customMappedObject = new CustomMappedObject();
+        	customMappedObject.setName("customMappedObject#" + i);
+            customMappedObject.setValue("number: " + i);
+            customMappedObject.setIntValue(i);
+        
+            list.add(customMappedObject);
+            map.put(customMappedObject.getName(), customMappedObject);
+        }
+       
+        containingObject.setCustomMappedObject(singleCustomMappedObject);
+        containingObject.setCustomMappedObjectList(list);
+        containingObject.setCustomMappedObjectMap(map);
+	}
+    
+    @Test
+    public void complexCustomMappingTest() throws Exception {
+    	morphium.registerTypeMapper(CustomMappedObject.class, new CustomMappedObjectMapper());
+    	morphium.dropCollection(ObjectWithCustomMappedObject.class);
+    	
+    	ComplexCustomMapperObject containingObject = new ComplexCustomMapperObject();
+        
+    	List<Map<String, List<CustomMappedObject>>> complexestList = new ArrayList<>();
+    	Map<String, List<Map<String, CustomMappedObject>>> complexestMap = new HashMap<>();
+    	
+    	List<Map<String, CustomMappedObject>> complexList = new ArrayList<>();
+    	Map<String, List<CustomMappedObject>> complexMap = new HashMap<>();
+    	
+        List<CustomMappedObject> list = new ArrayList<>();
+        Map<String, CustomMappedObject> map = new HashMap<>();
+        
+        mockupContainerObject(containingObject, list, map);
+        
+        complexList.add(map);
+        complexMap.put("a_list", list);
+        
+        complexestList.add(complexMap);
+        complexestMap.put("a_complex_list", complexList);
+        
+        containingObject.setComplexList(complexList);
+        containingObject.setComplexMap(complexMap);
+        
+        containingObject.setComplexestList(complexestList);
+        containingObject.setComplexestMap(complexestMap);
+        
+        morphium.store(containingObject);
+        
+        Query<ComplexCustomMapperObject> q = morphium.createQueryFor(ComplexCustomMapperObject.class).f("id").eq(containingObject.getId());
+        q.setReadPreferenceLevel(ReadPreferenceLevel.PRIMARY);
+        
+        ComplexCustomMapperObject readContainingObject = q.get();
+       
+        assert (readContainingObject != null) : "Error - not found?";
+        
+        assert (readContainingObject.getComplexList() != null) : "Complex list object null?";
+        assert (readContainingObject.getComplexMap() != null) : "Complex map object null?";
+        assert (readContainingObject.getComplexestList() != null) : "Complexest list object null?";
+        assert (readContainingObject.getComplexestMap() != null) : "Complexest map object null?";
+        
+        assert (readContainingObject.getComplexList().size() == 1) : "Complex list has wrong size?";
+        assert (readContainingObject.getComplexMap().size() == 1) : "Complex map has wrong size?";
+        assert (readContainingObject.getComplexestList().size() == 1) : "Complexest list has wrong size?";
+        assert (readContainingObject.getComplexestMap().size() == 1) : "Complexest map has wrong size?";
+        
+        assert (readContainingObject.getComplexList().equals(complexList)) : "Complex lists differ?";
+        assert (readContainingObject.getComplexMap().equals(complexMap)) : "Complex maps differ?";
+        assert (readContainingObject.getComplexestList().equals(complexestList)) : "Complexest lists differ?";
+        assert (readContainingObject.getComplexestMap().equals(complexestMap)) : "Complexest maps differ?";
+
+        morphium.deregisterTypeMapper(CustomMappedObject.class);
+        
+    }
+    
+    private static class ComplexCustomMapperObject extends ObjectWithCustomMappedObject {
+    	private List<Map<String, CustomMappedObject>> complexList;
+    	private Map<String, List<CustomMappedObject>> complexMap;
+    	
+    	private List<Map<String, List<CustomMappedObject>>> complexestList;
+    	private Map<String, List<Map<String, CustomMappedObject>>> complexestMap;
+    	
+    	public List<Map<String, CustomMappedObject>> getComplexList() {
+			return complexList;
+		}
+    	
+    	public void setComplexList(
+				List<Map<String, CustomMappedObject>> complexList) {
+			this.complexList = complexList;
+		}
+    	
+    	public Map<String, List<CustomMappedObject>> getComplexMap() {
+			return complexMap;
+		}
+    	
+    	public void setComplexMap(
+				Map<String, List<CustomMappedObject>> complexMap) {
+			this.complexMap = complexMap;
+		}
+    	
+    	public List<Map<String, List<CustomMappedObject>>> getComplexestList() {
+			return complexestList;
+		}
+    	
+    	public void setComplexestList(
+				List<Map<String, List<CustomMappedObject>>> complexestList) {
+			this.complexestList = complexestList;
+		}
+    	
+    	public Map<String, List<Map<String, CustomMappedObject>>> getComplexestMap() {
+			return complexestMap;
+		}
+    	
+    	public void setComplexestMap(
+				Map<String, List<Map<String, CustomMappedObject>>> complexestMap) {
+			this.complexestMap = complexestMap;
+		}
+    }
+}

--- a/test/de/caluga/test/mongo/suite/data/CustomMappedObject.java
+++ b/test/de/caluga/test/mongo/suite/data/CustomMappedObject.java
@@ -1,0 +1,48 @@
+package de.caluga.test.mongo.suite.data;
+
+public class CustomMappedObject {
+	private String name;
+	private String value;
+	private int intValue;
+	
+	public String getName() {
+		return name;
+	}
+	
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+	public String getValue() {
+		return value;
+	}
+	
+	public void setValue(String value) {
+		this.value = value;
+	}
+	
+	public int getIntValue() {
+		return intValue;
+	}
+	
+	public void setIntValue(int intValue) {
+		this.intValue = intValue;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof CustomMappedObject))
+			return false;
+		
+		CustomMappedObject that = (CustomMappedObject) obj;
+		
+		if (!this.getName().equals(that.getName()))
+			return false;
+		if (!this.getValue().equals(that.getValue()))
+			return false;
+		if (this.getIntValue() != that.getIntValue())
+			return false;
+		
+		return true;
+	}
+}

--- a/test/de/caluga/test/mongo/suite/data/CustomMappedObject.java
+++ b/test/de/caluga/test/mongo/suite/data/CustomMappedObject.java
@@ -36,7 +36,11 @@ public class CustomMappedObject {
 		
 		CustomMappedObject that = (CustomMappedObject) obj;
 		
+		if (this.getName() == null && that.getName() != null)
+			return false;
 		if (!this.getName().equals(that.getName()))
+			return false;
+		if (this.getValue() == null && that.getValue() != null)
 			return false;
 		if (!this.getValue().equals(that.getValue()))
 			return false;

--- a/test/de/caluga/test/mongo/suite/data/CustomMappedObjectMapper.java
+++ b/test/de/caluga/test/mongo/suite/data/CustomMappedObjectMapper.java
@@ -1,0 +1,34 @@
+package de.caluga.test.mongo.suite.data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import de.caluga.morphium.TypeMapper;
+
+public class CustomMappedObjectMapper implements TypeMapper<CustomMappedObject> {
+
+	@Override
+	public Object marshall(CustomMappedObject o) {
+		Map<String, Object> map = new HashMap<>();
+		
+		map.put("name", o.getName());
+		map.put("string_value", o.getValue());
+		map.put("int_value", o.getIntValue());
+		return map;
+	}
+
+	@Override
+	public CustomMappedObject unmarshall(Object d) {
+		if (d instanceof Map) {
+			Map<String, Object> map = (Map<String, Object>) d;
+			
+			CustomMappedObject cmo = new CustomMappedObject();
+			cmo.setName((String) map.get("name"));
+			cmo.setValue((String) map.get("string_value"));
+			cmo.setIntValue((int) map.get("int_value"));
+			return cmo;
+		}
+		return null;
+	}
+
+}

--- a/test/de/caluga/test/mongo/suite/data/CustomMappedObjectMapper.java
+++ b/test/de/caluga/test/mongo/suite/data/CustomMappedObjectMapper.java
@@ -3,6 +3,8 @@ package de.caluga.test.mongo.suite.data;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bson.Document;
+
 import de.caluga.morphium.TypeMapper;
 
 public class CustomMappedObjectMapper implements TypeMapper<CustomMappedObject> {
@@ -14,7 +16,7 @@ public class CustomMappedObjectMapper implements TypeMapper<CustomMappedObject> 
 		map.put("name", o.getName());
 		map.put("string_value", o.getValue());
 		map.put("int_value", o.getIntValue());
-		return map;
+		return new Document("value", map);
 	}
 
 	@Override

--- a/test/de/caluga/test/mongo/suite/data/ObjectWithCustomMappedObject.java
+++ b/test/de/caluga/test/mongo/suite/data/ObjectWithCustomMappedObject.java
@@ -1,0 +1,56 @@
+package de.caluga.test.mongo.suite.data;
+
+import java.util.List;
+import java.util.Map;
+
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.annotations.caching.Cache;
+import de.caluga.morphium.driver.bson.MorphiumId;
+
+@Entity(polymorph = true)
+@Cache
+public class ObjectWithCustomMappedObject {
+	@Id
+	private MorphiumId id;
+	
+	private CustomMappedObject customMappedObject;
+	
+	private List<CustomMappedObject> customMappedObjectList;
+	
+	private Map<String, CustomMappedObject> customMappedObjectMap;
+
+	public MorphiumId getId() {
+		return id;
+	}
+	
+	public void setId(MorphiumId id) {
+		this.id = id;
+	}
+	
+	public CustomMappedObject getCustomMappedObject() {
+		return customMappedObject;
+	}
+	
+	public void setCustomMappedObject(CustomMappedObject customMappedObject) {
+		this.customMappedObject = customMappedObject;
+	}
+	
+	public List<CustomMappedObject> getCustomMappedObjectList() {
+		return customMappedObjectList;
+	}
+	
+	public void setCustomMappedObjectList(
+			List<CustomMappedObject> customMappedObjectList) {
+		this.customMappedObjectList = customMappedObjectList;
+	}
+	
+	public Map<String, CustomMappedObject> getCustomMappedObjectMap() {
+		return customMappedObjectMap;
+	}
+	
+	public void setCustomMappedObjectMap(
+			Map<String, CustomMappedObject> customMappedObjectMap) {
+		this.customMappedObjectMap = customMappedObjectMap;
+	}
+}


### PR DESCRIPTION
Currently there is no way to have a list of Objects which are mapped via a custom mapper. The map is simply taken from the database and put into the list. That small change should fill the gap.