### PR TITLE
fix: replace ReflectionFactory with Unsafe.allocateInstance() for entity instantiation

### DIFF
--- a/src/main/java/de/caluga/morphium/ObjectMapperImpl.java
+++ b/src/main/java/de/caluga/morphium/ObjectMapperImpl.java
@@ -40,6 +40,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import sun.misc.Unsafe;
+
 /**
  * User: Stpehan Bösebeck
  * Date: 26.03.12
@@ -49,6 +51,40 @@ import java.util.stream.Collectors;
 @SuppressWarnings({"ConstantConditions", "MismatchedQueryAndUpdateOfCollection", "unchecked", "RedundantCast"})
 public class ObjectMapperImpl implements MorphiumObjectMapper {
     private final Logger log = LoggerFactory.getLogger(ObjectMapperImpl.class);
+
+    /**
+     * {@code Unsafe} is used solely for {@link Unsafe#allocateInstance(Class)} — creating entity
+     * instances without calling a constructor. This is the fallback when an entity class has no
+     * accessible no-arg constructor (e.g. only {@code @AllArgsConstructor} from Lombok).
+     *
+     * <p><b>Why not a public API?</b> Java does not provide a public API for constructor-free
+     * instantiation. The previously used {@code sun.reflect.ReflectionFactory} was removed from
+     * the internal API surface. {@code Unsafe.allocateInstance()} is the de facto standard,
+     * used by Spring, Jackson, Gson, Kryo, Hibernate/Objenesis, and Netty.</p>
+     *
+     * <p><b>JEP 471</b> (JDK 23) deprecates Unsafe's memory-access methods but does
+     * <b>not</b> cover {@code allocateInstance()} — no replacement exists yet.</p>
+     *
+     * <p>To avoid this code path entirely, add a no-arg constructor (can be {@code private})
+     * to all {@code @Entity} and {@code @Embedded} classes.</p>
+     *
+     * @see <a href="https://openjdk.org/jeps/471">JEP 471: Deprecate the Memory-Access Methods in sun.misc.Unsafe for Removal</a>
+     */
+    private static final Unsafe UNSAFE;
+    static {
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            UNSAFE = (Unsafe) f.get(null);
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(
+                "Failed to obtain sun.misc.Unsafe instance. Morphium requires "
+                + "Unsafe.allocateInstance() to deserialize entity classes without a no-arg "
+                + "constructor. If running on a modular JDK, ensure "
+                + "--add-opens java.base/sun.misc=ALL-UNNAMED is set.");
+        }
+    }
+
     private final Map < Class<?>, NameProvider > nameProviders;
     private final JSONParser jsonParser = new JSONParser();
 
@@ -891,8 +927,18 @@ public class ObjectMapperImpl implements MorphiumObjectMapper {
             }
 
             if (ret == null) {
-                throw new IllegalArgumentException("Could not instantiate " + cls.getName()
-                    + ": entity classes must declare a public no-arg constructor");
+                // No no-arg constructor — use Unsafe.allocateInstance() to create an
+                // instance without calling any constructor. See UNSAFE field JavaDoc.
+                try {
+                    ret = UNSAFE.allocateInstance(cls);
+                } catch (InstantiationException e) {
+                    log.error("Could not instantiate {} via Unsafe.allocateInstance(). "
+                        + "Consider adding a no-arg constructor (can be private).", cls.getName(), e);
+                }
+            }
+
+            if (ret == null) {
+                throw new IllegalArgumentException("Could not instantiate " + cls.getName());
             }
 
             List<String> flds = annotationHelper.getFields(cls);

--- a/src/main/java/de/caluga/morphium/driver/MorphiumId.java
+++ b/src/main/java/de/caluga/morphium/driver/MorphiumId.java
@@ -22,8 +22,6 @@ public class MorphiumId implements Comparable<MorphiumId>, Serializable {
 
     private static final int THE_MACHINE_ID;
     private static final AtomicInteger COUNT = new AtomicInteger(new SecureRandom().nextInt());
-    @SuppressWarnings("unused")
-    public static ThreadLocal<Short> threadPid;
 
     static {
         try {
@@ -98,10 +96,7 @@ public class MorphiumId implements Comparable<MorphiumId>, Serializable {
         }
     }
 
-    @SuppressWarnings("CommentedOutCode")
     private static short createPID() {
-        //        if (threadPid == null || threadPid.get() == null) {
-
         short processId;
         try {
             String pName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
@@ -114,12 +109,7 @@ public class MorphiumId implements Comparable<MorphiumId>, Serializable {
             LoggerFactory.getLogger(MorphiumId.class).error("could not get processID - using random fallback");
             processId = (short) new SecureRandom().nextInt();
         }
-        //            threadPid = new ThreadLocal<>();
-        //            threadPid.set(processId);
         return processId;
-        //        }
-        //
-        //        return threadPid.get();
     }
 
     private static int createMachineId() {


### PR DESCRIPTION
Hey Stephan,

we've got one more thing for you 😄

In PR #136 we restored the `ReflectionFactory.newConstructorForSerialization()` fallback that was accidentally dropped during the Jackson removal (9377c929). That fix worked — `noDefaultConstructorTest` passed again and all was good.

But when we reviewed it more closely, we realized that `sun.reflect.ReflectionFactory` is an internal JDK API that's been progressively hidden in recent releases and produces compiler warnings. Since we *do* need a way to instantiate entity classes without a no-arg constructor, we looked at what the rest of the Java ecosystem does — and the answer is pretty clear: everybody uses `sun.misc.Unsafe.allocateInstance()`.

Spring, Jackson, Gson, Kryo, Hibernate (via Objenesis), and Netty all rely on it for exactly this purpose. JEP 471 (JDK 23) deprecates Unsafe's memory-access methods but explicitly does **not** touch `allocateInstance()` — there's simply no public replacement API yet. So `Unsafe` is the safer bet for keeping Morphium running on future JDK versions.

Of course, the best approach for users remains: **add a no-arg constructor** (can be `private`, e.g. Lombok `@NoArgsConstructor`) on `@Entity` / `@Embedded` classes — then the `Unsafe` fallback is never even reached.

This PR supersedes #136 — same intent, better long-term solution.

## Changes

- **ObjectMapperImpl**: Replace `ReflectionFactory` with `Unsafe.allocateInstance()`, with detailed JavaDoc explaining the rationale and JEP 471 status
- **MorphiumId**: Remove the unused `threadPid` ThreadLocal and associated commented-out code (same cleanup as #136)

## Tests

- `ObjectMapperImplTest` — 34 pass (incl. `noDefaultConstructorTest`)
- `ObjectMapperSerializationTest` — 11 pass
- `MorphiumIdTest` — 10 pass

Cheers,
Heiko