### PR TITLE
fix: guard QueryIterator.close() against null cursor

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/query/QueryIterator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/query/QueryIterator.java
@@ -155,7 +155,9 @@ public class QueryIterator<T> implements MorphiumIterator<T>, Iterator<T> {
 
     @Override
     public void close() {
-        getMongoCursor().close();
+        if (cursor != null) {
+            cursor.close();
+        }
     }
 
     @Override

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/QueryIteratorCloseTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/QueryIteratorCloseTest.java
@@ -1,0 +1,45 @@
+package de.caluga.test.mongo.suite.base;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.query.MorphiumIterator;
+import de.caluga.test.mongo.suite.data.UncachedObject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+public class QueryIteratorCloseTest extends MultiDriverTestBase {
+
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
+    void closeWithoutConsumingDoesNotOpenCursor(Morphium morphium) {
+        for (int i = 1; i <= 5; i++) {
+            morphium.store(new UncachedObject("v" + i, i));
+        }
+
+        // Creating an iterator and closing it without calling hasNext()/next()
+        // must not wastefully open a MongoDB cursor
+        MorphiumIterator<UncachedObject> it = morphium.createQueryFor(UncachedObject.class).asIterable();
+        it.close(); // before fix: NPE or unnecessary cursor creation
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
+    void doubleCloseAfterExhaustion(Morphium morphium) {
+        for (int i = 1; i <= 3; i++) {
+            morphium.store(new UncachedObject("v" + i, i));
+        }
+
+        MorphiumIterator<UncachedObject> it = morphium.createQueryFor(UncachedObject.class).asIterable();
+        // exhaust the iterator
+        while (it.hasNext()) {
+            it.next();
+        }
+        // close after exhaustion — connection already released by hasNext()
+        it.close();
+        // second close must not throw
+        it.close();
+    }
+}


### PR DESCRIPTION
Hey Stephan,

while implementing a `Query.stream()` feature (PR follows shortly), we noticed a small issue in `QueryIterator.close()`: it calls `getMongoCursor()` which lazily initializes the cursor. If an iterator created via `asIterable()` is closed before it's ever consumed (no `hasNext()`/`next()` call), this wastefully opens a cursor and connection just to immediately close them again.

We initially spotted this in code review, and it turned out to be quite relevant in practice: during a profiling stress test of an application running on 10 pods with roughly 2.5 million queries per hour, we saw a significant number of short-lived cursors that were opened only to be immediately closed — adding unnecessary load on both the driver and the database.

The fix adds a null guard so `close()` is a no-op when the cursor was never initialized. Also added two tests covering close-without-consuming and double-close after exhaustion.

Cheers,
Heiko