### PR TITLE
Fixing squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/src/de/caluga/morphium/Morphium.java
+++ b/src/de/caluga/morphium/Morphium.java
@@ -1953,11 +1953,11 @@ public class Morphium {
             values.putIfAbsent(o.getClass(), new ArrayList<>());
             values.get(o.getClass()).add(o);
         }
-        for (Class cls : writers.keySet()) {
+        for (Map.Entry<Class<?>, MorphiumWriter> classMorphiumWriterEntry : writers.entrySet()) {
             try {
-                writers.get(cls).store((List<T>) values.get(cls), collection, callback);
+                classMorphiumWriterEntry.getValue().store((List<T>) values.get(classMorphiumWriterEntry.getKey()), collection, callback);
             } catch (Exception e) {
-                logger.error("Write failed for " + cls.getName() + " lst of size " + values.get(cls).size(), e);
+                logger.error("Write failed for " + classMorphiumWriterEntry.getKey().getName() + " lst of size " + values.get(classMorphiumWriterEntry.getKey()).size(), e);
             }
         }
     }

--- a/src/de/caluga/morphium/ObjectMapperImpl.java
+++ b/src/de/caluga/morphium/ObjectMapperImpl.java
@@ -584,25 +584,25 @@ public class ObjectMapperImpl implements ObjectMapper {
                     }
                     Set<String> keys = o.keySet();
                     Map<String, Object> data = new HashMap<>();
-                    for (String k : keys) {
-                        if (flds.contains(k)) {
+                    for (Map.Entry<String, Object> stringObjectEntry : o.entrySet()) {
+                        if (flds.contains(stringObjectEntry.getKey())) {
                             continue;
                         }
-                        if (k.equals("_id")) {
+                        if (stringObjectEntry.getKey().equals("_id")) {
                             //id already mapped
                             continue;
                         }
 
-                        if (o.get(k) instanceof Map) {
-                            if (((Map<String, Object>) o.get(k)).get("class_name") != null) {
-                                data.put(k, unmarshall(Class.forName((String) ((Map<String, Object>) o.get(k)).get("class_name")), (Map<String, Object>) o.get(k)));
+                        if (stringObjectEntry.getValue() instanceof Map) {
+                            if (((Map<String, Object>) stringObjectEntry.getValue()).get("class_name") != null) {
+                                data.put(stringObjectEntry.getKey(), unmarshall(Class.forName((String) ((Map<String, Object>) stringObjectEntry.getValue()).get("class_name")), (Map<String, Object>) stringObjectEntry.getValue()));
                             } else {
-                                data.put(k, createMap((Map<String, Object>) o.get(k)));
+                                data.put(stringObjectEntry.getKey(), createMap((Map<String, Object>) stringObjectEntry.getValue()));
                             }
-                        } else if (o.get(k) instanceof List && !((List) o.get(k)).isEmpty() && ((List) o.get(k)).get(0) instanceof Map) {
-                            data.put(k, createList((List<Map<String, Object>>) o.get(k)));
+                        } else if (stringObjectEntry.getValue() instanceof List && !((List) stringObjectEntry.getValue()).isEmpty() && ((List) stringObjectEntry.getValue()).get(0) instanceof Map) {
+                            data.put(stringObjectEntry.getKey(), createList((List<Map<String, Object>>) stringObjectEntry.getValue()));
                         } else {
-                            data.put(k, o.get(k));
+                            data.put(stringObjectEntry.getKey(), stringObjectEntry.getValue());
                         }
 
                     }
@@ -867,10 +867,10 @@ public class ObjectMapperImpl implements ObjectMapper {
     private Map createMap(Map<String, Object> dbObject) {
         Map retMap = new HashMap(dbObject);
         if (dbObject != null) {
-            for (String n : dbObject.keySet()) {
+            for (Map.Entry<String, Object> stringObjectEntry : dbObject.entrySet()) {
 
-                if (dbObject.get(n) instanceof Map) {
-                    Object val = dbObject.get(n);
+                if (stringObjectEntry.getValue() instanceof Map) {
+                    Object val = stringObjectEntry.getValue();
                     if (((Map<String, Object>) val).containsKey("class_name") || ((Map<String, Object>) val).containsKey("className")) {
                         //Entity to map!
                         String cn = (String) ((Map<String, Object>) val).get("class_name");
@@ -879,8 +879,8 @@ public class ObjectMapperImpl implements ObjectMapper {
                         }
                         try {
                             Class ecls = Class.forName(cn);
-                            Object obj = unmarshall(ecls, (HashMap<String, Object>) dbObject.get(n));
-                            if (obj != null) retMap.put(n, obj);
+                            Object obj = unmarshall(ecls, (HashMap<String, Object>) stringObjectEntry.getValue());
+                            if (obj != null) retMap.put(stringObjectEntry.getKey(), obj);
                         } catch (ClassNotFoundException e) {
                             throw new RuntimeException(e);
                         }
@@ -891,19 +891,19 @@ public class ObjectMapperImpl implements ObjectMapper {
                         try {
                             in = new ObjectInputStream(new ByteArrayInputStream(dec.decodeBuffer(d)));
                             Object read = in.readObject();
-                            retMap.put(n, read);
+                            retMap.put(stringObjectEntry.getKey(), read);
                         } catch (IOException | ClassNotFoundException e) {
                             throw new RuntimeException(e);
                         }
 
                     } else {
                         //maybe a map of maps? --> recurse
-                        retMap.put(n, createMap((Map<String, Object>) val));
+                        retMap.put(stringObjectEntry.getKey(), createMap((Map<String, Object>) val));
                     }
-                } else if (dbObject.get(n) instanceof List) {
-                    List<Map<String, Object>> lst = (List<Map<String, Object>>) dbObject.get(n);
+                } else if (stringObjectEntry.getValue() instanceof List) {
+                    List<Map<String, Object>> lst = (List<Map<String, Object>>) stringObjectEntry.getValue();
                     List mapValue = createList(lst);
-                    retMap.put(n, mapValue);
+                    retMap.put(stringObjectEntry.getKey(), mapValue);
                 }
             }
         } else {

--- a/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -318,11 +318,11 @@ public class InMemoryDriver implements MorphiumDriver {
         boolean matches = false;
         if (query.isEmpty()) return true;
         if (query.containsKey("$where")) throw new RuntimeException("$where not implemented yet");
-        for (String key : query.keySet()) {
-            switch (key) {
+        for (Map.Entry<String, Object> stringObjectEntry : query.entrySet()) {
+            switch (stringObjectEntry.getKey()) {
                 case "$and": {
                     //list of field queries
-                    List<Map<String, Object>> lst = ((List<Map<String, Object>>) query.get(key));
+                    List<Map<String, Object>> lst = ((List<Map<String, Object>>) stringObjectEntry.getValue());
                     for (Map<String, Object> q : lst) {
                         if (!matchesQuery(q, toCheck)) return false;
                     }
@@ -330,7 +330,7 @@ public class InMemoryDriver implements MorphiumDriver {
                 }
                 case "$or": {
                     //list of or queries
-                    List<Map<String, Object>> lst = ((List<Map<String, Object>>) query.get(key));
+                    List<Map<String, Object>> lst = ((List<Map<String, Object>>) stringObjectEntry.getValue());
                     for (Map<String, Object> q : lst) {
                         if (matchesQuery(q, toCheck)) return true;
                     }
@@ -339,31 +339,31 @@ public class InMemoryDriver implements MorphiumDriver {
                 }
                 default:
                     //field check
-                    if (query.get(key) instanceof Map) {
+                    if (stringObjectEntry.getValue() instanceof Map) {
                         //probably a query operand
-                        Map<String, Object> q = (Map<String, Object>) query.get(key);
+                        Map<String, Object> q = (Map<String, Object>) stringObjectEntry.getValue();
                         assert (q.size() == 1);
                         String k = q.keySet().iterator().next();
                         switch (k) {
                             case "$lt":
-                                return ((Comparable) toCheck.get(key)).compareTo(q.get(k)) < 0;
+                                return ((Comparable) toCheck.get(stringObjectEntry.getKey())).compareTo(q.get(k)) < 0;
                             case "$lte":
-                                return ((Comparable) toCheck.get(key)).compareTo(q.get(k)) <= 0;
+                                return ((Comparable) toCheck.get(stringObjectEntry.getKey())).compareTo(q.get(k)) <= 0;
                             case "$gt":
-                                return ((Comparable) toCheck.get(key)).compareTo(q.get(k)) > 0;
+                                return ((Comparable) toCheck.get(stringObjectEntry.getKey())).compareTo(q.get(k)) > 0;
                             case "$gte":
-                                return ((Comparable) toCheck.get(key)).compareTo(q.get(k)) >= 0;
+                                return ((Comparable) toCheck.get(stringObjectEntry.getKey())).compareTo(q.get(k)) >= 0;
                             case "$mod":
-                                Number n = (Number) toCheck.get(key);
+                                Number n = (Number) toCheck.get(stringObjectEntry.getKey());
                                 List arr = (List) q.get(k);
                                 int div = ((Integer) arr.get(0));
                                 int rem = ((Integer) arr.get(1));
                                 return n.intValue() % div == rem;
                             case "$ne":
-                                return ((Comparable) toCheck.get(key)).compareTo(q.get(k)) != 0;
+                                return ((Comparable) toCheck.get(stringObjectEntry.getKey())).compareTo(q.get(k)) != 0;
                             case "$exists":
 
-                                boolean exists = (toCheck.containsKey(key));
+                                boolean exists = (toCheck.containsKey(stringObjectEntry.getKey()));
                                 if (q.get(k).equals(Boolean.TRUE) || q.get(k).equals("true") || q.get(k).equals(1)) {
                                     return exists;
                                 } else {
@@ -371,7 +371,7 @@ public class InMemoryDriver implements MorphiumDriver {
                                 }
                             case "$in":
                                 for (Object v : (List) q.get(k)) {
-                                    if (toCheck.get(key).equals(v)) return true;
+                                    if (toCheck.get(stringObjectEntry.getKey()).equals(v)) return true;
                                 }
                                 return false;
                             default:
@@ -382,7 +382,7 @@ public class InMemoryDriver implements MorphiumDriver {
                     } else {
                         //value comparison - should only be one here
                         assert (query.size() == 1);
-                        return toCheck.get(key).equals(query.get(key));
+                        return toCheck.get(stringObjectEntry.getKey()).equals(stringObjectEntry.getValue());
                     }
             }
         }
@@ -486,11 +486,11 @@ public class InMemoryDriver implements MorphiumDriver {
 
         if (sort != null) {
             ret.sort((o1, o2) -> {
-                for (String f : sort.keySet()) {
-                    if (o1.get(f).equals(o2.get(f))) {
+                for (Map.Entry<String, Integer> stringIntegerEntry : sort.entrySet()) {
+                    if (o1.get(stringIntegerEntry.getKey()).equals(o2.get(stringIntegerEntry.getKey()))) {
                         continue;
                     }
-                    return ((Comparable) o1.get(f)).compareTo(o2.get(f)) * sort.get(f);
+                    return ((Comparable) o1.get(stringIntegerEntry.getKey())).compareTo(o2.get(stringIntegerEntry.getKey())) * stringIntegerEntry.getValue();
                 }
                 return 0;
             });
@@ -571,9 +571,9 @@ public class InMemoryDriver implements MorphiumDriver {
             throw new RuntimeException("Upsert not implemented yet!");
         }
         for (Map<String, Object> obj : lst) {
-            for (String operand : op.keySet()) {
-                Map<String, Object> cmd = (Map<String, Object>) op.get(operand);
-                switch (operand) {
+            for (Map.Entry<String, Object> stringObjectEntry : op.entrySet()) {
+                Map<String, Object> cmd = (Map<String, Object>) stringObjectEntry.getValue();
+                switch (stringObjectEntry.getKey()) {
                     case "$set":
                         for (Map.Entry<String, Object> entry : cmd.entrySet()) {
                             obj.put(entry.getKey(), entry.getValue());
@@ -638,7 +638,7 @@ public class InMemoryDriver implements MorphiumDriver {
                         }
                         break;
                     default:
-                        throw new RuntimeException("unknown operand " + operand);
+                        throw new RuntimeException("unknown operand " + stringObjectEntry.getKey());
                 }
             }
         }

--- a/src/de/caluga/morphium/driver/meta/MetaDriver.java
+++ b/src/de/caluga/morphium/driver/meta/MetaDriver.java
@@ -189,11 +189,11 @@ public class MetaDriver extends DriverBase {
 
     private int getTotalConnectionCount() {
         int c = 0;
-        for (String k : connectionPool.keySet()) {
-            c += connectionPool.get(k).size();
+        for (Map.Entry<String, List<Connection>> stringListEntry : connectionPool.entrySet()) {
+            c += stringListEntry.getValue().size();
         }
-        for (String k : connectionsInUse.keySet()) {
-            c += connectionsInUse.get(k).size();
+        for (Map.Entry<String, List<Connection>> stringListEntry : connectionsInUse.entrySet()) {
+            c += stringListEntry.getValue().size();
         }
         return c;
     }
@@ -216,19 +216,19 @@ public class MetaDriver extends DriverBase {
     @Override
     public void close() throws MorphiumDriverException {
         connected = false;
-        for (String h : connectionPool.keySet()) {
-            while (!connectionPool.get(h).isEmpty()) {
+        for (Map.Entry<String, List<Connection>> stringListEntry : connectionPool.entrySet()) {
+            while (!stringListEntry.getValue().isEmpty()) {
                 try {
-                    Connection c = connectionPool.get(h).remove(0);
+                    Connection c = stringListEntry.getValue().remove(0);
                     c.close();
                 } catch (Exception e) {
                 }
             }
         }
-        for (String h : connectionsInUse.keySet()) {
-            while (!connectionsInUse.get(h).isEmpty()) {
+        for (Map.Entry<String, List<Connection>> stringListEntry : connectionsInUse.entrySet()) {
+            while (!stringListEntry.getValue().isEmpty()) {
                 try {
-                    Connection c = connectionsInUse.get(h).remove(0);
+                    Connection c = stringListEntry.getValue().remove(0);
                     c.close();
                 } catch (Exception e) {
                 }
@@ -315,8 +315,8 @@ public class MetaDriver extends DriverBase {
         if (crs == null) return; //already closed
         SingleConnectCursor internalCursor = (SingleConnectCursor) crs.getInternalCursorObject();
         internalCursor.getDriver().closeIteration(crs);
-        for (String srv : connectionsInUse.keySet()) {
-            for (Connection c : connectionsInUse.get(srv)) {
+        for (Map.Entry<String, List<Connection>> stringListEntry : connectionsInUse.entrySet()) {
+            for (Connection c : stringListEntry.getValue()) {
                 if (c.getD().equals(internalCursor.getDriver())) {
                     freeConnection(c);
                     return;

--- a/src/de/caluga/morphium/driver/mongodb/Driver.java
+++ b/src/de/caluga/morphium/driver/mongodb/Driver.java
@@ -563,8 +563,8 @@ public class Driver implements MorphiumDriver {
     private Map<String, Object> convertBSON(Map d) {
         Map<String, Object> obj = new HashMap<>();
 
-        for (Object k : d.keySet()) {
-            Object value = d.get(k);
+        for (Object o1 : d.entrySet()) {
+            Object value = ((Map.Entry) o1).getValue();
             if (value instanceof BsonTimestamp) {
                 value = (((BsonTimestamp) value).getTime() * 1000);
             } else if (value instanceof BSONTimestamp) {
@@ -610,7 +610,7 @@ public class Driver implements MorphiumDriver {
             } else if (value instanceof BSONObject) {
                 value = convertBSON((Map) value);
             }
-            obj.put(k.toString(), value);
+            obj.put(((Map.Entry) o1).getKey().toString(), value);
         }
         return obj;
     }

--- a/src/de/caluga/morphium/validation/JavaxValidationStorageListener.java
+++ b/src/de/caluga/morphium/validation/JavaxValidationStorageListener.java
@@ -25,8 +25,8 @@ public class JavaxValidationStorageListener extends MorphiumStorageAdapter<Objec
 
     @Override
     public void preStore(Morphium m, Map<Object, Boolean> isNew) throws MorphiumAccessVetoException {
-        for (Object b : isNew.keySet()) {
-            preStore(m, b, isNew.get(b));
+        for (Map.Entry<Object, Boolean> objectBooleanEntry : isNew.entrySet()) {
+            preStore(m, objectBooleanEntry.getKey(), objectBooleanEntry.getValue());
         }
     }
 

--- a/src/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/src/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -914,9 +914,9 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                 morphium.firePreRemove(lst);
                 long start = System.currentTimeMillis();
                 try {
-                    for (Class<T> cls : sortedMap.keySet()) {
-                        Query<T> orQuery = morphium.createQueryFor(cls);
-                        orQuery = orQuery.or(sortedMap.get(cls));
+                    for (Map.Entry<Class<T>, List<Query<T>>> classListEntry : sortedMap.entrySet()) {
+                        Query<T> orQuery = morphium.createQueryFor(classListEntry.getKey());
+                        orQuery = orQuery.or(classListEntry.getValue());
                         remove(orQuery, null); //sync call
                     }
                     morphium.firePostRemove(lst);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2864
 Please let me know if you have any questions.
 Artyom Melnikov.