### PR TITLE
fix: use ChangeStreamMonitor.awaitReady() instead of Thread.sleep in tests

### DIFF
--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/ChangeStreamTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/ChangeStreamTest.java
@@ -240,7 +240,7 @@ public class ChangeStreamTest extends MultiDriverTestBase {
                     count.incrementAndGet();
                     log.info("count: " + count.get());
 
-                    if (count.get() == 50) {
+                    if (count.get() >= 50) {
                         run.set(false);
                         return false;
                     }

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/ChangeStreamInMemTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/ChangeStreamInMemTest.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("unchecked")
 @Tag("inmemory")
-@Tag("slow")  // May be flaky under high parallel load - uses change streams with timing-sensitive assertions
 public class ChangeStreamInMemTest extends MorphiumInMemTestBase {
     long start;
     long count;
@@ -45,7 +44,10 @@ public class ChangeStreamInMemTest extends MorphiumInMemTestBase {
         morphium.dropCollection(UncachedObject.class);
         count = 0;
         final boolean[] run = {true};
-        morphium.watchDbAsync(morphium.getDatabase(), true, null, evt->{
+
+        // Use ChangeStreamMonitor with awaitReady() instead of Thread.sleep(5000)
+        ChangeStreamMonitor dbMonitor = new ChangeStreamMonitor(morphium);
+        dbMonitor.addListener(evt -> {
             if (evt.getOperationType().equals("drop")) return true;
             printevent(evt);
             count++;
@@ -53,68 +55,78 @@ public class ChangeStreamInMemTest extends MorphiumInMemTestBase {
             log.info("===========");
             return run[0];
         });
-        // Give change stream listener time to start - under parallel load on shared CI runners
-        // this can take significantly longer than locally
-        Thread.sleep(5000);
-        morphium.store(new UncachedObject("test", 123));
-        ComplexObject o = new ComplexObject();
-        o.setEinText("Text");
-        morphium.store(o);
-        log.info("waiting for some time!");
-        TestUtils.waitForConditionToBecomeTrue(60000, "Expected 2 change events but got " + count,
-            () -> count == 2);
-        run[0] = false;
-        morphium.createQueryFor(UncachedObject.class).f("counter").eq(123).set("counter", 7777);
-        TestUtils.waitForConditionToBecomeTrue(60000, "Expected 3 change events but got " + count,
-            () -> count == 3); //the listener needs to be called to return false ;-)
-        morphium.store(new UncachedObject("test", 123)); //to have the monitor stop
-        assert(3 == count) : "Count wrong " + count + "!=3";
-        morphium.store(new UncachedObject("test again", 124));
-        assert(3 == count) : "Count wrong " + count + "!=3";  //monitor should have stopped by now
+        dbMonitor.start(); // blocks until watch cursor is established
+
+        try {
+            morphium.store(new UncachedObject("test", 123));
+            ComplexObject o = new ComplexObject();
+            o.setEinText("Text");
+            morphium.store(o);
+            log.info("waiting for some time!");
+            TestUtils.waitForConditionToBecomeTrue(60000, "Expected 2 change events but got " + count,
+                () -> count == 2);
+            run[0] = false;
+            morphium.createQueryFor(UncachedObject.class).f("counter").eq(123).set("counter", 7777);
+            TestUtils.waitForConditionToBecomeTrue(60000, "Expected 3 change events but got " + count,
+                () -> count == 3); //the listener needs to be called to return false ;-)
+            morphium.store(new UncachedObject("test", 123)); //to have the monitor stop
+            assert(3 == count) : "Count wrong " + count + "!=3";
+            morphium.store(new UncachedObject("test again", 124));
+            assert(3 == count) : "Count wrong " + count + "!=3";  //monitor should have stopped by now
+        } finally {
+            dbMonitor.terminate();
+        }
     }
 
     @Test
     public void changeStreamBackgroundTest() throws Exception {
         morphium.dropCollection(UncachedObject.class);
-        final boolean[] run = {true};
+        final AtomicBoolean run = new AtomicBoolean(true);
+        final AtomicInteger eventCount = new AtomicInteger(0);
+        final AtomicInteger written = new AtomicInteger(0);
+
+        // Use ChangeStreamMonitor with awaitReady() instead of raw watchAsync
+        ChangeStreamMonitor monitor = new ChangeStreamMonitor(morphium, UncachedObject.class);
+        monitor.addListener(evt -> {
+            if (evt.getOperationType().equals("drop")) return true;
+            eventCount.incrementAndGet();
+            printevent(evt);
+            return run.get();
+        });
+        monitor.start();
 
         try {
-            final int[] count = {0};
-            final int[] written = {0};
-            new Thread(()-> {
-                while (run[0]) {
+            Thread writerThread = new Thread(() -> {
+                while (run.get()) {
                     try {
                         Thread.sleep(2500);
                     } catch (InterruptedException e) {
+                        break;
                     }
-
-                    morphium.store(new UncachedObject("value", (int)(1 + (Math.random() * 100.0))));
+                    morphium.store(new UncachedObject("value", (int) (1 + (Math.random() * 100.0))));
                     log.info("Written");
-                    written[0]++;
+                    written.incrementAndGet();
                     morphium.createQueryFor(UncachedObject.class).f("counter").lt(50).set(UncachedObject.Fields.strValue, "newVal");
-                    // morphium.set(morphium.createQueryFor(UncachedObject.class).f("counter").lt(50), UncachedObject.Fields.strValue, "newVal");
                     log.info("updated");
-                    written[0]++;
+                    written.incrementAndGet();
                 }
                 log.info("Thread finished");
-            }).start();
-            start = System.currentTimeMillis();
-            morphium.watchAsync(UncachedObject.class, true, evt-> {
-                if (evt.getOperationType().equals("drop")) return true;
-                count[0]++;
-                printevent(evt);
-                return run[0];
             });
-            log.info("waiting for some time!");
-            Thread.sleep(8500);
-            run[0] = false;
-            assert(count[0] > 0 && count[0] >= written[0] - 3) : "Wrong count: " + count[0] + " written: " + written[0];
-        } finally {
-            run[0] = false;
-            // morphium.store(new UncachedObject("value", (int) (1 + (Math.random() * 100.0))));
-        }
+            writerThread.start();
 
-        Thread.sleep(2000);
+            // Wait for at least a few write cycles to complete
+            TestUtils.waitForConditionToBecomeTrue(30000, "No writes happened",
+                () -> written.get() >= 4);
+            run.set(false);
+            writerThread.join(5000);
+
+            assertTrue(eventCount.get() > 0, "Should have received events");
+            assertTrue(eventCount.get() >= written.get() - 3,
+                "Wrong count: " + eventCount.get() + " written: " + written.get());
+        } finally {
+            run.set(false);
+            monitor.terminate();
+        }
     }
 
     @Test
@@ -196,13 +208,13 @@ public class ChangeStreamInMemTest extends MorphiumInMemTestBase {
             printevent(evt);
             count.incrementAndGet();
             log.info("count: " + count.get());
-            if (count.get() == 50) {
+            if (count.get() >= 50) {
                 run.set(false);
                 return false;
             }
             return true;
         });
-        assertEquals(50, count.get());
+        assertTrue(count.get() >= 50, "Expected at least 50 events but got " + count.get());
         log.info("Quitting");
         run.set(false);
         Thread.sleep(500);
@@ -236,22 +248,24 @@ public class ChangeStreamInMemTest extends MorphiumInMemTestBase {
     public void changeStreamMonitorTest() throws Exception {
         morphium.dropCollection(UncachedObject.class);
         ChangeStreamMonitor m = new ChangeStreamMonitor(morphium, UncachedObject.class);
-        m.start();
         final AtomicInteger cnt = new AtomicInteger(0);
         m.addListener(evt->{
             if (evt.getOperationType().equals("drop")) return true;
             printevent(evt);
             return cnt.incrementAndGet() != 100;
         });
-        Thread.sleep(1000);
+        m.start(); // blocks until watch cursor is established
 
-        for (int i = 0; i < 100; i++) {
-            morphium.store(new UncachedObject("value " + i, i));
+        try {
+            for (int i = 0; i < 100; i++) {
+                morphium.store(new UncachedObject("value " + i, i));
+            }
+
+            TestUtils.waitForConditionToBecomeTrue(30000,
+                "count is wrong: " + cnt.get(), () -> cnt.get() >= 100);
+        } finally {
+            m.terminate();
         }
-
-        Thread.sleep(5000);
-        m.terminate();
-        assert(cnt.get() == 100) : "count is wrong: " + cnt.get();
     }
 
     @Test


### PR DESCRIPTION
Hey Stephan,

congrats on the 6.2.0 release and the PoppyDB extraction — the multi-module split is really clean, and having the server as a proper standalone module makes a lot of sense. The messaging bootstrapping speed-up with `awaitReady` per monitor instead of the blanket `Thread.sleep(5000)` is a nice improvement too.

This is the follow-up you suggested in #142 — replacing the `Thread.sleep(5000)` in `ChangeStreamInMemTest` with proper readiness signaling. The `ChangeStreamMonitor` already has `awaitReady()` with `CountDownLatch` + `registrationCallback`, so the infrastructure was already there:

- **changeStreamDatabaseTest**: switched from `watchDbAsync` + `Thread.sleep(5000)` to `ChangeStreamMonitor(morphium)` (db-level constructor) with `start()` which blocks until the watch cursor is established
- **changeStreamBackgroundTest**: switched from raw `watchAsync` + fixed 8.5s observation window to `ChangeStreamMonitor` + polling for a minimum number of write cycles
- **changeStreamMonitorTest**: moved `addListener` before `start()`, replaced `Thread.sleep(5000)` + exact assert with `waitForConditionToBecomeTrue`
- **changeStreamUpdateTest** (disabled): fixed `== 50` → `>= 50` race condition
- **ChangeStreamTest.changeStreamUpdateTest**: same `== 50` → `>= 50` fix (multi-doc update can generate 51+ events, causing the watch to never terminate)

Cheers,
Heiko