### PR TITLE
Fixing squid:S1068 - Unused private fields should be removed

### DIFF
--- a/src/de/caluga/morphium/cache/CacheHousekeeper.java
+++ b/src/de/caluga/morphium/cache/CacheHousekeeper.java
@@ -16,13 +16,11 @@ import java.util.concurrent.ConcurrentHashMap;
 @SuppressWarnings("UnusedDeclaration")
 public class CacheHousekeeper extends Thread {
 
-    private static final String MONGODBLAYER_CACHE = "mongodblayer.cache";
     private int housekeepingIntervalPause = 500;
     private Map<Class<?>, Integer> validTimeForClass;
     private int gcTimeout = 5000;
     private boolean running = true;
     private Logger log = new Logger(CacheHousekeeper.class);
-    private MorphiumCache cache;
     private AnnotationAndReflectionHelper annotationHelper;
     private MorphiumCache morphiumCache;
 

--- a/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -23,8 +23,6 @@ public class InMemoryDriver implements MorphiumDriver {
     // DBName => Collection => List of documents
     private Map<String, Map<String, List<Map<String, Object>>>> database = new ConcurrentHashMap<>();
 
-    private boolean replicaset = false;
-
     @Override
     public void setCredentials(String db, String login, char[] pwd) {
 

--- a/src/de/caluga/morphium/driver/meta/MetaDriver.java
+++ b/src/de/caluga/morphium/driver/meta/MetaDriver.java
@@ -37,12 +37,9 @@ public class MetaDriver extends DriverBase {
     private Map<String, Integer> errorCountByHost = new ConcurrentHashMap<>();
 
     private static ReadPreference primary = ReadPreference.primary();
-    private static ReadPreference secondary = ReadPreference.secondary();
     private static ReadPreference secondaryPreferred = ReadPreference.secondaryPreferred();
     private static ReadPreference primaryPreferred = ReadPreference.primaryPreferred();
-    private static ReadPreference nearest = ReadPreference.primary();
 
-    private static volatile int roundrobin = 0;
     private boolean connected = false;
     private long fastestHostTimestamp = System.currentTimeMillis();
 

--- a/src/de/caluga/morphium/driver/singleconnect/BulkContext.java
+++ b/src/de/caluga/morphium/driver/singleconnect/BulkContext.java
@@ -20,7 +20,6 @@ import java.util.Map;
  * Bulk Context implementation for the singleconnect drivers
  */
 public class BulkContext extends BulkRequestContext {
-    private Logger log = new Logger(BulkContext.class);
     private DriverBase driver;
     private boolean ordered;
     private String db;

--- a/src/de/caluga/morphium/replicaset/ReplicaSetStatus.java
+++ b/src/de/caluga/morphium/replicaset/ReplicaSetStatus.java
@@ -17,7 +17,6 @@ import java.util.List;
 @SuppressWarnings("UnusedDeclaration")
 @Embedded(translateCamelCase = false)
 public class ReplicaSetStatus {
-    private static Logger log = new Logger(ReplicaSetStatus.class);
     private String set;
     private String myState;
     private Date date;

--- a/src/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/src/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -1765,11 +1765,8 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
     public <T> void dropCollection(final Class<T> cls, final String collection, AsyncOperationCallback<T> callback) {
         if (morphium.getARHelper().isAnnotationPresentInHierarchy(cls, Entity.class)) {
             WriterTask r = new WriterTask() {
-                private AsyncOperationCallback<T> callback;
-
                 @Override
                 public void setCallback(AsyncOperationCallback cb) {
-                    callback = cb;
                 }
 
                 public void run() {
@@ -1799,11 +1796,9 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
     @Override
     public <T> void ensureIndex(final Class<T> cls, final String collection, final Map<String, Object> index, final Map<String, Object> options, AsyncOperationCallback<T> callback) {
         WriterTask r = new WriterTask() {
-            private AsyncOperationCallback<T> callback;
 
             @Override
             public void setCallback(AsyncOperationCallback cb) {
-                callback = cb;
             }
 
             @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1068 - "Unused private fields should be removed".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S1068
Please let me know if you have any questions.
Artyom Melnikov