### PR TITLE
fix: replace spring-core with standalone cglib to resolve CVE-2025-41249

### DIFF
--- a/morphium-core/pom.xml
+++ b/morphium-core/pom.xml
@@ -102,8 +102,8 @@
       <artifactId>figlet4s-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>

--- a/morphium-core/src/main/java/de/caluga/morphium/LazyDeReferencingProxy.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/LazyDeReferencingProxy.java
@@ -4,8 +4,8 @@ package de.caluga.morphium;
 // import net.sf.cglib.proxy.MethodProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cglib.proxy.MethodInterceptor;
-import org.springframework.cglib.proxy.MethodProxy;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 

--- a/morphium-core/src/main/java/de/caluga/morphium/Morphium.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/Morphium.java
@@ -39,7 +39,7 @@ import io.github.classgraph.ClassInfoList;
 import io.github.classgraph.ScanResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.Enhancer;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/AnnotationAndReflectionHelperTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/AnnotationAndReflectionHelperTest.java
@@ -10,8 +10,8 @@ import de.caluga.test.mongo.suite.data.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.cglib.proxy.Enhancer;
-import org.springframework.cglib.proxy.FixedValue;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.FixedValue;
 import java.lang.reflect.Field;
 import java.util.*;
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,9 +215,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>5.3.39</version>
+        <groupId>cglib</groupId>
+        <artifactId>cglib</artifactId>
+        <version>3.3.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Hey Stephan,

while integrating Morphium 6.2.1-SNAPSHOT into our Quarkus extension, a dependency
scan flagged **CVE-2025-41249** (CVSS 7.5 — Spring Framework Annotation Detection
Vulnerability) coming in transitively through `spring-core:5.3.39`.

We traced it through the dependency tree and noticed that the only thing Morphium
actually uses from Spring is the repackaged cglib — specifically `Enhancer`,
`MethodInterceptor`, and `MethodProxy` for the lazy de-referencing proxy. No other
Spring API is used anywhere in the codebase. The old commented-out imports in
`LazyDeReferencingProxy.java` even hint that this used to be `net.sf.cglib` at
some point before it was switched to the Spring-bundled variant.

So the idea here is straightforward: switch back to the standalone `cglib:3.3.0`
which provides the exact same classes under `net.sf.cglib.proxy`. This drops the
entire `spring-core` + `spring-jcl` transitive tree (~1.5 MB), resolves the CVE,
and keeps the actual proxy functionality identical.

Changes are minimal — just the dependency swap in the POMs and updating the import
statements in three files:

- `Morphium.java` — `Enhancer`
- `LazyDeReferencingProxy.java` — `MethodInterceptor`, `MethodProxy`
- `AnnotationAndReflectionHelperTest.java` — `Enhancer`, `FixedValue`

Builds and installs cleanly with `mvn install -DskipTests`.

Cheers,
Heiko