### PR TITLE
Fixing squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/src/de/caluga/morphium/Morphium.java
+++ b/src/de/caluga/morphium/Morphium.java
@@ -143,7 +143,7 @@ public class Morphium {
                 getConfig().getThreadPoolAsyncOpKeepAliveTime(), TimeUnit.MILLISECONDS,
                 new SynchronousQueue<>());
         asyncOperationsThreadPool.setThreadFactory(new ThreadFactory() {
-            AtomicInteger num = new AtomicInteger(1);
+            private AtomicInteger num = new AtomicInteger(1);
 
             @Override
             public Thread newThread(Runnable r) {

--- a/src/de/caluga/morphium/MorphiumConfig.java
+++ b/src/de/caluga/morphium/MorphiumConfig.java
@@ -98,10 +98,10 @@ public class MorphiumConfig {
     private String mongoLogin = null, mongoPassword = null;
 
     private boolean autoValues = true;
-    boolean readCacheEnabled = true;
-    boolean asyncWritesEnabled = true;
-    boolean bufferedWritesEnabled = true;
-    boolean camelCaseConversionEnabled = true;
+    private boolean readCacheEnabled = true;
+    private boolean asyncWritesEnabled = true;
+    private boolean bufferedWritesEnabled = true;
+    private boolean camelCaseConversionEnabled = true;
 
     //securitysettings
 //    private Class<? extends Object> userClass, roleClass, aclClass;

--- a/src/de/caluga/morphium/ObjectMapperImpl.java
+++ b/src/de/caluga/morphium/ObjectMapperImpl.java
@@ -34,7 +34,7 @@ public class ObjectMapperImpl implements ObjectMapper {
     private Map<Class, TypeMapper> customMapper;
 
     private List<Class<?>> mongoTypes;
-    final ReflectionFactory reflection = ReflectionFactory.getReflectionFactory();
+    private final ReflectionFactory reflection = ReflectionFactory.getReflectionFactory();
     private ContainerFactory containerFactory;
 
     public ObjectMapperImpl() {

--- a/src/de/caluga/morphium/annotations/SafetyLevel.java
+++ b/src/de/caluga/morphium/annotations/SafetyLevel.java
@@ -10,7 +10,7 @@ package de.caluga.morphium.annotations;
 public enum SafetyLevel {
     NORMAL(0), BASIC(1), WAIT_FOR_SLAVE(2), WAIT_FOR_ALL_SLAVES(3), MAJORITY(-99);
 
-    int value;
+    private int value;
 
     SafetyLevel(int v) {
         value = v;

--- a/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -742,7 +742,7 @@ public class InMemoryDriver implements MorphiumDriver {
     @Override
     public BulkRequestContext createBulkContext(Morphium m, String db, String collection, boolean ordered, WriteConcern wc) {
         return new BulkRequestContext(m) {
-            List<BulkRequest> requests = new ArrayList<>();
+            private List<BulkRequest> requests = new ArrayList<>();
 
             @Override
             public Map<String, Object> execute() {

--- a/src/de/caluga/morphium/driver/singleconnect/NetworkCallHelper.java
+++ b/src/de/caluga/morphium/driver/singleconnect/NetworkCallHelper.java
@@ -14,7 +14,7 @@ import java.util.Map;
  * this class capsulates these calls.
  **/
 public class NetworkCallHelper {
-    Logger logger = new Logger(NetworkCallHelper.class);
+    private Logger logger = new Logger(NetworkCallHelper.class);
 
 
     public Map<String, Object> doCall(MorphiumDriverOperation r, int maxRetry, int sleep) throws MorphiumDriverException {

--- a/src/de/caluga/morphium/driver/wireprotocol/OpQuery.java
+++ b/src/de/caluga/morphium/driver/wireprotocol/OpQuery.java
@@ -12,16 +12,16 @@ import java.util.Map;
  * Query call implementation for MongoDB wire protocol
  **/
 public class OpQuery extends WireProtocolMessage {
-    int opCode = 2004;
+    private int opCode = 2004;
 
-    String db;
-    String coll;
-    int skip = 0;
-    int limit = 1;
-    Map<String, Object> doc;
+    private String db;
+    private String coll;
+    private int skip = 0;
+    private int limit = 1;
+    private Map<String, Object> doc;
 
-    int reqId;
-    int inReplyTo;
+    private int reqId;
+    private int inReplyTo;
 
 
     public int getOpCode() {

--- a/src/de/caluga/morphium/driver/wireprotocol/OpReply.java
+++ b/src/de/caluga/morphium/driver/wireprotocol/OpReply.java
@@ -15,18 +15,18 @@ import java.util.Map;
  **/
 
 public class OpReply extends WireProtocolMessage {
-    int reqId;
-    int inReplyTo;
+    private int reqId;
+    private int inReplyTo;
 
-    int size = 0;
-    int opcode = 1;
-    int flags;
-    long cursorId;
-    int startFrom;
-    int numReturned;
-    byte[] readBytes;
+    private int size = 0;
+    private int opcode = 1;
+    private int flags;
+    private long cursorId;
+    private int startFrom;
+    private int numReturned;
+    private byte[] readBytes;
     public long timestamp;
-    List<Map<String, Object>> documents;
+    private List<Map<String, Object>> documents;
 
     public OpReply() {
         timestamp = System.currentTimeMillis();

--- a/src/de/caluga/morphium/messaging/Messaging.java
+++ b/src/de/caluga/morphium/messaging/Messaging.java
@@ -78,7 +78,7 @@ public class Messaging extends Thread implements ShutdownListener {
                     morphium.getConfig().getThreadPoolMessagingKeepAliveTime(), TimeUnit.MILLISECONDS,
                     new LinkedBlockingQueue<>());
             threadPool.setThreadFactory(new ThreadFactory() {
-                AtomicInteger num = new AtomicInteger(1);
+                private AtomicInteger num = new AtomicInteger(1);
 
                 @Override
                 public Thread newThread(Runnable r) {

--- a/src/de/caluga/morphium/replicaset/RSMonitor.java
+++ b/src/de/caluga/morphium/replicaset/RSMonitor.java
@@ -29,7 +29,7 @@ public class RSMonitor {
         this.morphium = morphium;
         executorService = new ScheduledThreadPoolExecutor(1);
         executorService.setThreadFactory(new ThreadFactory() {
-            AtomicInteger num = new AtomicInteger(1);
+            private AtomicInteger num = new AtomicInteger(1);
 
             @Override
             public Thread newThread(Runnable r) {

--- a/src/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/src/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -64,7 +64,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
 //                }
 //            });
             executor.setThreadFactory(new ThreadFactory() {
-                AtomicInteger num = new AtomicInteger(1);
+                private AtomicInteger num = new AtomicInteger(1);
 
                 @Override
                 public Thread newThread(Runnable r) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2039 - "Member variable visibility should be specified".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S2039
Please let me know if you have any questions.
Artyom Melnikov