### PR TITLE
Fixing squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/de/caluga/morphium/cache/CacheHousekeeper.java
+++ b/src/de/caluga/morphium/cache/CacheHousekeeper.java
@@ -194,7 +194,7 @@ public class CacheHousekeeper extends Thread {
                                 Arrays.sort(array);
                                 idx = 0;
                                 while (cache.get(clz).size() - del > maxEntries) {
-                                    if (lruTime.get(array[idx]) != null && lruTime.get(array[idx]).size() != 0) {
+                                    if (lruTime.get(array[idx]) != null && !lruTime.get(array[idx]).isEmpty()) {
                                         toDelete.putIfAbsent(clz, new ArrayList<>());
                                         toDelete.get(clz).add(lruTime.get(array[idx]).get(0));
                                         lruTime.get(array[idx]).remove(0);
@@ -211,7 +211,7 @@ public class CacheHousekeeper extends Thread {
                                 Arrays.sort(array);
                                 idx = 0;
                                 while (cache.get(clz).size() - del > maxEntries) {
-                                    if (fifoTime.get(array[array.length - 1 - idx]) != null && fifoTime.get(array[array.length - 1 - idx]).size() != 0) {
+                                    if (fifoTime.get(array[array.length - 1 - idx]) != null && !fifoTime.get(array[array.length - 1 - idx]).isEmpty()) {
                                         toDelete.putIfAbsent(clz, new ArrayList<>());
                                         toDelete.get(clz).add(fifoTime.get(array[array.length - 1 - idx]).get(0));
                                         fifoTime.get(array[array.length - 1 - idx]).remove(0);
@@ -229,7 +229,7 @@ public class CacheHousekeeper extends Thread {
                                 array = lst.toArray(new Long[lst.size()]);
                                 idx = 0;
                                 while (cache.get(clz).size() - del > maxEntries) {
-                                    if (lruTime.get(array[idx]) != null && lruTime.get(array[idx]).size() != 0) {
+                                    if (lruTime.get(array[idx]) != null && !lruTime.get(array[idx]).isEmpty()) {
                                         toDelete.putIfAbsent(clz, new ArrayList<>());
                                         toDelete.get(clz).add(lruTime.get(array[idx]).get(0));
                                         del++;

--- a/src/de/caluga/morphium/cache/CacheSynchronizer.java
+++ b/src/de/caluga/morphium/cache/CacheSynchronizer.java
@@ -174,7 +174,7 @@ public class CacheSynchronizer implements MessageListener, MorphiumStorageListen
 //cannot be updated, it's new
             toClrCachee.addAll(sorted.get(cls).get(true).stream().filter(record -> c.syncCache().equals(Cache.SyncCacheStrategy.CLEAR_TYPE_CACHE)).collect(Collectors.toList()));
 
-            if (toUpdate.size() != 0) {
+            if (!toUpdate.isEmpty()) {
                 Msg m = new Msg(CACHE_SYNC_RECORD, MsgType.MULTI, reason, cls.getName(), 30000);
 
                 toUpdate.stream().filter(k -> !k.getClass().equals(Msg.class)).forEach(k -> {
@@ -192,7 +192,7 @@ public class CacheSynchronizer implements MessageListener, MorphiumStorageListen
                 }
             }
 
-            if (toClrCachee.size() != 0) {
+            if (!toClrCachee.isEmpty()) {
                 Msg m = new Msg(CACHE_SYNC_TYPE, MsgType.MULTI, reason, cls.getName(), 30000);
 
                 toUpdate.stream().filter(k -> !k.getClass().equals(Msg.class)).forEach(k -> {

--- a/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -532,7 +532,7 @@ public class InMemoryDriver implements MorphiumDriver {
     public void insert(String db, String collection, List<Map<String, Object>> objs, WriteConcern wc) throws MorphiumDriverException {
         for (Map<String, Object> o : objs) {
             o.putIfAbsent("_id", new MorphiumId());
-            if (findByFieldValue(db, collection, "_id", o.get("_id")).size() != 0)
+            if (!findByFieldValue(db, collection, "_id", o.get("_id")).isEmpty())
                 throw new MorphiumDriverException("Duplicate _id!", null);
         }
         getCollection(db, collection).addAll(objs);
@@ -547,7 +547,7 @@ public class InMemoryDriver implements MorphiumDriver {
                 continue;
             }
             List<Map<String, Object>> srch = findByFieldValue(db, collection, "_id", o.get("_id"));
-            if (srch.size() != 0) {
+            if (!srch.isEmpty()) {
                 getCollection(db, collection).remove(srch.get(0));
             }
             getCollection(db, collection).add(o);

--- a/src/de/caluga/morphium/driver/meta/MetaDriver.java
+++ b/src/de/caluga/morphium/driver/meta/MetaDriver.java
@@ -148,7 +148,7 @@ public class MetaDriver extends DriverBase {
             log.debug("There are more nodes in replicaset than defined in seed...");
             for (int i = 0; i < secondaries.size(); i++) {
                 String h = secondaries.get(i);
-                if (getConnections(h).size() == 0) {
+                if (getConnections(h).isEmpty()) {
                     try {
                         createConnectionsForPool(h);
                     } catch (Exception e) {
@@ -612,7 +612,7 @@ public class MetaDriver extends DriverBase {
         Connection c = null;
         while (c == null) {
             try {
-                if (getConnections(host).size() != 0) {
+                if (!getConnections(host).isEmpty()) {
                     c = getConnections(host).remove(0); //get first available connection;
                     if (c == null) {
                         log.fatal("Hä? could not get connection from pool");

--- a/src/de/caluga/morphium/driver/mongodb/Driver.java
+++ b/src/de/caluga/morphium/driver/mongodb/Driver.java
@@ -944,7 +944,7 @@ public class Driver implements MorphiumDriver {
         }, retriesOnNetworkError, sleepBetweenErrorRetries);
 
 
-        return found != null && found.size() != 0;
+        return found != null && !found.isEmpty();
     }
 
     @Override

--- a/src/de/caluga/morphium/driver/mongodb/MongodbBulkContext.java
+++ b/src/de/caluga/morphium/driver/mongodb/MongodbBulkContext.java
@@ -133,14 +133,14 @@ public class MongodbBulkContext extends BulkRequestContext {
                 lst.clear();
             }
         }
-        if (lst.size() != 0) {
+        if (!lst.isEmpty()) {
             results.add(commitWrite(lst));
             lst.clear();
         }
 
 
 
-        if (inserts.size() != 0) {
+        if (!inserts.isEmpty()) {
             for (Map.Entry<Document, Map<String, Object>> e : inserts.entrySet()) {
                 Object id = e.getKey().get("_id");
                 if (id instanceof ObjectId) {

--- a/src/de/caluga/morphium/driver/singleconnect/BulkContext.java
+++ b/src/de/caluga/morphium/driver/singleconnect/BulkContext.java
@@ -122,15 +122,15 @@ public class BulkContext extends BulkRequestContext {
             }
             count++;
         }
-        if (inserts.size() != 0) {
+        if (!inserts.isEmpty()) {
             driver.insert(db, collection, inserts, wc);
         }
 
-        if (stores.size() != 0) {
+        if (!stores.isEmpty()) {
             driver.store(db, collection, stores, wc);
         }
 
-        if (updates.size() != 0) {
+        if (!updates.isEmpty()) {
             Map<String, Object> result = null;
             result = driver.update(db, collection, updates, ordered, wc);
         }

--- a/src/de/caluga/morphium/driver/singleconnect/SingleConnectDirectDriver.java
+++ b/src/de/caluga/morphium/driver/singleconnect/SingleConnectDirectDriver.java
@@ -230,7 +230,7 @@ public class SingleConnectDirectDriver extends DriverBase {
         if (limit > 0)
             doc.put("limit", limit);
         doc.put("skip", skip);
-        if (query.size() != 0)
+        if (!query.isEmpty())
             doc.put("filter", query);
         doc.put("sort", sort);
         doc.put("batchSize", batchSize);
@@ -347,7 +347,7 @@ public class SingleConnectDirectDriver extends DriverBase {
             if (limit > 0)
                 doc.put("limit", limit);
             doc.put("skip", skip);
-            if (query.size() != 0)
+            if (!query.isEmpty())
                 doc.put("filter", query);
             doc.put("sort", sort);
 
@@ -872,7 +872,7 @@ public class SingleConnectDirectDriver extends DriverBase {
     public boolean isCapped(String db, String coll) throws MorphiumDriverException {
         List<Map<String, Object>> lst = getCollectionInfo(db, coll);
         try {
-            if (lst.size() != 0 && lst.get(0).get("name").equals(coll)) {
+            if (!lst.isEmpty() && lst.get(0).get("name").equals(coll)) {
                 Object capped = ((Map) lst.get(0).get("options")).get("capped");
                 return capped != null && capped.equals(true);
             }

--- a/src/de/caluga/morphium/driver/singleconnect/SingleConnectThreaddedDriver.java
+++ b/src/de/caluga/morphium/driver/singleconnect/SingleConnectThreaddedDriver.java
@@ -279,7 +279,7 @@ public class SingleConnectThreaddedDriver extends DriverBase {
         if (limit > 0)
             doc.put("limit", limit);
         doc.put("skip", skip);
-        if (query.size() != 0)
+        if (!query.isEmpty())
             doc.put("filter", query);
         doc.put("sort", sort);
         doc.put("batchSize", batchSize);
@@ -392,7 +392,7 @@ public class SingleConnectThreaddedDriver extends DriverBase {
             if (limit > 0)
                 doc.put("limit", limit);
             doc.put("skip", skip);
-            if (query.size() != 0)
+            if (!query.isEmpty())
                 doc.put("filter", query);
             if (projection != null)
                 doc.put("projection", projection);
@@ -936,7 +936,7 @@ public class SingleConnectThreaddedDriver extends DriverBase {
     public boolean isCapped(String db, String coll) throws MorphiumDriverException {
         List<Map<String, Object>> lst = getCollectionInfo(db, coll);
         try {
-            if (lst.size() != 0 && lst.get(0).get("name").equals(coll)) {
+            if (!lst.isEmpty() && lst.get(0).get("name").equals(coll)) {
                 Object capped = ((Map) lst.get(0).get("options")).get("capped");
                 return capped != null && capped.equals(true);
             }

--- a/src/de/caluga/morphium/query/QueryImpl.java
+++ b/src/de/caluga/morphium/query/QueryImpl.java
@@ -539,7 +539,7 @@ public class QueryImpl<T> implements Query<T>, Cloneable {
             o.put("$and", lst);
             lst = new ArrayList<>();
         }
-        if (orQueries.size() != 0) {
+        if (!orQueries.isEmpty()) {
             for (Query<T> ex : orQueries) {
                 lst.add(ex.toQueryObject());
             }
@@ -551,7 +551,7 @@ public class QueryImpl<T> implements Query<T>, Cloneable {
             }
         }
 
-        if (norQueries.size() != 0) {
+        if (!norQueries.isEmpty()) {
             for (Query<T> ex : norQueries) {
                 lst.add(ex.toQueryObject());
             }
@@ -580,7 +580,7 @@ public class QueryImpl<T> implements Query<T>, Cloneable {
             setReadPreferenceLevel(pr.value());
         }
         List<String> fields = getARHelper().getFields(type, AdditionalData.class);
-        additionalDataPresent = fields != null && fields.size() != 0;
+        additionalDataPresent = fields != null && !fields.isEmpty();
     }
 
     @Override

--- a/src/de/caluga/morphium/writer/BufferedMorphiumWriterImpl.java
+++ b/src/de/caluga/morphium/writer/BufferedMorphiumWriterImpl.java
@@ -167,7 +167,7 @@ public class BufferedMorphiumWriterImpl implements MorphiumWriter, ShutdownListe
                     if (logger.isDebugEnabled()) {
                         logger.debug("Deleting oldest entry");
                     }
-                    if (opLog.get(type).size() != 0)
+                    if (!opLog.get(type).isEmpty())
                         opLog.get(type).remove(0);
                     opLog.get(type).add(wb);
                     return;

--- a/src/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/src/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -694,7 +694,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
 
                 Map<String, Object> update = Utils.getMap("$set", Utils.getMap(fieldName, value.getClass().isEnum() ? value.toString() : value));
                 List<String> lastChangeFields = morphium.getARHelper().getFields(cls, LastChange.class);
-                if (lastChangeFields != null && lastChangeFields.size() != 0) {
+                if (lastChangeFields != null && !lastChangeFields.isEmpty()) {
                     for (String fL : lastChangeFields) {
                         Field fld = morphium.getARHelper().getField(cls, fL);
                         if (fld.getType().equals(Date.class)) {
@@ -706,7 +706,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                 }
 
                 List<String> creationTimeFields = morphium.getARHelper().getFields(cls, CreationTime.class);
-                if (upsert && creationTimeFields != null && creationTimeFields.size() != 0) {
+                if (upsert && creationTimeFields != null && !creationTimeFields.isEmpty()) {
                     long cnt = 0;
                     try {
                         cnt = morphium.getDriver().count(getDbName(), collection, query, null);
@@ -1238,8 +1238,8 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                     qobj = morphium.simplifyQueryObject(qobj);
                     List<String> creationTimeFlds = morphium.getARHelper().getFields(cls, CreationTime.class);
                     try {
-                        if (creationTimeFlds != null && creationTimeFlds.size() != 0 && morphium.getDriver().count(getDbName(), coll, qobj, null) == 0) {
-                            if (creationTimeFlds != null && creationTimeFlds.size() != 0) {
+                        if (creationTimeFlds != null && !creationTimeFlds.isEmpty() && morphium.getDriver().count(getDbName(), coll, qobj, null) == 0) {
+                            if (creationTimeFlds != null && !creationTimeFlds.isEmpty()) {
                                 for (String fL : creationTimeFlds) {
                                     Field fld = morphium.getARHelper().getField(cls, fL);
                                     if (fld.getType().equals(Date.class)) {
@@ -1258,7 +1258,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
 
 
                 List<String> latChangeFlds = morphium.getARHelper().getFields(cls, LastChange.class);
-                if (latChangeFlds != null && latChangeFlds.size() != 0) {
+                if (latChangeFlds != null && !latChangeFlds.isEmpty()) {
                     for (String fL : latChangeFlds) {
                         Field fld = morphium.getARHelper().getField(cls, fL);
                         if (fld.getType().equals(Date.class)) {
@@ -1394,7 +1394,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                     morphium.getDriver().update(getDbName(), coll, query, update, false, false, wc);
 
                     List<String> lastChangeFields = morphium.getARHelper().getFields(cls, LastChange.class);
-                    if (lastChangeFields != null && lastChangeFields.size() != 0) {
+                    if (lastChangeFields != null && !lastChangeFields.isEmpty()) {
                         update = Utils.getMap("$set", new HashMap<String, Object>());
                         for (String fL : lastChangeFields) {
                             Field fld = morphium.getARHelper().getField(cls, fL);
@@ -1474,7 +1474,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                     morphium.getDriver().update(getDbName(), coll, query, update, false, false, wc);
 
                     List<String> lastChangeFields = morphium.getARHelper().getFields(cls, LastChange.class);
-                    if (lastChangeFields != null && lastChangeFields.size() != 0) {
+                    if (lastChangeFields != null && !lastChangeFields.isEmpty()) {
                         update = Utils.getMap("$set", new HashMap<String, Object>());
                         for (String fL : lastChangeFields) {
                             Field fld = morphium.getARHelper().getField(cls, fL);
@@ -1607,7 +1607,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
         morphium.firePreUpdateEvent(morphium.getARHelper().getRealClass(cls), push ? MorphiumStorageListener.UpdateTypes.PUSH : MorphiumStorageListener.UpdateTypes.PULL);
 
         List<String> lastChangeFields = morphium.getARHelper().getFields(cls, LastChange.class);
-        if (lastChangeFields != null && lastChangeFields.size() != 0) {
+        if (lastChangeFields != null && !lastChangeFields.isEmpty()) {
             update.put("$set", new HashMap<String, Object>());
             for (String fL : lastChangeFields) {
                 Field fld = morphium.getARHelper().getField(cls, fL);
@@ -1622,7 +1622,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
         }
         if (upsert) {
             List<String> creationTimeFields = morphium.getARHelper().getFields(cls, CreationTime.class);
-            if (upsert && creationTimeFields != null && creationTimeFields.size() != 0) {
+            if (upsert && creationTimeFields != null && !creationTimeFields.isEmpty()) {
                 long cnt = 0;
                 try {
                     cnt = morphium.getDriver().count(getDbName(), coll, qobj, null);
@@ -1695,7 +1695,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                     Map<String, Object> update = Utils.getMap(push ? "$pushAll" : "$pullAll", set);
 
                     List<String> lastChangeFields = morphium.getARHelper().getFields(cls, LastChange.class);
-                    if (lastChangeFields != null && lastChangeFields.size() != 0) {
+                    if (lastChangeFields != null && !lastChangeFields.isEmpty()) {
                         update.put("$set", new HashMap<String, Object>());
                         for (String fL : lastChangeFields) {
                             Field fld = morphium.getARHelper().getField(cls, fL);
@@ -1710,7 +1710,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                     }
                     if (upsert) {
                         List<String> creationTimeFields = morphium.getARHelper().getFields(cls, CreationTime.class);
-                        if (upsert && creationTimeFields != null && creationTimeFields.size() != 0) {
+                        if (upsert && creationTimeFields != null && !creationTimeFields.isEmpty()) {
                             long cnt = 0;
                             try {
                                 cnt = morphium.getDriver().count(getDbName(), coll, qobj, null);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1155
 Please let me know if you have any questions.
 Artyom Melnikov.