### PR TITLE
Make UuidRepresentation configurable or UUIDs can not be stored

### DIFF
--- a/src/de/caluga/morphium/Morphium.java
+++ b/src/de/caluga/morphium/Morphium.java
@@ -220,6 +220,7 @@ public class Morphium implements AutoCloseable {
             morphiumDriver.setMaxConnectionLifetime(config.getMaxConnectionLifeTime());
             morphiumDriver.setMaxWaitTime(config.getMaxWaitTime());
             morphiumDriver.setServerSelectionTimeout(config.getServerSelectionTimeout());
+            morphiumDriver.setUuidRepresentation(config.getUuidRepresentation());
 
             morphiumDriver.setUseSSL(config.isUseSSL());
             morphiumDriver.setSslContext(config.getSslContext());
@@ -2552,37 +2553,43 @@ public class Morphium implements AutoCloseable {
             rsMonitor = null;
         }
 
-        config.getAsyncWriter().close();
-        config.getBufferedWriter().close();
-        config.getWriter().close();
-        try {
-            getDriver().close();
-        } catch (MorphiumDriverException e) {
-            e.printStackTrace();
+        if (config != null) {
+            config.getAsyncWriter().close();
+            config.getBufferedWriter().close();
+            config.getWriter().close();
         }
-        //        if (oplogMonitor != null) {
-        //            oplogMonitor.terminate();
-        //            try {
-        //                Thread.sleep(1000); //wait for it to finish...
-        //            } catch (InterruptedException e) {
-        //                //ignoring interrupted excepition
-        //            }
-        //        }
-        //        if (oplogMonitorThread != null) {
-        //            try {
-        //                oplogMonitorThread.interrupt();
-        //            } catch (Exception e) {
-        //                //ignoring
-        //            }
-        //        }
-        config.getCache().resetCache();
-        config.setBufferedWriter(null);
-        config.setAsyncWriter(null);
-        config.setWriter(null);
-        config = null;
-        morphiumDriver = null;
-//        config.getCache().resetCache();
-        //        MorphiumSingleton.reset();
+        if (morphiumDriver != null) {
+            try {
+                morphiumDriver.close();
+            } catch (MorphiumDriverException e) {
+                e.printStackTrace();
+            }
+            morphiumDriver = null;
+        }
+        // if (oplogMonitor != null) {
+        // oplogMonitor.terminate();
+        // try {
+        // Thread.sleep(1000); //wait for it to finish...
+        // } catch (InterruptedException e) {
+        // //ignoring interrupted excepition
+        // }
+        // }
+        // if (oplogMonitorThread != null) {
+        // try {
+        // oplogMonitorThread.interrupt();
+        // } catch (Exception e) {
+        // //ignoring
+        // }
+        // }
+        if (config != null) {
+            config.getCache().resetCache();
+            config.setBufferedWriter(null);
+            config.setAsyncWriter(null);
+            config.setWriter(null);
+            config = null;
+        }
+        // config.getCache().resetCache();
+        // MorphiumSingleton.reset();
     }
 
     @SuppressWarnings("unused")

--- a/src/de/caluga/morphium/MorphiumConfig.java
+++ b/src/de/caluga/morphium/MorphiumConfig.java
@@ -19,6 +19,8 @@ import de.caluga.morphium.writer.AsyncWriterImpl;
 import de.caluga.morphium.writer.BufferedMorphiumWriterImpl;
 import de.caluga.morphium.writer.MorphiumWriter;
 import de.caluga.morphium.writer.MorphiumWriterImpl;
+
+import org.bson.UuidRepresentation;
 import org.json.simple.parser.ParseException;
 import org.slf4j.LoggerFactory;
 
@@ -141,6 +143,7 @@ public class MorphiumConfig {
     private int readTimeout;
     private boolean retryReads;
     private boolean retryWrites;
+    private String uuidRepresentation;
 
     public MorphiumConfig(final Properties prop) {
         this(null, prop);
@@ -1287,5 +1290,27 @@ public class MorphiumConfig {
 
     public void setRetryWrites(boolean retryWrites) {
         this.retryWrites = retryWrites;
+    }
+
+    public String getUuidRepresentation() {
+        return uuidRepresentation;
+    }
+
+    /**
+     * Sets the UUID representation to use when encoding instances of {@link java.util.UUID} and when decoding BSON binary values with
+     * subtype of 3.
+     *
+     * <p>The default is UNSPECIFIED, If your application stores UUID values in MongoDB, you must set this
+     * value to the desired representation.  New applications should prefer STANDARD, while existing Java
+     * applications should prefer JAVA_LEGACY. Applications wishing to interoperate with existing Python or
+     * .NET applications should prefer PYTHON_LEGACY or C_SHARP_LEGACY,
+     * respectively. Applications that do not store UUID values in MongoDB don't need to set this value.
+     * </p>
+     *
+     * @param uuidRepresentation the UUID representation
+     * @since 3.12
+     */
+    public void setUuidRepresentation(String uuidRepresentation) {
+        this.uuidRepresentation = uuidRepresentation;
     }
 }

--- a/src/de/caluga/morphium/driver/MorphiumDriver.java
+++ b/src/de/caluga/morphium/driver/MorphiumDriver.java
@@ -96,6 +96,10 @@ public interface MorphiumDriver {
 
     void setRetryWrites(boolean retryWrites);
 
+    String getUuidRepresentation();
+
+    void setUuidRepresentation(String uuidRepresentation);
+
     @SuppressWarnings("unused")
     boolean isUseSSL();
 

--- a/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/src/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -331,6 +331,14 @@ public class InMemoryDriver implements MorphiumDriver {
 
     }
 
+    @Override
+    public String getUuidRepresentation() {
+        return null;
+    }
+
+    @Override
+    public void setUuidRepresentation(String uuidRepresentation) {
+    }
 
     @Override
     public boolean isUseSSL() {

--- a/test/de/caluga/test/mongo/suite/AnnotationAndReflectionHelperTest.java
+++ b/test/de/caluga/test/mongo/suite/AnnotationAndReflectionHelperTest.java
@@ -1,14 +1,21 @@
 package de.caluga.test.mongo.suite;
 
 import de.caluga.morphium.AnnotationAndReflectionHelper;
-import de.caluga.morphium.annotations.*;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.annotations.IgnoreFields;
+import de.caluga.morphium.annotations.Index;
+import de.caluga.morphium.annotations.LimitToFields;
 import de.caluga.morphium.annotations.caching.Cache;
 import de.caluga.morphium.driver.MorphiumId;
 import de.caluga.test.mongo.suite.data.CachedObject;
 import de.caluga.test.mongo.suite.data.EmbeddedObject;
+import de.caluga.test.mongo.suite.data.UUIDTestObject;
 import de.caluga.test.mongo.suite.data.UncachedObject;
+
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.FixedValue;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -138,6 +146,14 @@ public class AnnotationAndReflectionHelperTest {
         UncachedObject uncachedObject = new UncachedObject();
         helper.setValue(uncachedObject, 123, "counter");
         assertThat(uncachedObject.getCounter()).isEqualTo(123);
+    }
+
+    @Test
+    public void testSetUUIDFromJavaLegacyUIIDByteArray() {
+        UUIDTestObject uuidTestObject = new UUIDTestObject();
+        byte[] dbValue = new byte[] {78, 67, 47, -34, -114, 8, 62, -13, 72, -42, 126, -10, 38, 56, -106, -122};
+        helper.setValue(uuidTestObject, dbValue, "uuidValue");
+        assertThat(uuidTestObject.uuidValue).isEqualTo(UUID.fromString("4e432fde-8e08-3ef3-48d6-7ef626389686"));
     }
 
     @Test

--- a/test/de/caluga/test/mongo/suite/data/UUIDTestObject.java
+++ b/test/de/caluga/test/mongo/suite/data/UUIDTestObject.java
@@ -1,0 +1,21 @@
+package de.caluga.test.mongo.suite.data;
+
+import java.util.UUID;
+
+import de.caluga.morphium.annotations.DefaultReadPreference;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.annotations.ReadPreferenceLevel;
+import de.caluga.morphium.annotations.SafetyLevel;
+import de.caluga.morphium.annotations.WriteSafety;
+
+@Entity(typeId = "uuidtest", nameProvider = TestEntityNameProvider.class)
+@WriteSafety(timeout = -1, level = SafetyLevel.WAIT_FOR_ALL_SLAVES)
+@DefaultReadPreference(ReadPreferenceLevel.SECONDARY_PREFERRED)
+public class UUIDTestObject {
+
+    @Id
+    public UUID id;
+
+    public UUID uuidValue;
+}


### PR DESCRIPTION
Mongo Driver 4 has UuidRepresentation.UNSPECIFIED as default, what
renders the driver and morhpium unable to store UUID values. If tried
the driver will throw an exception. UuidRepresentation can now be
configured with MorphiumConfig. UuidRepresentation.STANDARD should be
preferred if not an other application that only supportes JAVA_LEGACY is
using the same database.

Morphium will creae UUID objects from JAVA_LEGACY (type 3) UUID values
from the database that are delivered as byte array from the driver.

UUID objects are supported as keys and as values in Maps.

Further changes: LocalDate, LocalTime and LocalDateTime are stored as
Dates in the mongo database