### PR TITLE
feat: add resetThreadLocalOverrides() for per-thread state cleanup

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -95,6 +95,39 @@ public boolean isTransactionInProgress()
 public MorphiumTransactionContext getTransactionContext()
 ```
 
+#### Per-Thread Behavior Overrides
+
+Morphium allows overriding certain global settings on a per-thread basis. This is useful for temporarily disabling caching or auto-values within a specific request or task.
+
+```java
+// Disable/enable auto-values for the current thread
+public void disableAutoValuesForThread()
+public void enableAutoValuesForThread()
+public boolean isAutoValuesEnabledForThread()
+
+// Disable/enable read cache for the current thread
+public void disableReadCacheForThread()
+public void enableReadCacheForThread()
+public boolean isReadCacheEnabledForThread()
+
+// Disable/enable write buffer for the current thread
+public void disableWriteBufferForThread()
+public void enableWriteBufferForThread()
+public boolean isWriteBufferEnabledForThread()
+
+// Disable/enable async writes for the current thread
+public void disableAsyncWritesForThread()
+public void enableAsyncWritesForThread()
+public boolean isAsyncWritesEnabledForThread()
+
+// Reset ALL per-thread overrides back to defaults (= follow global config)
+public void resetThreadLocalOverrides()
+```
+
+**Important:** These overrides are backed by `ThreadLocal` and are **not** automatically cleaned up. In thread-pool or virtual-thread environments, always call `resetThreadLocalOverrides()` at the end of a request or task to prevent state from leaking between threads.
+
+> **Future improvement:** Once `java.lang.ScopedValue` ([JEP 487](https://openjdk.org/jeps/487)) is finalized (currently in preview as of JDK 24), these thread-local overrides should be replaced with scoped values. Scoped values provide automatic cleanup at scope exit and are inherently safe with virtual threads — eliminating the need for manual `resetThreadLocalOverrides()` calls.
+
 ## Query API
 
 ### Query Interface

--- a/src/main/java/de/caluga/morphium/Morphium.java
+++ b/src/main/java/de/caluga/morphium/Morphium.java
@@ -2973,6 +2973,26 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
         return (disableAsyncWrites.get() == null || disableAsyncWrites.get()) && getConfig().cacheSettings().isAsyncWritesEnabled();
     }
 
+    /**
+     * Resets all per-thread overrides (autoValues, readCache, writeBuffer, asyncWrites)
+     * back to their defaults (= follow global config).
+     * <p>
+     * Call this at the end of a request or task to prevent state leaking between
+     * threads in a thread pool. This is especially important with virtual threads
+     * where thread-local state is not automatically cleaned up.
+     * <p>
+     * <b>Future:</b> Once {@code java.lang.ScopedValue} (JEP 487) is finalized,
+     * these thread-local overrides should be replaced with scoped values, which
+     * provide automatic cleanup at scope exit and are inherently safe with
+     * virtual threads.
+     */
+    public void resetThreadLocalOverrides() {
+        enableAutoValues.remove();
+        enableReadCache.remove();
+        disableWriteBuffer.remove();
+        disableAsyncWrites.remove();
+    }
+
     public void queueTask(Runnable runnable) {
         boolean queued = false;
 


### PR DESCRIPTION
## Summary

The four per-thread Boolean overrides (`disableAutoValuesForThread()`, `disableReadCacheForThread()`, etc.) are backed by `ThreadLocal` but never cleaned up after use. In thread-pool and virtual-thread environments, this causes state to leak between requests — a thread that called `disableAutoValuesForThread()` in one request will still have auto-values disabled in the next request handled by that same thread.

This adds `resetThreadLocalOverrides()` which removes all four `ThreadLocal` values at once, restoring default behavior (= follow global config). Callers should invoke this at the end of a request or task.

```java
try {
    morphium.disableReadCacheForThread();
    // ... work ...
} finally {
    morphium.resetThreadLocalOverrides();
}
```

**Future:** Once `ScopedValue` (JEP 487, currently in preview) is finalized, these thread-local overrides should be replaced with scoped values — providing automatic cleanup at scope exit without manual `reset` calls.

## Changes

- **Morphium.java**: New `resetThreadLocalOverrides()` method
- **docs/api-reference.md**: Document all per-thread override APIs and the new reset method

## Tests

Compilation verified, no behavioral change to existing code — purely additive API.