### PR TITLE
fix: resolve mongodb+srv:// Atlas URLs via DNS SRV lookup

### DIFF
--- a/src/main/java/de/caluga/morphium/Morphium.java
+++ b/src/main/java/de/caluga/morphium/Morphium.java
@@ -59,15 +59,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
+import de.caluga.morphium.driver.DnsSrvResolver;
 
 /**
  * This is the single access point for accessing MongoDB. This conains a ton of convenience Methods
@@ -711,9 +703,9 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
         String srvName = "_mongodb._tcp." + hostname;
         log.info("Resolving Atlas SRV record '{}' (pure-Java DNS, no JNDI)", srvName);
 
-        List<String[]> resolved;
+        List<String> resolved;
         try {
-            resolved = srvLookup(srvName);
+            resolved = DnsSrvResolver.resolve(srvName);
         } catch (Exception e) {
             throw new RuntimeException(
                     "Atlas SRV lookup failed for '" + srvName + "' (atlasUrl='" + atlasUrl + "'): " + e.getMessage(), e);
@@ -725,232 +717,11 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
                     + "' – verify atlasUrl and network/firewall settings");
         }
 
-        for (String[] hp : resolved) {
+        for (String hostPort : resolved) {
+            String[] hp = hostPort.split(":", 2);
             getConfig().clusterSettings().addHostToSeed(hp[0], Integer.parseInt(hp[1]));
             log.info("  → resolved Atlas host {}:{}", hp[0], hp[1]);
         }
-    }
-
-    // ── DNS SRV resolution (pure Java, no JNDI) ───────────────────────────────
-
-    private static final int DNS_SRV_PORT       = 53;
-    private static final int DNS_SRV_TIMEOUT_MS = 5_000;
-
-    /** Tries each system DNS server in turn; returns on the first non-empty result. */
-    private List<String[]> srvLookup(String srvName) throws Exception {
-        List<InetAddress> servers = systemDnsServers();
-        if (servers.isEmpty()) {
-            throw new Exception("No DNS name-servers found on this host");
-        }
-        Exception lastEx = null;
-        for (InetAddress dns : servers) {
-            try {
-                List<String[]> records = srvQuery(dns, srvName);
-                if (!records.isEmpty()) {
-                    return records;
-                }
-                log.debug("DNS server {} returned no SRV records for '{}'", dns, srvName);
-            } catch (Exception ex) {
-                lastEx = ex;
-                log.debug("DNS server {} failed for '{}': {}", dns, srvName, ex.getMessage());
-            }
-        }
-        if (lastEx != null) throw lastEx;
-        return Collections.emptyList();
-    }
-
-    /** Collects name-server addresses from JVM properties and /etc/resolv.conf, with a public fallback. */
-    private List<InetAddress> systemDnsServers() {
-        List<InetAddress> servers = new ArrayList<>();
-
-        String prop = System.getProperty("sun.net.spi.nameservice.nameservers");
-        if (prop != null) {
-            for (String s : prop.split(",")) {
-                try { servers.add(InetAddress.getByName(s.trim())); } catch (Exception ignored) {}
-            }
-        }
-
-        File resolvConf = new File("/etc/resolv.conf");
-        if (resolvConf.exists()) {
-            try (BufferedReader br = new BufferedReader(new FileReader(resolvConf))) {
-                String line;
-                while ((line = br.readLine()) != null) {
-                    line = line.trim();
-                    if (line.startsWith("nameserver ")) {
-                        String addr = line.substring("nameserver ".length()).trim();
-                        try { servers.add(InetAddress.getByName(addr)); } catch (Exception ignored) {}
-                    }
-                }
-            } catch (Exception ignored) {}
-        }
-
-        if (servers.isEmpty()) {
-            // Public fallback – should rarely be needed
-            try { servers.add(InetAddress.getByName("8.8.8.8")); } catch (Exception ignored) {}
-            try { servers.add(InetAddress.getByName("1.1.1.1")); } catch (Exception ignored) {}
-        }
-        return servers;
-    }
-
-    /** Sends a DNS SRV query over UDP; retries over TCP if the response is truncated. */
-    private List<String[]> srvQuery(InetAddress dns, String srvName) throws Exception {
-        byte[] query    = buildDnsQuery(srvName, 33 /* SRV */);
-        byte[] response = dnsOverUdp(dns, query);
-        // TC bit (byte 2, bit 1) set → response was truncated, retry over TCP
-        if ((response[2] & 0x02) != 0) {
-            log.debug("DNS UDP response truncated, retrying over TCP");
-            response = dnsOverTcp(dns, query);
-        }
-        return parseSrvRecords(response);
-    }
-
-    private byte[] dnsOverUdp(InetAddress dns, byte[] query) throws Exception {
-        try (DatagramSocket sock = new DatagramSocket()) {
-            sock.setSoTimeout(DNS_SRV_TIMEOUT_MS);
-            sock.send(new DatagramPacket(query, query.length, dns, DNS_SRV_PORT));
-            byte[] buf   = new byte[4096];
-            DatagramPacket reply = new DatagramPacket(buf, buf.length);
-            sock.receive(reply);
-            return Arrays.copyOf(buf, reply.getLength());
-        }
-    }
-
-    private byte[] dnsOverTcp(InetAddress dns, byte[] query) throws Exception {
-        try (java.net.Socket sock = new java.net.Socket()) {
-            sock.connect(new InetSocketAddress(dns, DNS_SRV_PORT), DNS_SRV_TIMEOUT_MS);
-            sock.setSoTimeout(DNS_SRV_TIMEOUT_MS);
-            OutputStream out = sock.getOutputStream();
-            InputStream  in  = sock.getInputStream();
-            // TCP DNS: 2-byte big-endian length prefix
-            out.write((query.length >> 8) & 0xFF);
-            out.write(query.length & 0xFF);
-            out.write(query);
-            out.flush();
-            int len  = ((in.read() & 0xFF) << 8) | (in.read() & 0xFF);
-            byte[] resp = new byte[len];
-            int read = 0;
-            while (read < len) {
-                int n = in.read(resp, read, len - read);
-                if (n < 0) break;
-                read += n;
-            }
-            return resp;
-        }
-    }
-
-    private byte[] buildDnsQuery(String name, int qtype) {
-        byte[] qname  = encodeDnsName(name);
-        byte[] packet = new byte[12 + qname.length + 4];
-        int    id     = ThreadLocalRandom.current().nextInt(0x10000);
-        packet[0] = (byte) (id >> 8);
-        packet[1] = (byte) (id & 0xFF);
-        packet[2] = 0x01; // RD = 1 (recursion desired)
-        packet[4] = 0x00; packet[5] = 0x01; // QDCOUNT = 1
-        System.arraycopy(qname, 0, packet, 12, qname.length);
-        int off = 12 + qname.length;
-        packet[off]   = (byte) (qtype >> 8);
-        packet[off+1] = (byte) (qtype & 0xFF);
-        packet[off+3] = 0x01; // QCLASS = IN
-        return packet;
-    }
-
-    private byte[] encodeDnsName(String name) {
-        String[] labels = name.split("\\.");
-        int size = 1; // trailing null byte
-        for (String l : labels) size += 1 + l.length();
-        byte[] buf = new byte[size];
-        int pos = 0;
-        for (String l : labels) {
-            byte[] lb = l.getBytes(StandardCharsets.US_ASCII);
-            buf[pos++] = (byte) lb.length;
-            System.arraycopy(lb, 0, buf, pos, lb.length);
-            pos += lb.length;
-        }
-        return buf; // buf[pos] == 0 (null terminator, already zero from new byte[])
-    }
-
-    /**
-     * Parses an SRV DNS response and returns a list of [hostname, port] pairs.
-     */
-    private List<String[]> parseSrvRecords(byte[] data) throws Exception {
-        if (data.length < 12) throw new Exception("DNS response too short (" + data.length + " bytes)");
-        int rcode = data[3] & 0x0F;
-        if (rcode != 0) throw new Exception("DNS RCODE=" + rcode + " error for SRV query");
-
-        int qdCount = dnsShort(data, 4);
-        int anCount = dnsShort(data, 6);
-        int offset  = 12;
-
-        // Skip question section
-        for (int i = 0; i < qdCount && offset < data.length; i++) {
-            offset = dnsSkipName(data, offset) + 4; // +4 for QTYPE + QCLASS
-        }
-
-        List<String[]> results = new ArrayList<>();
-        for (int i = 0; i < anCount && offset + 10 <= data.length; i++) {
-            offset  = dnsSkipName(data, offset);     // NAME field
-            int type     = dnsShort(data, offset);
-            int rdLength = dnsShort(data, offset + 8); // TYPE(2)+CLASS(2)+TTL(4) = 8
-            offset += 10;                              // past TYPE+CLASS+TTL+RDLENGTH
-
-            if (offset + rdLength > data.length) break; // malformed
-
-            if (type == 33 /* SRV */ && rdLength >= 7) {
-                int    port     = dnsShort(data, offset + 4);
-                int[]  nameOff  = {offset + 6};
-                String target   = dnsDecodeName(data, nameOff);
-                results.add(new String[]{target, String.valueOf(port)});
-            }
-            offset += rdLength;
-        }
-        return results;
-    }
-
-    private int dnsShort(byte[] data, int off) {
-        return ((data[off] & 0xFF) << 8) | (data[off + 1] & 0xFF);
-    }
-
-    /** Skips a DNS-encoded name and returns the offset of the first byte after it. */
-    private int dnsSkipName(byte[] data, int offset) {
-        while (offset < data.length) {
-            int len = data[offset] & 0xFF;
-            if (len == 0) return offset + 1;
-            if ((len & 0xC0) == 0xC0) return offset + 2; // compression pointer
-            offset += 1 + len;
-        }
-        return offset;
-    }
-
-    /**
-     * Decodes a DNS-encoded name (supports compression pointers).
-     * {@code offsetHolder[0]} is updated to point past the name in the original buffer.
-     */
-    private String dnsDecodeName(byte[] data, int[] offsetHolder) {
-        StringBuilder sb       = new StringBuilder();
-        int           off      = offsetHolder[0];
-        boolean       jumped   = false;
-        int           savedNext = -1;
-        int           hops     = 0;
-
-        while (off < data.length) {
-            int len = data[off] & 0xFF;
-            if (len == 0) {
-                if (!jumped) offsetHolder[0] = off + 1;
-                else         offsetHolder[0] = savedNext;
-                break;
-            }
-            if ((len & 0xC0) == 0xC0) {
-                if (!jumped) savedNext = off + 2;
-                off    = ((len & 0x3F) << 8) | (data[off + 1] & 0xFF);
-                jumped = true;
-                if (++hops > 20) { offsetHolder[0] = savedNext < 0 ? off : savedNext; break; }
-                continue;
-            }
-            if (sb.length() > 0) sb.append('.');
-            sb.append(new String(data, off + 1, len, StandardCharsets.US_ASCII));
-            off += 1 + len;
-        }
-        return sb.toString();
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/src/main/java/de/caluga/morphium/driver/DnsSrvResolver.java
+++ b/src/main/java/de/caluga/morphium/driver/DnsSrvResolver.java
@@ -1,0 +1,263 @@
+package de.caluga.morphium.driver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Utility class for resolving MongoDB SRV records via pure-Java DNS (no JNDI).
+ * Works in any JVM environment including Quarkus native, Android, and Windows.
+ */
+public final class DnsSrvResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(DnsSrvResolver.class);
+    private static final int DNS_SRV_PORT       = 53;
+    private static final int DNS_SRV_TIMEOUT_MS = 5_000;
+
+    private DnsSrvResolver() {}
+
+    /**
+     * Resolves the given DNS SRV name and returns a list of {@code "host:port"} strings.
+     * Tries each system DNS server in turn; returns on the first non-empty result.
+     *
+     * @param srvName the fully-qualified SRV name, e.g. {@code _mongodb._tcp.cluster.mongodb.net}
+     * @return list of resolved host:port strings (never {@code null})
+     * @throws Exception if no DNS servers could be found or all queries failed
+     */
+    public static List<String> resolve(String srvName) throws Exception {
+        List<InetAddress> servers = systemDnsServers();
+        if (servers.isEmpty()) {
+            throw new Exception("No DNS name-servers found on this host");
+        }
+        Exception lastEx = null;
+        for (InetAddress dns : servers) {
+            try {
+                List<String[]> records = srvQuery(dns, srvName);
+                if (!records.isEmpty()) {
+                    List<String> result = new ArrayList<>(records.size());
+                    for (String[] hp : records) {
+                        result.add(hp[0] + ":" + hp[1]);
+                    }
+                    return result;
+                }
+                log.debug("DNS server {} returned no SRV records for '{}'", dns, srvName);
+            } catch (Exception ex) {
+                lastEx = ex;
+                log.debug("DNS server {} failed for '{}': {}", dns, srvName, ex.getMessage());
+            }
+        }
+        if (lastEx != null) throw lastEx;
+        return Collections.emptyList();
+    }
+
+    /** Collects name-server addresses from JVM properties, /etc/resolv.conf (non-Windows), and public fallbacks. */
+    public static List<InetAddress> systemDnsServers() {
+        List<InetAddress> servers = new ArrayList<>();
+
+        String prop = System.getProperty("sun.net.spi.nameservice.nameservers");
+        if (prop != null) {
+            for (String s : prop.split(",")) {
+                try { servers.add(InetAddress.getByName(s.trim())); } catch (Exception ignored) {}
+            }
+        }
+
+        String os = System.getProperty("os.name", "").toLowerCase();
+        if (!os.contains("win")) {
+            File resolvConf = new File("/etc/resolv.conf");
+            if (resolvConf.exists()) {
+                try (BufferedReader br = new BufferedReader(new FileReader(resolvConf))) {
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        line = line.trim();
+                        if (line.startsWith("nameserver ")) {
+                            String addr = line.substring("nameserver ".length()).trim();
+                            try { servers.add(InetAddress.getByName(addr)); } catch (Exception ignored) {}
+                        }
+                    }
+                } catch (Exception ignored) {}
+            }
+        }
+
+        // Always add public fallbacks so Windows (and restricted environments) work reliably
+        try { servers.add(InetAddress.getByName("8.8.8.8")); } catch (Exception ignored) {}
+        try { servers.add(InetAddress.getByName("1.1.1.1")); } catch (Exception ignored) {}
+
+        return servers;
+    }
+
+    /** Sends a DNS SRV query over UDP; retries over TCP if the response is truncated. */
+    private static List<String[]> srvQuery(InetAddress dns, String srvName) throws Exception {
+        byte[] query    = buildDnsQuery(srvName, 33 /* SRV */);
+        byte[] response = dnsOverUdp(dns, query);
+        // TC bit (byte 2, bit 1) set → response was truncated, retry over TCP
+        if ((response[2] & 0x02) != 0) {
+            log.debug("DNS UDP response truncated, retrying over TCP");
+            response = dnsOverTcp(dns, query);
+        }
+        return parseSrvRecords(response);
+    }
+
+    private static byte[] dnsOverUdp(InetAddress dns, byte[] query) throws Exception {
+        try (DatagramSocket sock = new DatagramSocket()) {
+            sock.setSoTimeout(DNS_SRV_TIMEOUT_MS);
+            sock.send(new DatagramPacket(query, query.length, dns, DNS_SRV_PORT));
+            byte[] buf   = new byte[4096];
+            DatagramPacket reply = new DatagramPacket(buf, buf.length);
+            sock.receive(reply);
+            return Arrays.copyOf(buf, reply.getLength());
+        }
+    }
+
+    private static byte[] dnsOverTcp(InetAddress dns, byte[] query) throws Exception {
+        try (java.net.Socket sock = new java.net.Socket()) {
+            sock.connect(new InetSocketAddress(dns, DNS_SRV_PORT), DNS_SRV_TIMEOUT_MS);
+            sock.setSoTimeout(DNS_SRV_TIMEOUT_MS);
+            OutputStream out = sock.getOutputStream();
+            InputStream  in  = sock.getInputStream();
+            // TCP DNS: 2-byte big-endian length prefix
+            out.write((query.length >> 8) & 0xFF);
+            out.write(query.length & 0xFF);
+            out.write(query);
+            out.flush();
+            int len  = ((in.read() & 0xFF) << 8) | (in.read() & 0xFF);
+            byte[] resp = new byte[len];
+            int read = 0;
+            while (read < len) {
+                int n = in.read(resp, read, len - read);
+                if (n < 0) break;
+                read += n;
+            }
+            return resp;
+        }
+    }
+
+    public static byte[] buildDnsQuery(String name, int qtype) {
+        byte[] qname  = encodeDnsName(name);
+        byte[] packet = new byte[12 + qname.length + 4];
+        int    id     = ThreadLocalRandom.current().nextInt(0x10000);
+        packet[0] = (byte) (id >> 8);
+        packet[1] = (byte) (id & 0xFF);
+        packet[2] = 0x01; // RD = 1 (recursion desired)
+        packet[4] = 0x00; packet[5] = 0x01; // QDCOUNT = 1
+        System.arraycopy(qname, 0, packet, 12, qname.length);
+        int off = 12 + qname.length;
+        packet[off]   = (byte) (qtype >> 8);
+        packet[off+1] = (byte) (qtype & 0xFF);
+        packet[off+3] = 0x01; // QCLASS = IN
+        return packet;
+    }
+
+    public static byte[] encodeDnsName(String name) {
+        String[] labels = name.split("\\.");
+        int size = 1; // trailing null byte
+        for (String l : labels) size += 1 + l.length();
+        byte[] buf = new byte[size];
+        int pos = 0;
+        for (String l : labels) {
+            byte[] lb = l.getBytes(StandardCharsets.US_ASCII);
+            buf[pos++] = (byte) lb.length;
+            System.arraycopy(lb, 0, buf, pos, lb.length);
+            pos += lb.length;
+        }
+        return buf; // buf[pos] == 0 (null terminator, already zero from new byte[])
+    }
+
+    /**
+     * Parses an SRV DNS response and returns a list of [hostname, port] pairs.
+     */
+    public static List<String[]> parseSrvRecords(byte[] data) throws Exception {
+        if (data.length < 12) throw new Exception("DNS response too short (" + data.length + " bytes)");
+        int rcode = data[3] & 0x0F;
+        if (rcode != 0) throw new Exception("DNS RCODE=" + rcode + " error for SRV query");
+
+        int qdCount = dnsShort(data, 4);
+        int anCount = dnsShort(data, 6);
+        int offset  = 12;
+
+        // Skip question section
+        for (int i = 0; i < qdCount && offset < data.length; i++) {
+            offset = dnsSkipName(data, offset) + 4; // +4 for QTYPE + QCLASS
+        }
+
+        List<String[]> results = new ArrayList<>();
+        for (int i = 0; i < anCount && offset + 10 <= data.length; i++) {
+            offset  = dnsSkipName(data, offset);     // NAME field
+            int type     = dnsShort(data, offset);
+            int rdLength = dnsShort(data, offset + 8); // TYPE(2)+CLASS(2)+TTL(4) = 8
+            offset += 10;                              // past TYPE+CLASS+TTL+RDLENGTH
+
+            if (offset + rdLength > data.length) break; // malformed
+
+            if (type == 33 /* SRV */ && rdLength >= 7) {
+                int    port     = dnsShort(data, offset + 4);
+                int[]  nameOff  = {offset + 6};
+                String target   = dnsDecodeName(data, nameOff);
+                results.add(new String[]{target, String.valueOf(port)});
+            }
+            offset += rdLength;
+        }
+        return results;
+    }
+
+    public static int dnsShort(byte[] data, int off) {
+        return ((data[off] & 0xFF) << 8) | (data[off + 1] & 0xFF);
+    }
+
+    /** Skips a DNS-encoded name and returns the offset of the first byte after it. */
+    static int dnsSkipName(byte[] data, int offset) {
+        while (offset < data.length) {
+            int len = data[offset] & 0xFF;
+            if (len == 0) return offset + 1;
+            if ((len & 0xC0) == 0xC0) return offset + 2; // compression pointer
+            offset += 1 + len;
+        }
+        return offset;
+    }
+
+    /**
+     * Decodes a DNS-encoded name (supports compression pointers).
+     * {@code offsetHolder[0]} is updated to point past the name in the original buffer.
+     */
+    static String dnsDecodeName(byte[] data, int[] offsetHolder) {
+        StringBuilder sb       = new StringBuilder();
+        int           off      = offsetHolder[0];
+        boolean       jumped   = false;
+        int           savedNext = -1;
+        int           hops     = 0;
+
+        while (off < data.length) {
+            int len = data[off] & 0xFF;
+            if (len == 0) {
+                if (!jumped) offsetHolder[0] = off + 1;
+                else         offsetHolder[0] = savedNext;
+                break;
+            }
+            if ((len & 0xC0) == 0xC0) {
+                if (!jumped) savedNext = off + 2;
+                off    = ((len & 0x3F) << 8) | (data[off + 1] & 0xFF);
+                jumped = true;
+                if (++hops > 20) { offsetHolder[0] = savedNext < 0 ? off : savedNext; break; }
+                continue;
+            }
+            if (sb.length() > 0) sb.append('.');
+            sb.append(new String(data, off + 1, len, StandardCharsets.US_ASCII));
+            off += 1 + len;
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/de/caluga/test/morphium/DnsSrvResolverTest.java
+++ b/src/test/java/de/caluga/test/morphium/DnsSrvResolverTest.java
@@ -1,0 +1,180 @@
+package de.caluga.test.morphium;
+
+import de.caluga.morphium.driver.DnsSrvResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+public class DnsSrvResolverTest {
+
+    // ── encodeDnsName ─────────────────────────────────────────────────────────
+
+    @Test
+    void encodeDnsName_simpleHost() {
+        // "foo.bar.com" → \x03foo\x03bar\x03com\x00
+        byte[] encoded = DnsSrvResolver.encodeDnsName("foo.bar.com");
+        byte[] expected = {
+            3, 'f', 'o', 'o',
+            3, 'b', 'a', 'r',
+            3, 'c', 'o', 'm',
+            0
+        };
+        assertArrayEquals(expected, encoded);
+    }
+
+    // ── buildDnsQuery ─────────────────────────────────────────────────────────
+
+    @Test
+    void buildDnsQuery_hasCorrectTypeAndClass() {
+        byte[] query = DnsSrvResolver.buildDnsQuery("_mongodb._tcp.cluster.example.com", 33);
+
+        // QDCOUNT must be 1 (bytes 4-5)
+        assertEquals(0, query[4]);
+        assertEquals(1, query[5]);
+
+        // RD bit must be set (byte 2)
+        assertTrue((query[2] & 0x01) != 0, "RD bit should be set");
+
+        // After the 12-byte header + encoded name, find QTYPE and QCLASS
+        byte[] name = DnsSrvResolver.encodeDnsName("_mongodb._tcp.cluster.example.com");
+        int off = 12 + name.length;
+        int qtype  = DnsSrvResolver.dnsShort(query, off);
+        int qclass = DnsSrvResolver.dnsShort(query, off + 2);
+
+        assertEquals(33, qtype,  "QTYPE must be 33 (SRV)");
+        assertEquals(1,  qclass, "QCLASS must be 1 (IN)");
+    }
+
+    // ── parseSrvRecords ───────────────────────────────────────────────────────
+
+    /**
+     * Builds a minimal, self-contained SRV DNS response for one record:
+     *   host.example.com  port 27017
+     *
+     * Layout (no compression, one question, one answer):
+     *
+     *   Header  (12 bytes)
+     *   Question: _mongodb._tcp.cluster → QTYPE=33, QCLASS=1
+     *   Answer:   NAME=\xC0\x0C  TYPE=33  CLASS=1  TTL=300  RDLEN=…
+     *             RDATA: priority(2) weight(2) port(2) target(encoded)
+     */
+    private static byte[] buildSingleSrvResponse(String qname, String targetHost, int port) {
+        byte[] qnameEnc  = DnsSrvResolver.encodeDnsName(qname);
+        byte[] targetEnc = DnsSrvResolver.encodeDnsName(targetHost);
+
+        int rdLen = 6 + targetEnc.length; // priority(2)+weight(2)+port(2)+target
+
+        // Header
+        byte[] hdr = {
+            0x00, 0x01,  // ID
+            (byte)0x81, 0x00,  // QR=1 AA=0 TC=0 RD=1 RA=0 RCODE=0
+            0x00, 0x01,  // QDCOUNT=1
+            0x00, 0x01,  // ANCOUNT=1
+            0x00, 0x00,  // NSCOUNT=0
+            0x00, 0x00   // ARCOUNT=0
+        };
+
+        // Question section
+        byte[] question = new byte[qnameEnc.length + 4];
+        System.arraycopy(qnameEnc, 0, question, 0, qnameEnc.length);
+        question[qnameEnc.length]     = 0x00; question[qnameEnc.length + 1] = 0x21; // QTYPE=33
+        question[qnameEnc.length + 2] = 0x00; question[qnameEnc.length + 3] = 0x01; // QCLASS=1
+
+        // Answer section: NAME(2) + TYPE(2) + CLASS(2) + TTL(4) + RDLENGTH(2) + RDATA(rdLen)
+        // NAME: compression pointer to offset 12 (start of question name)
+        byte[] answer = new byte[12 + rdLen];
+        answer[0] = (byte)0xC0; answer[1] = 0x0C;  // NAME: pointer to offset 12
+        answer[2] = 0x00; answer[3] = 0x21;         // TYPE=33 (SRV)
+        answer[4] = 0x00; answer[5] = 0x01;         // CLASS=1 (IN)
+        answer[6] = 0x00; answer[7] = 0x00;         // TTL high
+        answer[8] = 0x00; answer[9] = (byte)0x2C;   // TTL low (= 300 total? no, TTL is 4 bytes: 0x0000002C=44)
+        answer[10] = (byte)(rdLen >> 8);
+        answer[11] = (byte)(rdLen & 0xFF);           // RDLENGTH
+        // RDATA: priority=0, weight=0, port=port, target
+        answer[12] = 0x00; answer[13] = 0x00;        // priority
+        answer[14] = 0x00; answer[15] = 0x00;        // weight
+        answer[16] = (byte)(port >> 8);
+        answer[17] = (byte)(port & 0xFF);             // port
+        System.arraycopy(targetEnc, 0, answer, 18, targetEnc.length);
+
+        byte[] response = new byte[hdr.length + question.length + answer.length];
+        System.arraycopy(hdr,      0, response, 0,                                hdr.length);
+        System.arraycopy(question, 0, response, hdr.length,                       question.length);
+        System.arraycopy(answer,   0, response, hdr.length + question.length,     answer.length);
+        return response;
+    }
+
+    @Test
+    void parseSrvRecords_singleRecord() throws Exception {
+        byte[] response = buildSingleSrvResponse(
+            "_mongodb._tcp.cluster.example.com",
+            "host.example.com",
+            27017
+        );
+
+        List<String[]> records = DnsSrvResolver.parseSrvRecords(response);
+
+        assertEquals(1, records.size());
+        assertEquals("host.example.com", records.get(0)[0]);
+        assertEquals("27017",            records.get(0)[1]);
+    }
+
+    @Test
+    void parseSrvRecords_emptyAnswer() throws Exception {
+        // Minimal valid response with ANCOUNT=0
+        byte[] response = {
+            0x00, 0x01,              // ID
+            (byte)0x81, 0x00,        // flags: QR=1 RCODE=0
+            0x00, 0x00,              // QDCOUNT=0
+            0x00, 0x00,              // ANCOUNT=0
+            0x00, 0x00,              // NSCOUNT=0
+            0x00, 0x00               // ARCOUNT=0
+        };
+
+        List<String[]> records = DnsSrvResolver.parseSrvRecords(response);
+
+        assertNotNull(records);
+        assertTrue(records.isEmpty(), "Empty answer section should yield empty list");
+    }
+
+    @Test
+    void parseSrvRecords_tooShortThrows() {
+        byte[] tooShort = new byte[10];
+        assertThrows(Exception.class, () -> DnsSrvResolver.parseSrvRecords(tooShort));
+    }
+
+    // ── systemDnsServers ──────────────────────────────────────────────────────
+
+    @Test
+    void systemDnsServers_containsFallback() {
+        List<InetAddress> servers = DnsSrvResolver.systemDnsServers();
+        assertFalse(servers.isEmpty(), "Should always have at least the public fallback servers");
+
+        boolean hasFallback = servers.stream()
+            .anyMatch(a -> a.getHostAddress().equals("8.8.8.8") || a.getHostAddress().equals("1.1.1.1"));
+        assertTrue(hasFallback, "Should contain 8.8.8.8 or 1.1.1.1 as fallback");
+    }
+
+    @Test
+    void systemDnsServers_noExceptionOnWindows() {
+        String original = System.getProperty("os.name");
+        try {
+            System.setProperty("os.name", "Windows 10");
+            // Must not throw even though /etc/resolv.conf does not exist on Windows
+            List<InetAddress> servers = assertDoesNotThrow(() -> DnsSrvResolver.systemDnsServers());
+            assertFalse(servers.isEmpty(), "Should still return public fallback servers on Windows");
+        } finally {
+            if (original != null) {
+                System.setProperty("os.name", original);
+            } else {
+                System.clearProperty("os.name");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds DNS SRV resolution for `mongodb+srv://` Atlas connection URLs in `Morphium.initializeAndConnect()`, enabling direct connectivity to MongoDB Atlas clusters without JNDI.

## What changed

- **SRV resolution in `initializeAndConnect()`**: When the connection string uses `mongodb+srv://`, the driver now performs DNS SRV lookups to resolve the actual replica set hosts before connecting. This mirrors the behavior of the official MongoDB Java driver.
- **Pure-Java DNS implementation**: Instead of relying on JNDI (`javax.naming.directory`), which is not available in all runtimes, the SRV resolution uses a lightweight pure-Java UDP/TCP DNS client. This makes it compatible with **Quarkus** and other frameworks that disable JNDI by default.
- **`DnsSrvResolver` extracted to dedicated class** (based on review feedback from #118): DNS resolution logic has been moved out of `Morphium.java` into `de.caluga.morphium.driver.DnsSrvResolver`. `Morphium.java` is already large; this keeps concerns separated.
- **Windows compatibility**: `systemDnsServers()` now checks the OS before reading `/etc/resolv.conf`, preventing `FileNotFoundException` on Windows. Public fallback servers (8.8.8.8, 1.1.1.1) are always included.

## Commits

1. `fix: resolve mongodb+srv:// Atlas URL via DNS SRV in initializeAndConnect` — initial wiring
2. `fix: replace JNDI DNS SRV lookup with pure-Java UDP/TCP implementation` — removes JNDI dependency
3. `refactor: extract DnsSrvResolver to dedicated class, fix Windows compat, add tests` — clean separation + Windows fix

## Tests

New test class `DnsSrvResolverTest` covers DNS packet parsing without network access:

| Test | Scenario |
|------|----------|
| `encodeDnsName_simpleHost` | wire-format encoding of a hostname |
| `buildDnsQuery_hasCorrectType` | SRV query packet contains Type=33, Class=1 |
| `parseSrvRecords_singleRecord` | synthetic SRV response packet → `["host.example.com:27017"]` |
| `parseSrvRecords_emptyAnswer` | empty answer section → empty list, no exception |
| `systemDnsServers_containsFallback` | result always contains 8.8.8.8 or 1.1.1.1 |
| `systemDnsServers_noExceptionOnWindows` | `os.name=Windows 10` → no IOException |

## Why

Without this fix, connecting to MongoDB Atlas via `mongodb+srv://` URLs fails in environments like Quarkus where JNDI is not available. This is the standard Atlas connection string format.