### PR TITLE
fix: MongoField.not() produces wrong query structure for $regex and other operators

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Expr.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Expr.java
@@ -951,8 +951,11 @@ public abstract class Expr {
         return new OpExpr("cond", Arrays.asList(condition, caseTrue, caseFalse)) {
             @Override
             public Object evaluate(Map<String, Object> context) {
-                LoggerFactory.getLogger(Expr.class).error("cond not implemented yet,sorry");
-                return null;
+                Object condResult = eval(condition, context);
+                boolean isTrue = condResult != null
+                        && !Boolean.FALSE.equals(condResult)
+                        && !Integer.valueOf(0).equals(condResult);
+                return isTrue ? eval(caseTrue, context) : eval(caseFalse, context);
             }
         };
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/QueryHelper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/QueryHelper.java
@@ -702,7 +702,11 @@ public class QueryHelper {
                                 return ev != null && (ev.equals(Boolean.TRUE) || ev.equals(1) || ev.equals("true"));
 
                             case "$not":
-                                return !(matchesQuery((Map) commandMap.get(commandKey), toCheck, collation));
+                                // $not on field level: {field: {$not: {$regex: ...}}}
+                                // Wrap the $not content back into a field query so matchesQuery
+                                // can apply it against the correct field value.
+                                Map<String, Object> notInner = (Map<String, Object>) commandMap.get(commandKey);
+                                return !(matchesQuery(Map.of(keyQuery, notInner), toCheck, collation));
 
                             case "$regex":
                             case "$regularExpression":

--- a/morphium-core/src/main/java/de/caluga/morphium/query/MongoFieldImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/query/MongoFieldImpl.java
@@ -189,14 +189,18 @@ public class MongoFieldImpl<T> implements MongoField<T> {
 
     private void add(String op, Object value) {
         fe.setField(mapper.getMorphium().getARHelper().getMongoFieldName(query.getType(), fldStr));
-        FilterExpression child = new FilterExpression();
-        child.setField(op);
         if (not) {
-            child.setValue(UtilsMap.of("$not", value));
+            // {field: {$not: {$op: value}}} — $not wraps the operator, not the value
+            FilterExpression notChild = new FilterExpression();
+            notChild.setField("$not");
+            notChild.setValue(UtilsMap.of(op, value));
+            fe.addChild(notChild);
         } else {
+            FilterExpression child = new FilterExpression();
+            child.setField(op);
             child.setValue(value);
+            fe.addChild(child);
         }
-        fe.addChild(child);
 
         query.addChild(fe);
     }

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/RawQueryTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/RawQueryTests.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 @Tag("inmemory")
@@ -49,5 +50,31 @@ public class RawQueryTests extends MorphiumInMemTestBase {
 
         lst = morphium.createQueryFor(UncachedObject.class).f(UncachedObject.Fields.strValue).matches(Pattern.compile(".*value.*", Pattern.CASE_INSENSITIVE)).asList();
         assertEquals(3, lst.size());
+    }
+
+    @Test
+    public void notRegexQueryTest() throws Exception {
+        morphium.store(new UncachedObject("OPEN_order", 1));
+        morphium.store(new UncachedObject("OPEN_other", 2));
+        morphium.store(new UncachedObject("CLOSED_order", 3));
+        morphium.store(new UncachedObject("CANCELLED", 4));
+
+        // NOT LIKE "OPEN.*" → should exclude the two OPEN entries, returning 2
+        var query = morphium.createQueryFor(UncachedObject.class);
+        var field = query.f(UncachedObject.Fields.strValue);
+        field.not();
+        field.matches(Pattern.compile("OPEN.*"));
+        List<UncachedObject> lst = query.asList();
+        assertEquals(2, lst.size(), "NOT regex should exclude matching docs");
+
+        // Verify the query document structure: {str_value: {$not: {$regex: "OPEN.*"}}}
+        Map<String, Object> queryObj = query.toQueryObject();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> fieldExpr = (Map<String, Object>) queryObj.get("str_value");
+        assertNotNull(fieldExpr, "Field expression should not be null");
+        assertNotNull(fieldExpr.get("$not"), "$not operator should be present");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> notExpr = (Map<String, Object>) fieldExpr.get("$not");
+        assertNotNull(notExpr.get("$regex"), "$regex should be inside $not");
     }
 }


### PR DESCRIPTION
Hi Stephan,

here's a fix for a long-standing bug where `MongoField.not()` produced incorrect query structures.

## Summary

- `MongoFieldImpl.add()` wrapped `$not` around the operator value instead of the
  operator itself, producing `{field: {$regex: {$not: "pattern"}}}` instead of
  the correct MongoDB form `{field: {$not: {$regex: "pattern"}}}`
- `QueryHelper` field-level `$not` handler passed the inner expression to
  `matchesQuery()` without field context, so the InMemoryDriver never evaluated
  it correctly
- `Expr.$cond` evaluate was stubbed out (logged error, returned null) — now implemented

## Changed files

| File | Change |
|------|--------|
| `MongoFieldImpl.java` | `add()`: emit `{$not: {$op: value}}` instead of `{$op: {$not: value}}` |
| `QueryHelper.java` | Field-level `$not`: wrap inner expression back into field context |
| `Expr.java` | Implement `$cond` evaluate |
| `RawQueryTests.java` | New: `notRegexQueryTest` verifying query structure + InMemory execution |

## Test plan

- [x] New `notRegexQueryTest` passes
- [x] All 174 `inmemory`-tagged tests pass (0 failures, 0 errors)

Cheers!