### PR TITLE
read preference secondary will fail, when there is only one node in the cluster

### DIFF
--- a/src/de/caluga/morphium/MorphiumConfig.java
+++ b/src/de/caluga/morphium/MorphiumConfig.java
@@ -466,7 +466,7 @@ public class MorphiumConfig {
         return queryClass;
     }
 
-    public MorphiumConfig setQueryClass(Class<Query> queryClass) {
+    public MorphiumConfig setQueryClass(Class<? extends Query> queryClass) {
         this.queryClass = queryClass;
         return this;
     }

--- a/src/de/caluga/morphium/driver/mongodb/Driver.java
+++ b/src/de/caluga/morphium/driver/mongodb/Driver.java
@@ -1012,7 +1012,7 @@ public class Driver implements MorphiumDriver {
                     if (tags != null) {
                         prf = com.mongodb.ReadPreference.secondaryPreferred(tags);
                     } else {
-                        prf = com.mongodb.ReadPreference.secondary();
+                        prf = com.mongodb.ReadPreference.secondaryPreferred();
                     }
                     break;
                 default:


### PR DESCRIPTION
Therefore read preference secondary preferred should not be changed to secondary