### PR TITLE
fix: replace deprecated setDriverName/setRetriesOnNetworkError in test files

### DIFF
--- a/src/test/java/de/caluga/test/morphium/JavaTimeEntityIntegrationTest.java
+++ b/src/test/java/de/caluga/test/morphium/JavaTimeEntityIntegrationTest.java
@@ -59,7 +59,7 @@ public class JavaTimeEntityIntegrationTest {
     @BeforeEach
     public void setup() {
         MorphiumConfig cfg = new MorphiumConfig("java_time_test_db", 10, 10_000, 1_000);
-        cfg.setDriverName(InMemoryDriver.driverName);
+        cfg.driverSettings().setDriverName(InMemoryDriver.driverName);
         morphium = new Morphium(cfg);
     }
 

--- a/src/test/java/de/caluga/test/morphium/MorphiumDriverExceptionPropagationTest.java
+++ b/src/test/java/de/caluga/test/morphium/MorphiumDriverExceptionPropagationTest.java
@@ -49,9 +49,9 @@ public class MorphiumDriverExceptionPropagationTest {
     @BeforeEach
     public void setup() {
         MorphiumConfig cfg = new MorphiumConfig("driver_exception_test_db", 10, 10_000, 1_000);
-        cfg.setDriverName(InMemoryDriver.driverName);
+        cfg.driverSettings().setDriverName(InMemoryDriver.driverName);
         // Configure retries > 0 so we can verify the exception is NOT retried
-        cfg.setRetriesOnNetworkError(3);
+        cfg.connectionSettings().setRetriesOnNetworkError(3);
         morphium = new Morphium(cfg);
         morphium.ensureIndicesFor(UniqueEntity.class);
     }

--- a/src/test/java/de/caluga/test/morphium/ObjectMapperClassLoaderTest.java
+++ b/src/test/java/de/caluga/test/morphium/ObjectMapperClassLoaderTest.java
@@ -60,7 +60,7 @@ public class ObjectMapperClassLoaderTest {
     public void clearEntityCache_allowsFreshScan() {
         // First Morphium instance populates the static entity cache
         MorphiumConfig cfg1 = new MorphiumConfig("classloader_test_db_1", 10, 10_000, 1_000);
-        cfg1.setDriverName(InMemoryDriver.driverName);
+        cfg1.driverSettings().setDriverName(InMemoryDriver.driverName);
         Morphium m1 = new Morphium(cfg1);
 
         ClassLoaderTestEntity e1 = new ClassLoaderTestEntity("from-first-instance");
@@ -74,7 +74,7 @@ public class ObjectMapperClassLoaderTest {
 
         // Second Morphium instance should perform a fresh scan
         MorphiumConfig cfg2 = new MorphiumConfig("classloader_test_db_2", 10, 10_000, 1_000);
-        cfg2.setDriverName(InMemoryDriver.driverName);
+        cfg2.driverSettings().setDriverName(InMemoryDriver.driverName);
         morphium = new Morphium(cfg2);
 
         // Verify the entity type is still recognized after cache clear + fresh scan
@@ -97,7 +97,7 @@ public class ObjectMapperClassLoaderTest {
 
         // Create Morphium — this triggers entity scanning using the context ClassLoader
         MorphiumConfig cfg = new MorphiumConfig("classloader_ctx_test_db", 10, 10_000, 1_000);
-        cfg.setDriverName(InMemoryDriver.driverName);
+        cfg.driverSettings().setDriverName(InMemoryDriver.driverName);
         morphium = new Morphium(cfg);
 
         // If context ClassLoader is not used, this entity from the test ClassLoader


### PR DESCRIPTION
## Summary

- Replace deprecated `cfg.setDriverName(String)` with `cfg.driverSettings().setDriverName(String)` in 3 test files
- Replace deprecated `cfg.setRetriesOnNetworkError(int)` with `cfg.connectionSettings().setRetriesOnNetworkError(int)` in `MorphiumDriverExceptionPropagationTest`

## Affected files

- `ObjectMapperClassLoaderTest.java` — 3 occurrences
- `MorphiumDriverExceptionPropagationTest.java` — 2 occurrences (setDriverName + setRetriesOnNetworkError)
- `JavaTimeEntityIntegrationTest.java` — 1 occurrence

## Test plan

- [ ] `mvn clean install` — all existing tests pass, no deprecation warnings for these files