### PR TITLE
fix: QueryHelper.matchesQuery short-circuits on first field in multi-field queries

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/QueryHelper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/QueryHelper.java
@@ -126,6 +126,7 @@ public class QueryHelper {
         }
 
         // Special handling for map field queries and array index queries
+        Set<String> consumedKeys = new HashSet<>();
         for (String key : query.keySet()) {
             if (query.get(key) instanceof Map) {
                 Map<String, Object> queryMap = (Map<String, Object>) query.get(key);
@@ -144,7 +145,7 @@ public class QueryHelper {
                     }
 
                     if (allMatched) {
-                        return true;
+                        consumedKeys.add(key);
                     }
                 } else if (toCheck.get(key) instanceof List) {
                     // Query has Map but document has List - this could be array index access
@@ -214,7 +215,7 @@ public class QueryHelper {
                     }
 
                     if (allMatched) {
-                        return true;
+                        consumedKeys.add(key);
                     }
                 }
             }
@@ -244,6 +245,10 @@ public class QueryHelper {
         boolean ret = false;
 
         for (String keyQuery : query.keySet()) {
+            if (consumedKeys.contains(keyQuery)) {
+                ret = true;
+                continue;
+            }
             switch (keyQuery) {
                 case "$and": {
                         // list of field queries
@@ -340,6 +345,28 @@ public class QueryHelper {
                         throw new IllegalArgumentException("unknown top level operator: " + keyQuery);
                     }
 
+                    if (!matchesFieldCondition(keyQuery, query, toCheck, collation)) {
+                        return false;
+                    }
+                    ret = true;
+                    continue;
+            }
+        }
+
+        return ret;
+    }
+
+    /**
+     * Evaluates a single field condition within a query document.
+     * Extracted from matchesQuery so that multi-field queries correctly AND
+     * all field conditions (previously, early returns in this block would
+     * short-circuit the outer loop, skipping remaining fields).
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static boolean matchesFieldCondition(String keyQuery,
+                                                  Map<String, Object> query,
+                                                  Map<String, Object> toCheck,
+                                                  Map<String, Object> collation) {
                     // field check
                     if (query.get(keyQuery) instanceof Map) {
                         // probably a query operand
@@ -370,8 +397,7 @@ public class QueryHelper {
                                 }
                             }
 
-                            ret = true;
-                            continue;
+                            return true;
                         }
                         var it = commandMap.keySet().iterator();
                         String commandKey = it.next();
@@ -694,7 +720,7 @@ public class QueryHelper {
                                 }
 
                             case "$comment":
-                                continue;
+                                return true;
 
                             case "$expr":
                                 Expr e = (Expr) commandMap.get(commandKey);
@@ -851,8 +877,7 @@ public class QueryHelper {
                                     return false;
                                 }
 
-                                ret = true;
-                                continue;
+                                return true;
 
                             case "$nearSphere":
                             case "$near":
@@ -1140,6 +1165,8 @@ public class QueryHelper {
 
                                 return commandMap.equals(toCheck);
                         }
+                        // Fallthrough from break cases ($options, $jsonSchema, $geoWithin)
+                        return true;
                     } else {
                         if (keyQuery.contains(".")) {
                             String[] path = keyQuery.split("\\.");
@@ -1230,10 +1257,6 @@ public class QueryHelper {
                         }
                         return toCheck.get(keyQuery) != null && toCheck.get(keyQuery).equals(query.get(keyQuery));
                     }
-            }
-        }
-
-        return ret;
     }
 
     private static boolean matchesJsonSchema(Map<String, Object> schema, Map<String, Object> document) {

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/QueryHelperTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/QueryHelperTest.java
@@ -382,10 +382,104 @@ public class QueryHelperTest extends MorphiumInMemTestBase {
     public void geoNearTests() throws Exception {
         GeoSearchTests.Place p = new GeoSearchTests.Place();
         p.setPosition(Arrays.asList(-73.9667,40.78));
-        var ret=QueryHelper.matchesQuery(Doc.of("position",Doc.of("$near",Doc.of("$geometry",Doc.of("type","Point","coordinates",Arrays.asList(-73.9966,40.77)))),
-          "$minDistance",1000,"$maxDistance",2000),
+        var ret=QueryHelper.matchesQuery(Doc.of("position",Doc.of("$near",Doc.of(
+          "$geometry",Doc.of("type","Point","coordinates",Arrays.asList(-73.9966,40.77)),
+          "$minDistance",1.0,"$maxDistance",5.0))),
           morphium.getMapper().serialize(p), null);
         assertTrue(ret);
+    }
+
+    @Test
+    public void multiFieldMatchAndsAllConditions() {
+        // Regression test: multi-field $match must AND all conditions.
+        // Previously, matchesQuery returned true after the first field matched,
+        // ignoring remaining fields.
+        Map<String, Object> doc = Doc.of("count", 5, "total", 1500.0);
+        Map<String, Object> query = Doc.of(
+                "count", Doc.of("$gt", 2),
+                "total", Doc.of("$gte", 2000.0));
+        // count=5 > 2 (pass), but total=1500 < 2000 (fail) → overall: false
+        assertFalse(QueryHelper.matchesQuery(query, doc, null));
+    }
+
+    @Test
+    public void multiFieldMatchAllPass() {
+        Map<String, Object> doc = Doc.of("count", 5, "total", 2100.0);
+        Map<String, Object> query = Doc.of(
+                "count", Doc.of("$gt", 2),
+                "total", Doc.of("$gte", 2000.0));
+        // count=5 > 2 (pass), total=2100 >= 2000 (pass) → overall: true
+        assertTrue(QueryHelper.matchesQuery(query, doc, null));
+    }
+
+    @Test
+    public void multiFieldMatchFirstFails() {
+        Map<String, Object> doc = Doc.of("count", 1, "total", 3000.0);
+        Map<String, Object> query = Doc.of(
+                "count", Doc.of("$gt", 2),
+                "total", Doc.of("$gte", 2000.0));
+        // count=1 <= 2 (fail) → short-circuit false
+        assertFalse(QueryHelper.matchesQuery(query, doc, null));
+    }
+
+    @Test
+    public void multiFieldMatchWithEqAndGt() {
+        Map<String, Object> doc = Doc.of("status", "OPEN", "amount", 500);
+        // {status: "OPEN", amount: {$gt: 100}} — mixed equality + operator
+        Map<String, Object> query = Doc.of(
+                "status", "OPEN",
+                "amount", Doc.of("$gt", 100));
+        assertTrue(QueryHelper.matchesQuery(query, doc, null));
+
+        Map<String, Object> doc2 = Doc.of("status", "CLOSED", "amount", 500);
+        assertFalse(QueryHelper.matchesQuery(query, doc2, null));
+    }
+
+    @Test
+    public void mapFieldPlusOperatorBothPass() {
+        Map<String, Object> doc = Doc.of(
+                "metadata", Doc.of("type", "invoice", "region", "EU"),
+                "amount", 250);
+        Map<String, Object> query = Doc.of(
+                "metadata", Doc.of("type", "invoice"),
+                "amount", Doc.of("$gt", 100));
+        assertTrue(QueryHelper.matchesQuery(query, doc, null));
+    }
+
+    @Test
+    public void mapFieldPassesButOperatorFails() {
+        // Regression: map match must not short-circuit; amount 50 is NOT > 100
+        Map<String, Object> doc = Doc.of(
+                "metadata", Doc.of("type", "invoice", "region", "EU"),
+                "amount", 50);
+        Map<String, Object> query = Doc.of(
+                "metadata", Doc.of("type", "invoice"),
+                "amount", Doc.of("$gt", 100));
+        assertFalse(QueryHelper.matchesQuery(query, doc, null),
+                "Map match must not short-circuit; amount 50 is NOT > 100");
+    }
+
+    @Test
+    public void mapFieldFailsOperatorPasses() {
+        Map<String, Object> doc = Doc.of(
+                "metadata", Doc.of("type", "receipt"),
+                "amount", 250);
+        Map<String, Object> query = Doc.of(
+                "metadata", Doc.of("type", "invoice"),
+                "amount", Doc.of("$gt", 100));
+        assertFalse(QueryHelper.matchesQuery(query, doc, null));
+    }
+
+    @Test
+    public void arrayIndexPlusOperatorCondition() {
+        Map<String, Object> doc = Doc.of(
+                "items", List.of(Doc.of("name", "Widget")),
+                "status", "DRAFT");
+        Map<String, Object> query = Doc.of(
+                "items", Doc.of("0", Doc.of("name", "Widget")),
+                "status", "PUBLISHED");
+        assertFalse(QueryHelper.matchesQuery(query, doc, null),
+                "Array index match must not short-circuit; status mismatch");
     }
 
 }


### PR DESCRIPTION
Hey Stephan,

while implementing HAVING support for our quarkus-morphium Jakarta Data provider,
we hit a subtle bug in the InMemoryDriver's `QueryHelper.matchesQuery()`: multi-field
query documents (implicit AND) only check the **first** field — remaining fields are
silently ignored.

**Example:** Given a query `{count: {$gt: 2}, total: {$gte: 2000}}` and a document
`{count: 5, total: 1500}`, `matchesQuery` returns `true` even though `total < 2000`.
This affects any `$match` stage in aggregation pipelines (and regular queries) that
combine multiple field conditions without explicit `$and`.

**Root cause:** The field-checking logic lives inside the outer `for (keyQuery : query.keySet())`
loop's `default:` branch. The inner operator switch (`$gt`, `$eq`, `$in`, etc.) uses
direct `return true/false` statements that exit the entire `matchesQuery` method —
so after the first field matches, the loop never reaches the second field.

**Fix:** Extract the field-checking block into a new `matchesFieldCondition()` method.
The outer loop now calls it per field and returns `false` immediately if any field fails
(correct AND semantics), or continues to the next field on success. All existing `return`
statements in the field-checking code now return from the helper method, not from
`matchesQuery`.

**Side fix:** The `geoNearTests` test had `$minDistance`/`$maxDistance` at the query top
level instead of inside `$near` — incorrect MongoDB syntax that only passed because
the early-return bug skipped those keys entirely. Fixed to correct placement with
appropriate distance values.

**Tests:**
- 4 new tests in `QueryHelperTest`: multi-field AND with partial match, full match,
  first-field failure, and mixed equality + operator conditions
- All 177 inmemory-tagged tests pass (0 failures)
- All 24 InMemAggregation tests pass (0 failures)

Cheers,
Heiko