### PR TITLE
Make MorphiumDriverException unchecked (extends RuntimeException)

### DIFF
--- a/src/main/java/de/caluga/morphium/Morphium.java
+++ b/src/main/java/de/caluga/morphium/Morphium.java
@@ -484,11 +484,7 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
 
         morphiumDriver.setHostSeed(seed);
 
-        try {
-            morphiumDriver.connect(getConfig().clusterSettings().getRequiredReplicaSetName());
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        morphiumDriver.connect(getConfig().clusterSettings().getRequiredReplicaSetName());
 
         if (getConfig().writerSettings().getWriter() == null) {
             getConfig().writerSettings().setWriter(new MorphiumWriterImpl());
@@ -528,40 +524,30 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
                         break;
 
                     case CONVERT_EXISTING_ON_STARTUP:
-                        try {
-                            if (exists(getDatabase(), getMapper().getCollectionName(cls))) {
-                                log.warn("Existing collection is not capped - ATTENTION!");
-                                // convertToCapped(cls, capped.get(cls).get("size"), capped.get(cls).get("max"),
-                                // null);
-                            }
-                        } catch (MorphiumDriverException e) {
-                            throw new RuntimeException(e);
+                        if (exists(getDatabase(), getMapper().getCollectionName(cls))) {
+                            log.warn("Existing collection is not capped - ATTENTION!");
+                            // convertToCapped(cls, capped.get(cls).get("size"), capped.get(cls).get("max"),
+                            // null);
                         }
 
                         break;
 
                     case CREATE_ON_STARTUP:
-                        try {
-                            if (!morphiumDriver.exists(getDatabase(), getMapper().getCollectionName(cls))) {
-                                MongoConnection primaryConnection = null;
-                                CreateCommand cmd = null;
+                        if (!morphiumDriver.exists(getDatabase(), getMapper().getCollectionName(cls))) {
+                            MongoConnection primaryConnection = null;
+                            CreateCommand cmd = null;
 
-                                try {
-                                    primaryConnection = morphiumDriver.getPrimaryConnection(null);
-                                    cmd = new CreateCommand(primaryConnection);
-                                    cmd.setDb(getDatabase()).setColl(getMapper().getCollectionName(cls)).setCapped(true).setMax(capped.get(cls).get("max")).setSize(capped.get(cls).get("size"));
-                                    var ret = cmd.execute();
-                                    log.debug("Created capped collection");
-                                } catch (MorphiumDriverException e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    if (primaryConnection != null) {
-                                        cmd.releaseConnection();
-                                    }
+                            try {
+                                primaryConnection = morphiumDriver.getPrimaryConnection(null);
+                                cmd = new CreateCommand(primaryConnection);
+                                cmd.setDb(getDatabase()).setColl(getMapper().getCollectionName(cls)).setCapped(true).setMax(capped.get(cls).get("max")).setSize(capped.get(cls).get("size"));
+                                var ret = cmd.execute();
+                                log.debug("Created capped collection");
+                            } finally {
+                                if (primaryConnection != null) {
+                                    cmd.releaseConnection();
                                 }
                             }
-                        } catch (MorphiumDriverException e) {
-                            throw new RuntimeException(e);
                         }
 
                     case CREATE_ON_WRITE_NEW_COL:
@@ -680,7 +666,7 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
         try {
             return getDriver().listDatabases();
         } catch (MorphiumDriverException e) {
-            throw new RuntimeException("Could not list databases", e);
+            throw new MorphiumDriverException("Could not list databases", e);
         }
     }
 
@@ -700,19 +686,15 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
             return ret;
         }
 
-        try {
-            var result = getDriver().listCollections(getConfig().connectionSettings().getDatabase(), pattern);
-            var lst = new ArrayList<CollectionInfo>();
+        var result = getDriver().listCollections(getConfig().connectionSettings().getDatabase(), pattern);
+        var lst = new ArrayList<CollectionInfo>();
 
-            for (var r : result) {
-                lst.add(new CollectionInfo().setName(r));
-            }
-
-            getCache().addToCache(pattern, CollectionInfo.class, lst);
-            return result;
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
+        for (var r : result) {
+            lst.add(new CollectionInfo().setName(r));
         }
+
+        getCache().addToCache(pattern, CollectionInfo.class, lst);
+        return result;
     }
 
     public void reconnectToDb(String db) {
@@ -1655,17 +1637,13 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
     }
 
     public int getEstimatedCount(Class<?> type) {
-        try {
-            var stats = getCollStats(getMapper().getCollectionName(type));
+        var stats = getCollStats(getMapper().getCollectionName(type));
 
-            if (stats == null || stats.isEmpty()) {
-                return 0;
-            }
-
-            return (Integer) stats.get("count");
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
+        if (stats == null || stats.isEmpty()) {
+            return 0;
         }
+
+        return (Integer) stats.get("count");
     }
 
     public long getCount(Class<?> type) {
@@ -1703,8 +1681,6 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
             }
 
             return settings.execute();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (settings != null) {
                 settings.releaseConnection();
@@ -2196,7 +2172,7 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
             if (e.getMessage() != null && e.getMessage().contains("Error: 26")) {
                 return new ArrayList<>();
             }
-            throw new RuntimeException(e);
+            throw e;
         } finally {
             if (cmd != null) {
                 cmd.releaseConnection();
@@ -2840,19 +2816,11 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
     }
 
     public void commitTransaction() {
-        try {
-            getDriver().commitTransaction();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        getDriver().commitTransaction();
     }
 
     public void abortTransaction() {
-        try {
-            getDriver().abortTransaction();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        getDriver().abortTransaction();
     }
 
     public <T> void watchAsync(String collectionName, boolean updateFull, ChangeStreamListener lst) {
@@ -2906,8 +2874,6 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
 
             getDriver().watch(settings);
             // settings.releaseConnection();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (settings != null) settings.releaseConnection();
         }
@@ -2974,8 +2940,6 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
             });
 
             cmd.watch();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (cmd != null) {
                 cmd.releaseConnection();

--- a/src/main/java/de/caluga/morphium/aggregation/AggregationIterator.java
+++ b/src/main/java/de/caluga/morphium/aggregation/AggregationIterator.java
@@ -31,7 +31,7 @@ public class AggregationIterator<T, R> implements MorphiumAggregationIterator<T,
             getMongoCursor().ahead(jump);
         } catch (MorphiumDriverException e) {
             getMongoCursor().close();
-            throw new RuntimeException(e);
+            throw e;
         }
     }
 
@@ -41,7 +41,7 @@ public class AggregationIterator<T, R> implements MorphiumAggregationIterator<T,
             getMongoCursor().back(jump);
         } catch (MorphiumDriverException e) {
             getMongoCursor().close();
-            throw new RuntimeException(e);
+            throw e;
         }
     }
 
@@ -126,14 +126,10 @@ public class AggregationIterator<T, R> implements MorphiumAggregationIterator<T,
 
     private MorphiumCursor getMongoCursor() {
         if (cursor == null) {
-            try {
-                var morphium = aggregator.getMorphium();
-                var config = morphium != null ? morphium.getConfig() : null;
-                int batchSize = config != null ? config.getCursorBatchSize() : 1000; // default batch size
-                cursor = aggregator.getAggregateCmd().executeIterable(batchSize);
-            } catch (MorphiumDriverException e) {
-                throw new RuntimeException(e);
-            }
+            var morphium = aggregator.getMorphium();
+            var config = morphium != null ? morphium.getConfig() : null;
+            int batchSize = config != null ? config.getCursorBatchSize() : 1000; // default batch size
+            cursor = aggregator.getAggregateCmd().executeIterable(batchSize);
         }
 
         return cursor;

--- a/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
+++ b/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
@@ -306,11 +306,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public List<R> aggregate() {
-        try {
-            return deserializeList();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        return deserializeList();
     }
 
     @Override
@@ -323,8 +319,6 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         try {
             cmd.setPipeline(pipeline);
             res = cmd.execute();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             cmd.releaseConnection();
         }
@@ -353,8 +347,6 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             try {
                 log.warn("Async operation but callback is null!");
                 cmd.executeAsync();
-            } catch (MorphiumDriverException e) {
-                throw new RuntimeException(e);
             } finally {
                 cmd.releaseConnection();
             }
@@ -401,8 +393,6 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         try {
             if (collation != null) cmd.setCollation(Doc.of(getCollation().toQueryObject()));
             return cmd.execute();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             cmd.releaseConnection();
         }
@@ -415,8 +405,6 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
             try {
                 cmd.execute();
-            } catch (MorphiumDriverException e) {
-                throw new RuntimeException(e);
             } finally {
                 cmd.releaseConnection();
             }

--- a/src/main/java/de/caluga/morphium/bulk/MorphiumBulkContext.java
+++ b/src/main/java/de/caluga/morphium/bulk/MorphiumBulkContext.java
@@ -7,7 +7,6 @@ import de.caluga.morphium.MorphiumStorageListener;
 import de.caluga.morphium.Utils;
 import de.caluga.morphium.UtilsMap;
 import de.caluga.morphium.driver.Doc;
-import de.caluga.morphium.driver.MorphiumDriverException;
 import de.caluga.morphium.driver.bulk.BulkRequestContext;
 import de.caluga.morphium.driver.bulk.DeleteBulkRequest;
 import de.caluga.morphium.driver.bulk.UpdateBulkRequest;
@@ -35,12 +34,7 @@ public class MorphiumBulkContext<T> {
 
     public Map<String, Object> runBulk() {
         firePre();
-        Map<String, Object> ret;
-        try {
-            ret = ctx.execute();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        Map<String, Object> ret = ctx.execute();
         firePost();
         return ret;
     }

--- a/src/main/java/de/caluga/morphium/driver/MorphiumDriverException.java
+++ b/src/main/java/de/caluga/morphium/driver/MorphiumDriverException.java
@@ -5,9 +5,26 @@ package de.caluga.morphium.driver;/**
 import java.util.Map;
 
 /**
- * error during accessing the database through the driver
+ * Base exception for all errors that occur while accessing the database through
+ * the Morphium driver layer.
+ * <p>
+ * This is an <b>unchecked</b> exception ({@code RuntimeException}) — consistent
+ * with the convention established by the official MongoDB Java driver
+ * ({@code com.mongodb.MongoException extends RuntimeException}) and with the
+ * general trend in modern Java persistence frameworks (JPA, jOOQ, Spring Data)
+ * that treat database errors as unrecoverable at the point of call.
+ * <p>
+ * Making this unchecked eliminated the pervasive
+ * {@code catch (MorphiumDriverException e) { throw new RuntimeException(e); }}
+ * pattern that previously existed throughout the codebase wherever a
+ * method could not declare checked exceptions — for example in
+ * {@link java.util.Iterator} implementations, {@code MorphiumWriter} methods,
+ * and lambda callbacks. Those catch-and-wrap blocks have been removed.
+ *
+ * @see MorphiumDriverNetworkException
+ * @see FunctionNotSupportedException
  **/
-public class MorphiumDriverException extends Exception {
+public class MorphiumDriverException extends RuntimeException {
     private String collection;
     private String db;
     private Map<String, Object> query;

--- a/src/main/java/de/caluga/morphium/driver/commands/ReadMongoCommand.java
+++ b/src/main/java/de/caluga/morphium/driver/commands/ReadMongoCommand.java
@@ -20,11 +20,7 @@ public abstract class ReadMongoCommand<T extends MongoCommand> extends MongoComm
 
     @Override
     public Iterator<Map<String, Object>> iterator() {
-        try {
-            return executeIterable(getConnection().getDriver().getDefaultBatchSize());
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        return executeIterable(getConnection().getDriver().getDefaultBatchSize());
     }
 
     public List<Map<String, Object>> execute() throws MorphiumDriverException {

--- a/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
+++ b/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
@@ -293,11 +293,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public List<R> aggregate() {
-        try {
-            return deserializeList();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        return deserializeList();
     }
 
     @Override
@@ -1592,7 +1588,6 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
                     }
 
                     for (Map<String, Object> doc : data) {
-                        try {
                             Map<String, Object> q = new HashMap<>();
 
                             for (String onfld : on) {
@@ -1705,10 +1700,6 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
                                         throw new IllegalArgumentException("unknown whenMatched action " + matched);
                                 }
                             }
-                        } catch (MorphiumDriverException e) {
-                            throw new RuntimeException(e);
-                            // e.printStackTrace();
-                        }
                     }
                 } else {
                     //                    try {

--- a/src/main/java/de/caluga/morphium/driver/wire/PooledDriver.java
+++ b/src/main/java/de/caluga/morphium/driver/wire/PooledDriver.java
@@ -1198,7 +1198,7 @@ public class PooledDriver extends DriverBase {
         } catch (MorphiumDriverException e) {
             log.error("Error getting connection", e);
             stats.get(DriverStatsKey.ERRORS).incrementAndGet();
-            throw new RuntimeException(e);
+            throw e;
         }
     }
 

--- a/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnectDriver.java
+++ b/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnectDriver.java
@@ -445,20 +445,12 @@ public class SingleMongoConnectDriver extends DriverBase {
 
     @Override
     public MongoConnection getReadConnection(ReadPreference rp) {
-        try {
-            return getConnection();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        return getConnection();
     }
 
     @Override
     public MongoConnection getPrimaryConnection(WriteConcern wc) {
-        try {
-            return getConnection();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        return getConnection();
     }
 
     @Override

--- a/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnectionCursor.java
+++ b/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnectionCursor.java
@@ -109,11 +109,7 @@ public class SingleMongoConnectionCursor extends MorphiumCursor {
 
         if (getCursorId() != 0) {
             // next batch
-            try {
-                getNextIteration();
-            } catch (MorphiumDriverException e) {
-                throw new RuntimeException(e);
-            }
+            getNextIteration();
 
             if (getBatch() == null || getBatch().isEmpty()) {
                 if (connection != null) {
@@ -155,11 +151,7 @@ public class SingleMongoConnectionCursor extends MorphiumCursor {
         }
 
         if (getBatch().size() <= internalIndex) {
-            try {
-                getNextIteration();
-            } catch (MorphiumDriverException e) {
-                throw new RuntimeException(e);
-            }
+            getNextIteration();
 
             if (getBatch() == null || getBatch().isEmpty()) {
                 return null;
@@ -178,8 +170,6 @@ public class SingleMongoConnectionCursor extends MorphiumCursor {
 
         try {
             getConnection().closeIteration(this);
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (connection != null) {
                 connection.getDriver().releaseConnection(connection);

--- a/src/main/java/de/caluga/morphium/query/Query.java
+++ b/src/main/java/de/caluga/morphium/query/Query.java
@@ -529,9 +529,6 @@ public class Query<T> implements Cloneable {
             cmd.releaseConnection();
             cmd = null;
             con = null;
-        } catch (MorphiumDriverException e) {
-            // TODO: Implement Handling
-            throw new RuntimeException(e);
         } finally {
             if (cmd != null) {
                 cmd.releaseConnection();
@@ -590,9 +587,6 @@ public class Query<T> implements Cloneable {
             }
 
             obj = settings.execute();
-        } catch (MorphiumDriverException e) {
-            // TODO: Implement Handling
-            throw new RuntimeException(e);
         } finally {
             morphium.getDriver().releaseConnection(settings.getConnection());
         }
@@ -708,8 +702,6 @@ public class Query<T> implements Cloneable {
             cmd = null;
             con = null;
             return result;
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (cmd != null) {
                 cmd.releaseConnection();
@@ -736,8 +728,6 @@ public class Query<T> implements Cloneable {
             cmd = null;
             con = null;
             return result;
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (cmd != null) {
                 cmd.releaseConnection();
@@ -1638,11 +1628,7 @@ public class Query<T> implements Cloneable {
         try {
             settings = getFindCmd();
             srch = settings.execute();
-        } catch (MorphiumDriverException e) {
-            // TODO: Implement Handling
-            throw new RuntimeException(e);
-        }
-        finally {
+        } finally {
             if (settings != null) {
                 settings.releaseConnection();
             }
@@ -1740,11 +1726,7 @@ public class Query<T> implements Cloneable {
             settings.setProjection(Doc.of("_id", 1));
             query = settings.execute();
             srv = (String) settings.getMetaData().get("server");
-        } catch (MorphiumDriverException e) {
-            // TODO: Implement Handling
-            throw new RuntimeException(e);
-        }
-        finally {
+        } finally {
             if (settings != null) {
                 settings.releaseConnection();
             }
@@ -2293,9 +2275,6 @@ public class Query<T> implements Cloneable {
             cmd.releaseConnection();
             cmd = null;
             con = null;
-        } catch (MorphiumDriverException e) {
-            // TODO: Implement Handling
-            throw new RuntimeException(e);
         } finally {
             if (cmd != null) {
                 cmd.releaseConnection();

--- a/src/main/java/de/caluga/morphium/query/QueryIterator.java
+++ b/src/main/java/de/caluga/morphium/query/QueryIterator.java
@@ -56,7 +56,7 @@ public class QueryIterator<T> implements MorphiumIterator<T>, Iterator<T> {
             if (getMongoCursor() != null && getMongoCursor().getConnection() != null)
                 getMongoCursor().getConnection().close();
 
-            throw new RuntimeException(e);
+            throw e;
         }
     }
 
@@ -67,7 +67,7 @@ public class QueryIterator<T> implements MorphiumIterator<T>, Iterator<T> {
             if (getMongoCursor() != null && getMongoCursor().getConnection() != null)
                 getMongoCursor().getConnection().close();
 
-            throw new RuntimeException(e);
+            throw e;
         }
     }
 
@@ -173,7 +173,7 @@ public class QueryIterator<T> implements MorphiumIterator<T>, Iterator<T> {
                 cursor = cmd.executeIterable(windowSize);
             } catch (MorphiumDriverException e) {
                 cmd.releaseConnection();
-                throw new RuntimeException(e);
+                throw e;
             }
         }
 

--- a/src/main/java/de/caluga/morphium/writer/BufferedMorphiumWriterImpl.java
+++ b/src/main/java/de/caluga/morphium/writer/BufferedMorphiumWriterImpl.java
@@ -108,8 +108,6 @@ public class BufferedMorphiumWriterImpl implements MorphiumWriter, ShutdownListe
             cmd.releaseConnection();
             cmd = null;
             primaryConnection = null;
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (cmd != null) {
                 cmd.releaseConnection();
@@ -164,7 +162,7 @@ public class BufferedMorphiumWriterImpl implements MorphiumWriter, ShutdownListe
             }
         } catch (MorphiumDriverException ex) {
             logger.error("Got error during write!", ex);
-            throw new RuntimeException(ex);
+            throw ex;
         }
 
         try {
@@ -310,11 +308,7 @@ public class BufferedMorphiumWriterImpl implements MorphiumWriter, ShutdownListe
                 }
             }
 
-            try {
-                ctx.execute();
-            } catch (MorphiumDriverException e) {
-                throw new RuntimeException(e);
-            }
+            ctx.execute();
         } else {
             opLog.putIfAbsent(type, Collections.synchronizedList(new ArrayList<>()));
             opLog.get(type).add(wb);

--- a/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -860,7 +860,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
             if (ex.getMessage().contains("already exists")) {
                 LoggerFactory.getLogger(MorphiumWriterImpl.class).error("Collection already exists...cannot create");
             } else {
-                throw new RuntimeException(ex);
+                throw ex;
             }
         } finally {
             if (cmd != null) {
@@ -960,11 +960,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
 
     @SuppressWarnings({"unused", "UnusedParameters"})
     private void executeWriteBatch(List<Object> es, Class c, WriteConcern wc, BulkRequestContext bulkCtx, long start) {
-        try {
-            bulkCtx.execute();
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
-        }
+        bulkCtx.execute();
 
         long dur = System.currentTimeMillis() - start;
         // morphium.fireProfilingWriteEvent(c, es, dur, false,
@@ -1337,8 +1333,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
             settings = new DeleteMongoCommand(con).setColl(collectionName).setDb(getDbName())
             .setDeletes(Arrays.asList(Doc.of("q", q.toQueryObject(), "limit", limit, "collation", q.getCollation() == null ? null : q.getCollation().toQueryObject())));
             return settings.explain(verbosity);
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (settings != null) {
                 settings.releaseConnection();
@@ -1456,8 +1450,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
             }
 
             return settings.explain(verbosity);
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (settings != null) {
                 settings.releaseConnection();
@@ -2515,8 +2507,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
             }
 
             morphium.inc(StatisticKeys.WRITES);
-        } catch (MorphiumDriverException e) {
-            throw new RuntimeException(e);
         } finally {
             if (settings != null) {
                 settings.releaseConnection();
@@ -2639,8 +2629,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                         }
 
                         morphium.inc(StatisticKeys.WRITES);
-                    } catch (MorphiumDriverException e) {
-                        throw new RuntimeException(e);
                     } finally {
                         if (settings != null) {
                             settings.releaseConnection();
@@ -2726,7 +2714,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                         if (e.getMessage().endsWith("error: 26 - ns not found")) {
                             LoggerFactory.getLogger(MorphiumWriterImpl.class).warn("NS not found: " + morphium.getMapper().getCollectionName(cls));
                         } else {
-                            throw new RuntimeException(e);
+                            throw e;
                         }
                     } finally {
                         if (settings != null) {
@@ -2799,9 +2787,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                             throw new MorphiumDriverException((String) res.get("errmsg"));
                         }
                     }
-                } catch (MorphiumDriverException e) {
-                    // e.printStackTrace();
-                    throw new RuntimeException(e);
                 } finally {
                     if (cmd != null) {
                         cmd.releaseConnection();

--- a/src/test/java/de/caluga/test/morphium/driver/InMemUniqueIndexTest.java
+++ b/src/test/java/de/caluga/test/morphium/driver/InMemUniqueIndexTest.java
@@ -56,7 +56,7 @@ public class InMemUniqueIndexTest {
         try {
             upd.execute();
             fail("Expected duplicate key enforcement on update");
-        } catch (RuntimeException | MorphiumDriverException ex) {
+        } catch (MorphiumDriverException ex) {
             assertTrue(ex.getMessage() == null || ex.getMessage().contains("Duplicate") || ex.getCause() != null);
         }
     }

--- a/src/test/java/de/caluga/test/morphium/driver/MorphiumDriverExceptionTest.java
+++ b/src/test/java/de/caluga/test/morphium/driver/MorphiumDriverExceptionTest.java
@@ -1,0 +1,176 @@
+package de.caluga.test.morphium.driver;
+
+import de.caluga.morphium.driver.FunctionNotSupportedException;
+import de.caluga.morphium.driver.MorphiumDriverException;
+import de.caluga.morphium.driver.MorphiumDriverNetworkException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests verifying that {@link MorphiumDriverException} is an unchecked
+ * ({@code RuntimeException}) and that the exception hierarchy behaves correctly.
+ * <p>
+ * Rationale: MorphiumDriverException was changed from {@code extends Exception}
+ * to {@code extends RuntimeException} so that callers of Morphium's persistence
+ * API can catch database errors directly without the pervasive
+ * {@code catch (MorphiumDriverException e) { throw new RuntimeException(e); }}
+ * wrapping pattern. This aligns with the MongoDB Java driver convention
+ * ({@code MongoException extends RuntimeException}) and modern Java persistence
+ * frameworks (JPA, jOOQ, Spring Data).
+ */
+@Tag("inmemory")
+class MorphiumDriverExceptionTest {
+
+    // ------------------------------------------------------------------ //
+    //  1. Type hierarchy assertions
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void morphiumDriverException_isRuntimeException() {
+        var ex = new MorphiumDriverException("test error");
+        assertInstanceOf(RuntimeException.class, ex,
+            "MorphiumDriverException must extend RuntimeException");
+    }
+
+    @Test
+    void morphiumDriverNetworkException_isRuntimeException() {
+        var ex = new MorphiumDriverNetworkException("network error");
+        assertInstanceOf(RuntimeException.class, ex,
+            "MorphiumDriverNetworkException must extend RuntimeException");
+        assertInstanceOf(MorphiumDriverException.class, ex,
+            "MorphiumDriverNetworkException must extend MorphiumDriverException");
+    }
+
+    @Test
+    void functionNotSupportedException_isRuntimeException() {
+        var ex = new FunctionNotSupportedException("not supported");
+        assertInstanceOf(RuntimeException.class, ex,
+            "FunctionNotSupportedException must extend RuntimeException");
+        assertInstanceOf(MorphiumDriverException.class, ex,
+            "FunctionNotSupportedException must extend MorphiumDriverException");
+    }
+
+    @Test
+    void morphiumDriverException_isNotCheckedException() {
+        // Exception (checked) is a supertype of RuntimeException, so this
+        // verifies the hierarchy is NOT checked.
+        var ex = new MorphiumDriverException("test");
+        // If MorphiumDriverException were checked (extends Exception but not
+        // RuntimeException), this next assertion would still pass because
+        // RuntimeException extends Exception. So we check the class hierarchy
+        // explicitly.
+        assertTrue(RuntimeException.class.isAssignableFrom(MorphiumDriverException.class),
+            "MorphiumDriverException.class must be assignable to RuntimeException.class");
+    }
+
+    // ------------------------------------------------------------------ //
+    //  2. Constructor / metadata preservation
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void messageOnly_constructor() {
+        var ex = new MorphiumDriverException("something broke");
+        assertEquals("something broke", ex.getMessage());
+        assertNull(ex.getCause());
+    }
+
+    @Test
+    void messageAndCause_constructor() {
+        var cause = new IllegalStateException("root cause");
+        var ex = new MorphiumDriverException("wrapper", cause);
+        assertEquals("wrapper", ex.getMessage());
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void fullContext_constructor() {
+        var cause = new RuntimeException("io error");
+        var query = Map.<String, Object>of("_id", "abc");
+        var ex = new MorphiumDriverException("failed", cause, "myCollection", "myDb", query);
+
+        assertEquals("failed", ex.getMessage());
+        assertSame(cause, ex.getCause());
+        assertEquals("myCollection", ex.getCollection());
+        assertEquals("myDb", ex.getDb());
+        assertEquals(query, ex.getQuery());
+    }
+
+    @Test
+    void mongoCodeAndReason_preserved() {
+        var ex = new MorphiumDriverException("dup key");
+        ex.setMongoCode(11000);
+        ex.setMongoReason("E11000 duplicate key error");
+
+        assertEquals(11000, ex.getMongoCode());
+        assertEquals("E11000 duplicate key error", ex.getMongoReason());
+    }
+
+    // ------------------------------------------------------------------ //
+    //  3. Catch behaviour — the key use-case
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void canBeCaughtAsMorphiumDriverException() {
+        assertThrows(MorphiumDriverException.class, () -> {
+            throw new MorphiumDriverException("db error");
+        });
+    }
+
+    @Test
+    void canBeCaughtAsRuntimeException() {
+        // This is the critical test: callers that catch RuntimeException
+        // will now also catch MorphiumDriverException.
+        assertThrows(RuntimeException.class, () -> {
+            throw new MorphiumDriverException("db error");
+        });
+    }
+
+    @Test
+    void networkException_caughtByDriverExceptionCatch() {
+        // Subclass should be caught by parent catch clause
+        assertThrows(MorphiumDriverException.class, () -> {
+            throw new MorphiumDriverNetworkException("timeout");
+        });
+    }
+
+    @Test
+    void propagatesThroughMethodWithoutThrowsDeclaration() {
+        // Before the change, this pattern required a try-catch-wrap.
+        // Now MorphiumDriverException propagates naturally through methods
+        // that don't declare "throws MorphiumDriverException".
+        assertThrows(MorphiumDriverException.class, () -> {
+            methodWithoutThrowsClause();
+        });
+    }
+
+    @Test
+    void noDoubleWrapping_whenRethrown() {
+        // Verify that catching and rethrowing does NOT create nested
+        // RuntimeException(MorphiumDriverException) — the original exception
+        // type is preserved.
+        try {
+            throw new MorphiumDriverException("original");
+        } catch (MorphiumDriverException e) {
+            // Simply rethrow — no wrapping needed anymore
+            var rethrown = assertThrows(MorphiumDriverException.class, () -> { throw e; });
+            assertEquals("original", rethrown.getMessage());
+            assertNull(rethrown.getCause(), "No unnecessary cause wrapping");
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Helpers
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Simulates a method that does NOT declare {@code throws MorphiumDriverException}
+     * — which was the root cause of the pervasive wrapping pattern.
+     */
+    private void methodWithoutThrowsClause() {
+        throw new MorphiumDriverException("propagates without declaration");
+    }
+}


### PR DESCRIPTION
## Summary

This PR changes `MorphiumDriverException` from a **checked exception** (`extends Exception`) to an **unchecked exception** (`extends RuntimeException`), and removes 40+ redundant catch-and-wrap blocks that this change makes unnecessary.

## Motivation

### 1. Industry convention alignment

Every major Java database framework uses unchecked exceptions for database errors:

| Framework | Base Exception | Extends |
|-----------|----------------|---------|
| **MongoDB Java Driver** | `MongoException` | `RuntimeException` |
| **JPA / Hibernate** | `PersistenceException` | `RuntimeException` |
| **jOOQ** | `DataAccessException` | `RuntimeException` |
| **Spring Data** | `DataAccessException` | `RuntimeException` (`NestedRuntimeException`) |
| **Morphium (before)** | `MorphiumDriverException` | `Exception` |
| **Morphium (after)** | `MorphiumDriverException` | `RuntimeException` |

Database errors are typically not recoverable at the point of the API call. Forcing callers to catch-or-declare serves no purpose — it only creates boilerplate.

### 2. Elimination of pervasive catch-and-wrap boilerplate

The Morphium codebase contained **40+ instances** of this pattern:

```java
try {
    someCommand.execute(); // throws MorphiumDriverException (checked)
} catch (MorphiumDriverException e) {
    throw new RuntimeException(e); // forced wrapping
}
```

This pattern was **required** because:
- `Iterator.hasNext()` / `next()` cannot declare checked exceptions
- `MorphiumWriter` interface methods have no `throws` clause
- Lambda callbacks cannot propagate checked exceptions
- `Morphium.save()` / `delete()` don't declare `throws`

The wrapping had two negative effects:
1. **Loss of exception type**: Callers saw `RuntimeException` instead of `MorphiumDriverException`, making it impossible to catch database errors specifically
2. **Unnecessary stack noise**: Every wrapped exception added an extra frame with no diagnostic value

### 3. Better exception propagation for users

**Before**: Users could not catch database errors from high-level methods like `morphium.save()`:
```java
try {
    morphium.save(entity);
} catch (MorphiumDriverException e) {
    // COMPILE ERROR: "exception MorphiumDriverException is never thrown
    //                  in body of corresponding try statement"
    // The writer wraps it in RuntimeException before it reaches here
}
```

**After**: Direct, type-safe catch works:
```java
try {
    morphium.save(entity);
} catch (MorphiumDriverException e) {
    // Works! Exception propagates with its original type
    log.error("DB error: code={}, reason={}", e.getMongoCode(), e.getMongoReason());
}
```

## Changes

| Category | Files | Description |
|----------|-------|-------------|
| Core change | `MorphiumDriverException.java` | `extends Exception` → `extends RuntimeException` |
| Cleanup | 13 source files | Removed 40+ redundant `catch-wrap-rethrow` blocks |
| Tests | `MorphiumDriverExceptionTest.java` | 13 new test cases (type hierarchy, constructors, catch semantics) |
| Test fix | `InMemUniqueIndexTest.java` | Fixed multi-catch subclass redundancy |

### Affected source files (cleanup)

- `Morphium.java` — 11 wrappings removed
- `Query.java` — 7 wrappings removed
- `MorphiumWriterImpl.java` — 6 wrappings removed
- `AggregatorImpl.java` — 5 wrappings removed
- `BufferedMorphiumWriterImpl.java` — 3 wrappings removed
- `SingleMongoConnectionCursor.java` — 3 wrappings removed
- `AggregationIterator.java` — 2 wrappings removed
- `InMemAggregator.java` — 2 wrappings removed
- `SingleMongoConnectDriver.java` — 2 wrappings removed
- `QueryIterator.java`, `PooledDriver.java`, `MorphiumBulkContext.java`, `ReadMongoCommand.java` — 1 each

## Backward Compatibility

| Aspect | Impact |
|--------|--------|
| **Existing catch blocks** | Still work — `RuntimeException` is a subtype of `Exception` |
| **Existing throws declarations** | Preserved as documentation; no longer compiler-enforced |
| **Subclasses** | `MorphiumDriverNetworkException` and `FunctionNotSupportedException` inherit the change |
| **Binary compatibility** | Existing compiled code catching `MorphiumDriverException` continues to work at runtime |

The only breaking scenario: code that **relied on the compiler** to enforce `catch-or-declare` for `MorphiumDriverException`. In practice, this is extremely rare because most callers already wrapped it in `RuntimeException` anyway.

## Test plan

- [x] All 13 new `MorphiumDriverExceptionTest` tests pass
- [x] `InMemUniqueIndexTest` compiles and passes (multi-catch fix)
- [x] Full `mvn clean compile` succeeds
- [x] InMemory test suite passes