### PR TITLE
fix: add volatile to shared boolean fields and fix exact-count race in tests

### DIFF
--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/AsyncOperationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/AsyncOperationTest.java
@@ -36,8 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SuppressWarnings("AssertWithSideEffects")
 @Tag("core")
 public class AsyncOperationTest extends MultiDriverTestBase {
-    private boolean asyncCall = false;
-    private boolean callback;
+    private volatile boolean asyncCall = false;
+    private volatile boolean callback;
 
     @ParameterizedTest
     @MethodSource("getMorphiumInstances")

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/BulkInsertTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/BulkInsertTest.java
@@ -29,8 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SuppressWarnings("AssertWithSideEffects")
 @Tag("core")
 public class BulkInsertTest extends MultiDriverTestBase {
-    private boolean asyncSuccess = true;
-    private boolean asyncCall = false;
+    private volatile boolean asyncSuccess = true;
+    private volatile boolean asyncCall = false;
 
     @ParameterizedTest
     @MethodSource("getMorphiumInstances")

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/CacheSyncTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/CacheSyncTest.java
@@ -41,10 +41,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Tag("cache")
 @Tag("slow")  // May be flaky under high parallel load - uses caching with timing-sensitive operations
 public class CacheSyncTest extends MultiDriverTestBase {
-    private boolean preSendClear = false;
-    private boolean postSendClear = false;
-    private boolean preClear = false;
-    private boolean postclear = false;
+    private volatile boolean preSendClear = false;
+    private volatile boolean postSendClear = false;
+    private volatile boolean preClear = false;
+    private volatile boolean postclear = false;
 
     @ParameterizedTest
     @MethodSource("getMorphiumInstancesNoSingle")

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/AnsweringBasicTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/AnsweringBasicTests.java
@@ -24,10 +24,10 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @Tag("messaging")
 public class AnsweringBasicTests extends MultiDriverTestBase {
-    public boolean gotMessage1 = false;
-    public boolean gotMessage2 = false;
-    public boolean gotMessage3 = false;
-    public boolean error = false;
+    public volatile boolean gotMessage1 = false;
+    public volatile boolean gotMessage2 = false;
+    public volatile boolean gotMessage3 = false;
+    public volatile boolean error = false;
     public MorphiumId lastMsgId;
 
     @ParameterizedTest

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/AnsweringTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/AnsweringTests.java
@@ -27,14 +27,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("messaging")
 public class AnsweringTests extends MultiDriverTestBase {
-    public boolean gotMessage = false;
+    public volatile boolean gotMessage = false;
 
-    public boolean gotMessage1 = false;
-    public boolean gotMessage2 = false;
-    public boolean gotMessage3 = false;
-    public boolean gotMessage4 = false;
+    public volatile boolean gotMessage1 = false;
+    public volatile boolean gotMessage2 = false;
+    public volatile boolean gotMessage3 = false;
+    public volatile boolean gotMessage4 = false;
 
-    public boolean error = false;
+    public volatile boolean error = false;
 
     public MorphiumId lastMsgId;
 

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/BasicMessagingTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/BasicMessagingTests.java
@@ -27,10 +27,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("messaging")
 public class BasicMessagingTests extends MultiDriverTestBase {
 
-    private boolean gotMessage1 = false;
-    private boolean gotMessage2 = false;
-    private boolean gotMessage3 = false;
-    private boolean error = false;
+    private volatile boolean gotMessage1 = false;
+    private volatile boolean gotMessage2 = false;
+    private volatile boolean gotMessage3 = false;
+    private volatile boolean error = false;
 
     @ParameterizedTest
     @MethodSource("getMorphiumInstancesNoSingle")

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/ExclusiveMessageBasicTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/ExclusiveMessageBasicTests.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Tag("messaging")
 @Tag("slow")
 public class ExclusiveMessageBasicTests extends MultiDriverTestBase {
-    private boolean gotMessage1 = false;
-    private boolean gotMessage2 = false;
-    private boolean gotMessage3 = false;
+    private volatile boolean gotMessage1 = false;
+    private volatile boolean gotMessage2 = false;
+    private volatile boolean gotMessage3 = false;
 
     @ParameterizedTest
     @MethodSource("getMorphiumInstancesNoSingle")

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/ExclusiveMessageTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/ExclusiveMessageTests.java
@@ -41,10 +41,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Tag("messaging")
 @Tag("slow")  // Timing-sensitive messaging tests - may be flaky under high parallel load
 public class ExclusiveMessageTests extends MultiDriverTestBase {
-    private boolean gotMessage1 = false;
-    private boolean gotMessage2 = false;
-    private boolean gotMessage3 = false;
-    private boolean gotMessage4 = false;
+    private volatile boolean gotMessage1 = false;
+    private volatile boolean gotMessage2 = false;
+    private volatile boolean gotMessage3 = false;
+    private volatile boolean gotMessage4 = false;
 
     @ParameterizedTest
     @MethodSource("getMorphiumInstancesNoSingle")

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/MessagingBroadcastTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/MessagingBroadcastTests.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Tag;
 @Tag("messaging")
 public class MessagingBroadcastTests extends MultiDriverTestBase {
 
-    private boolean gotMessage1, gotMessage2, gotMessage3, gotMessage4, error;
+    private volatile boolean gotMessage1, gotMessage2, gotMessage3, gotMessage4, error;
     @ParameterizedTest
     @MethodSource("getMorphiumInstancesNoSingle")
     public void broadcastTest(Morphium morphium) throws Exception {

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/TimeoutTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/TimeoutTests.java
@@ -67,7 +67,7 @@ public class TimeoutTests extends MultiDriverTestBase {
                     }
 
                     TestUtils.waitForConditionToBecomeTrue(20000, "Did not get all messages?",
-                                                           () -> msgCount.get() == 50);
+                                                           () -> msgCount.get() >= 50);
                     assertEquals(50, m.createQueryFor(Msg.class, m1.getCollectionName("test")).countAll());
 
                     for (Msg mm : m.createQueryFor(Msg.class, m1.getCollectionName("test")).asIterable()) {


### PR DESCRIPTION
Hey Stephan,

while going through the test suite for CI stability, we found that several messaging and cache test classes use plain `boolean` instance fields that are written from callback threads but read from the test thread. Without `volatile`, the Java Memory Model doesn't guarantee cross-thread visibility — the test thread may read stale `false` values indefinitely.

This adds `volatile` to 26 fields across 9 test classes:
- ExclusiveMessageTests, ExclusiveMessageBasicTests, BasicMessagingTests
- MessagingBroadcastTests, AnsweringTests, AnsweringBasicTests
- CacheSyncTest, AsyncOperationTest, BulkInsertTest

Also fixes `TimeoutTests.timeOutTests` where `msgCount.get() == 50` can fail if a duplicate message arrives (changed to `>= 50`).

Cheers,
Heiko