### PR TITLE
add property localThreshold to clusterSettings of MongoClientSettings

### DIFF
--- a/src/de/caluga/morphium/MorphiumConfig.java
+++ b/src/de/caluga/morphium/MorphiumConfig.java
@@ -129,6 +129,7 @@ public class MorphiumConfig {
     private long threadPoolAsyncOpKeepAliveTime = 1000;
     private boolean objectSerializationEnabled = true;
     private int heartbeatFrequency = 1000;
+    private int localThreshold = 15;
     private int maxConnectionIdleTime = 10000;
     private int maxConnectionLifeTime = 60000;
 
@@ -1151,6 +1152,32 @@ public class MorphiumConfig {
         return this;
     }
 
+    public int getLocalThreshold() {
+        return localThreshold;
+    }
+
+    /**
+     * <p>
+     * Sets the local threshold. When choosing among multiple MongoDB servers to send a request, the MongoClient will only send that request to a server whose ping time is less than or equal to the server with the fastest ping time plus the local threshold.
+     * </p>
+     *
+     * <p>
+     * For example, let's say that the client is choosing a server to send a query when the read preference is {@code
+     * ReadPreference.secondary()}, and that there are three secondaries, server1, server2, and server3, whose ping times are 10, 15, and 16 milliseconds, respectively. With a local threshold of 5 milliseconds, the client will send the query to either server1 or server2 (randomly selecting between the two).
+     * </p>
+     *
+     * <p>
+     * Default is 15 milliseconds.
+     * </p>
+     *
+     * @return the local threshold, in milliseconds
+     * @mongodb.driver.manual reference/program/mongos/#cmdoption--localThreshold Local Threshold
+     * @since 2.13.0
+     */
+    public MorphiumConfig setLocalThreshold(int localThreshold) {
+        this.localThreshold = localThreshold;
+        return this;
+    }
 
     public int getMaxConnectionIdleTime() {
         return maxConnectionIdleTime;

--- a/src/de/caluga/morphium/driver/MorphiumDriver.java
+++ b/src/de/caluga/morphium/driver/MorphiumDriver.java
@@ -108,6 +108,10 @@ public interface MorphiumDriver {
     @SuppressWarnings("unused")
     void setDefaultJ(boolean j);
 
+    int getLocalThreshold();
+
+    void setLocalThreshold(int thr);
+
     int getReadTimeout();
 
     void setReadTimeout(int readTimeout);

--- a/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -363,6 +363,16 @@ public class InMemoryDriver implements MorphiumDriver {
     }
 
     @Override
+    public int getLocalThreshold() {
+        return 0;
+    }
+
+    @Override
+    public void setLocalThreshold(int thr) {
+
+    }
+
+    @Override
     public void heartBeatFrequency(int t) {
 
     }

--- a/src/de/caluga/morphium/driver/mongodb/MongoDriver.java
+++ b/src/de/caluga/morphium/driver/mongodb/MongoDriver.java
@@ -60,6 +60,7 @@ public class MongoDriver implements MorphiumDriver {
     private int heartbeatFrequency = 1000;
     private boolean defaultJ = false;
     private int writeTimeout = 1000;
+    private int localThreshold = 15;
     private boolean defaultFsync;
     private int maxWaitTime;
     private int serverSelectionTimeout;
@@ -369,6 +370,16 @@ public class MongoDriver implements MorphiumDriver {
     }
 
     @Override
+    public int getLocalThreshold() {
+        return localThreshold;
+    }
+
+    @Override
+    public void setLocalThreshold(int thr) {
+        localThreshold = thr;
+    }
+
+    @Override
     public void heartBeatFrequency(int t) {
         heartbeatFrequency = t;
     }
@@ -548,6 +559,7 @@ public class MongoDriver implements MorphiumDriver {
                 }
                 clusterSettings.hosts(hosts);
                 clusterSettings.serverSelectionTimeout(getServerSelectionTimeout(), TimeUnit.MILLISECONDS);
+                clusterSettings.localThreshold(getLocalThreshold(), TimeUnit.MILLISECONDS);
                 clusterSettings.addClusterListener(new ClusterListener() {
                     @Override
                     public void clusterOpening(ClusterOpeningEvent event) {
@@ -586,7 +598,6 @@ public class MongoDriver implements MorphiumDriver {
 
 //            o.connectTimeout(getConnectionTimeout());
 //            o.connectionsPerHost(getMaxConnectionsPerHost());
-//            o.socketKeepAlive(isSocketKeepAlive());
 //            o.threadsAllowedToBlockForConnectionMultiplier(getMaxBlockintThreadMultiplier());
             //        o.cursorFinalizerEnabled(isCursorFinalizerEnabled()); //Deprecated?
             //        o.alwaysUseMBeans(isAlwaysUseMBeans());


### PR DESCRIPTION
and reinstitute the property localThreshold in MorphiumConfig.

I don't think this property is particular important. But why not keep it
if the mongo driver supports it.