### PR TITLE
Fixing squid:S2259 - Null pointers should not be dereferenced

### DIFF
--- a/src/de/caluga/morphium/cache/CacheHousekeeper.java
+++ b/src/de/caluga/morphium/cache/CacheHousekeeper.java
@@ -96,9 +96,9 @@ public class CacheHousekeeper extends Thread {
             if (annotationHelper == null) {
                 try {
                     Thread.sleep(1000);
-                    continue;
                 } catch (InterruptedException e) {
                 }
+                continue;
             }
             try {
                 Map<Class, List<String>> toDelete = new HashMap<>();

--- a/src/de/caluga/morphium/driver/bson/MorphiumId.java
+++ b/src/de/caluga/morphium/driver/bson/MorphiumId.java
@@ -109,6 +109,7 @@ public class MorphiumId implements Comparable<MorphiumId> {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
+        if (o == null) return false;
         if (o.getClass() != this.getClass()) return false;
 
         MorphiumId morphiumId = (MorphiumId) o;

--- a/src/de/caluga/morphium/driver/meta/MetaDriver.java
+++ b/src/de/caluga/morphium/driver/meta/MetaDriver.java
@@ -998,6 +998,7 @@ public class MetaDriver extends DriverBase {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
+            if (o == null) return false;
             if (o.getClass() != this.getClass()) return false;
 
             Connection that = (Connection) o;

--- a/src/de/caluga/morphium/driver/singleconnect/SingleConnectDirectDriver.java
+++ b/src/de/caluga/morphium/driver/singleconnect/SingleConnectDirectDriver.java
@@ -257,12 +257,13 @@ public class SingleConnectDirectDriver extends DriverBase {
             crs.setCursorId((Long) cursor.get("id"));
         }
 
-        if (cursor.get("firstBatch") != null) {
-            crs.setBatch((List) cursor.get("firstBatch"));
-        } else if (cursor.get("nextBatch") != null) {
-            crs.setBatch((List) cursor.get("nextBatch"));
+        if (cursor != null) {
+            if (cursor.get("firstBatch") != null) {
+                crs.setBatch((List) cursor.get("firstBatch"));
+            } else if (cursor.get("nextBatch") != null) {
+                crs.setBatch((List) cursor.get("nextBatch"));
+            }
         }
-
 
         SingleConnectCursor internalCursorData = new SingleConnectCursor(this);
         internalCursorData.setBatchSize(batchSize);

--- a/src/de/caluga/morphium/query/DefaultMorphiumIterator.java
+++ b/src/de/caluga/morphium/query/DefaultMorphiumIterator.java
@@ -89,12 +89,16 @@ public class DefaultMorphiumIterator<T> implements MorphiumIterator<T> {
             }
 
         }
-        cursor++;
-        if (idx >= buffer.size()) {
-            log.debug("Trying to read past end of buffer - automatic deletion?");
+        if (buffer != null) {
+            cursor++;
+            if (idx >= buffer.size()) {
+                log.debug("Trying to read past end of buffer - automatic deletion?");
+                return null;
+            }
+            return buffer.get(idx);
+        } else {
             return null;
         }
-        return buffer.get(idx);
     }
 
     private void updateLastValues(Query<T> q, List<T> buffer) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2259 - “Null pointers should not be dereferenced”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2259
 Please let me know if you have any questions.
 Artyom Melnikov.