### PR TITLE
test: increase timeouts for flaky messaging and changestream tests

### DIFF
--- a/src/test/java/de/caluga/test/mongo/suite/inmem/ChangeStreamInMemTest.java
+++ b/src/test/java/de/caluga/test/mongo/suite/inmem/ChangeStreamInMemTest.java
@@ -53,18 +53,19 @@ public class ChangeStreamInMemTest extends MorphiumInMemTestBase {
             log.info("===========");
             return run[0];
         });
-        // Give change stream listener time to start - under parallel load this can take longer
-        Thread.sleep(2000);
+        // Give change stream listener time to start - under parallel load on shared CI runners
+        // this can take significantly longer than locally
+        Thread.sleep(5000);
         morphium.store(new UncachedObject("test", 123));
         ComplexObject o = new ComplexObject();
         o.setEinText("Text");
         morphium.store(o);
         log.info("waiting for some time!");
-        TestUtils.waitForConditionToBecomeTrue(30000, "Expected 2 change events but got " + count,
+        TestUtils.waitForConditionToBecomeTrue(60000, "Expected 2 change events but got " + count,
             () -> count == 2);
         run[0] = false;
         morphium.createQueryFor(UncachedObject.class).f("counter").eq(123).set("counter", 7777);
-        TestUtils.waitForConditionToBecomeTrue(30000, "Expected 3 change events but got " + count,
+        TestUtils.waitForConditionToBecomeTrue(60000, "Expected 3 change events but got " + count,
             () -> count == 3); //the listener needs to be called to return false ;-)
         morphium.store(new UncachedObject("test", 123)); //to have the monitor stop
         assert(3 == count) : "Count wrong " + count + "!=3";

--- a/src/test/java/de/caluga/test/morphium/messaging/ExclusiveMessageBasicTests.java
+++ b/src/test/java/de/caluga/test/morphium/messaging/ExclusiveMessageBasicTests.java
@@ -171,9 +171,8 @@ public class ExclusiveMessageBasicTests extends MultiDriverTestBase {
 
                 assertThat(rec).isLessThanOrEqualTo(1);
                 Thread.sleep(50);
-                // Exclusive message should be received within 30 seconds, not minutes
-                // Allow generous tolerance for network latency (remote MongoDB/MorphiumServer)
-                assertThat(System.currentTimeMillis() - s).isLessThan(60000);
+                // Allow generous timeout for shared CI runners under parallel load
+                assertThat(System.currentTimeMillis() - s).isLessThan(120000);
             }
 
             TestUtils.waitForConditionToBecomeTrue(5000, "Messages not processed", () -> m1.getNumberOfMessages() == 0);

--- a/src/test/java/de/caluga/test/morphium/messaging/ExclusiveMessageTests.java
+++ b/src/test/java/de/caluga/test/morphium/messaging/ExclusiveMessageTests.java
@@ -128,11 +128,11 @@ public class ExclusiveMessageTests extends MultiDriverTestBase {
 
                 assertThat(rec).isLessThanOrEqualTo(1);
                 Thread.sleep(50);
-                // 60s timeout should be sufficient for message delivery
-                assertThat(System.currentTimeMillis() - s).isLessThan(60000);
+                // Allow generous timeout for shared CI runners under parallel load
+                assertThat(System.currentTimeMillis() - s).isLessThan(120000);
             }
 
-            TestUtils.waitForConditionToBecomeTrue(30000, "Messages not processed", () -> m1.getNumberOfMessages() == 0);
+            TestUtils.waitForConditionToBecomeTrue(60000, "Messages not processed", () -> m1.getNumberOfMessages() == 0);
             TestUtils.waitForConditionToBecomeTrue(15000, "Msg collection not empty", () -> morphium.createQueryFor(Msg.class, m1.getCollectionName()).countAll() == 0);
             TestUtils.waitForConditionToBecomeTrue(15000, "MsgLock collection not empty", () -> morphium.createQueryFor(MsgLock.class, m1.getLockCollectionName()).countAll() == 0);
         } finally {
@@ -240,8 +240,8 @@ public class ExclusiveMessageTests extends MultiDriverTestBase {
                 while (!gotMessage1 && !gotMessage2) {
                     Thread.sleep(200);
                     log.info("Still did not get all messages: m1=" + gotMessage1 + " m2=" + gotMessage2);
-                    // Use longer timeout for MorphiumServer replicaset under parallel load
-                    assertThat(System.currentTimeMillis() - s).isLessThan(60000);
+                    // Allow generous timeout for shared CI runners under parallel load
+                    assertThat(System.currentTimeMillis() - s).isLessThan(120000);
                 }
 
                 int rec = 0;
@@ -486,7 +486,7 @@ public class ExclusiveMessageTests extends MultiDriverTestBase {
                         sender.sendMessage(m);
                     }
 
-                    long waitUntil = System.currentTimeMillis() + 180000;
+                    long waitUntil = System.currentTimeMillis() + 300000;
 
                     while (received.get() != amount + broadcastAmount * 4) {
                         int rec = received.get();


### PR DESCRIPTION
Hey Stephan,

small test stability fix — similar to what we did in #138 for LastAccessTest.

The `ExclusiveMessageTests`, `ExclusiveMessageBasicTests`, and `ChangeStreamInMemTest`
occasionally fail on slower CI environments because the `Thread.sleep()` durations and
assertion timeouts are too tight. Bumped them to more generous values to reduce flaky
failures without changing any test logic.

Cheers,
Heiko