### PR TITLE
feat: enhance @CreationTime/@LastChange with LocalDateTime support and field-only usage

### DIFF
--- a/src/main/java/de/caluga/morphium/Morphium.java
+++ b/src/main/java/de/caluga/morphium/Morphium.java
@@ -1889,10 +1889,18 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
             return aNew;
         }
 
-        if (getARHelper().isAnnotationPresentInHierarchy(type, CreationTime.class)) {
+        if (getARHelper().isAnnotationPresentInHierarchy(type, CreationTime.class)
+                || getARHelper().isAnnotationOnAnyField(type, CreationTime.class)) {
             Object reread = null;
             CreationTime ct = getARHelper().getAnnotationFromHierarchy(o.getClass(), CreationTime.class);
-            boolean checkForNew = Objects.requireNonNull(ct).checkForNew() && getConfig().objectMappingSettings().isCheckForNew();
+            if (ct == null) {
+                List<String> ctFields = getARHelper().getFields(type, CreationTime.class);
+                if (!ctFields.isEmpty()) {
+                    Field ctField = getARHelper().getField(type, ctFields.get(0));
+                    ct = ctField.getAnnotation(CreationTime.class);
+                }
+            }
+            boolean checkForNew = ct != null && ct.checkForNew() && getConfig().objectMappingSettings().isCheckForNew();
             List<String> lst = getARHelper().getFields(type, CreationTime.class);
 
             if (id == null) {
@@ -1951,7 +1959,8 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
             }
         }
 
-        if (getARHelper().isAnnotationPresentInHierarchy(type, LastChange.class)) {
+        if (getARHelper().isAnnotationPresentInHierarchy(type, LastChange.class)
+                || getARHelper().isAnnotationOnAnyField(type, LastChange.class)) {
             List<String> lst = getARHelper().getFields(type, LastChange.class);
 
             if (lst != null && !lst.isEmpty()) {

--- a/src/main/java/de/caluga/morphium/annotations/CreationTime.java
+++ b/src/main/java/de/caluga/morphium/annotations/CreationTime.java
@@ -12,15 +12,17 @@ import static java.lang.annotation.ElementType.FIELD;
  * Date: 29.05.12
  * Time: 15:30
  * <p>
- * define the field to store the creation timestamp. Only works ifthis annotation is also added to  the type
+ * Define the field to store the creation timestamp. Can be used on field level only,
+ * or on both field and type level.
  * <code>
  *
- * @CreationTime class Test {
+ * class Test {
  * @CreationTime private long theTimestamp;
  * ...
  * }
  * </code>
- * if you use a non-MongoId-Field or create the IDs in code, you should set checkForNew to true. Otherwise creationtime won't be set.
+ * Supported field types: long, Long, Date, LocalDateTime, String.
+ * If you use a non-MongoId-Field or create the IDs in code, you should set checkForNew to true. Otherwise creationtime won't be set.
  */
 @Target({FIELD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/de/caluga/morphium/annotations/LastChange.java
+++ b/src/main/java/de/caluga/morphium/annotations/LastChange.java
@@ -12,8 +12,9 @@ import static java.lang.annotation.ElementType.TYPE;
  * Date: 29.05.12
  * Time: 15:31
  * <p>
- * tell Morphium to store the timestamp of the last change. put this annotation both to the type and the field to store
- * the last access timestamp. Field needs to be of type long
+ * Tell Morphium to store the timestamp of the last change. Can be used on field level only,
+ * or on both field and type level.
+ * Supported field types: long, Long, Date, LocalDateTime, String.
  */
 @Target({FIELD, TYPE})
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Hey Stephan,

two small quality-of-life improvements for @CreationTime and @LastChange:

**1. LocalDateTime support**

Until now, @CreationTime/@LastChange only worked with `long`, `Date`, and `String` fields.
We've added `LocalDateTime` as a fourth option — it's the natural choice for
modern Java code and avoids the old `java.util.Date` warts.

**2. Field-only usage (no class-level annotation required)**

Previously, @CreationTime/@LastChange silently required matching class-level annotations
(`@CreationTime` on the type) to trigger. This was easy to miss — the field annotation
was there, no error was thrown, but nothing happened. Now the field-level annotation
alone is sufficient, which aligns with how most users expect it to work.

Both changes are backwards compatible — existing entities with class-level annotations
continue to work exactly as before.

Cheers,
Heiko