### PR TITLE
fix: auto-detect single-node replica sets from hello response

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/PooledDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/PooledDriver.java
@@ -375,6 +375,17 @@ public class PooledDriver extends DriverBase {
             }
         }
 
+        // Auto-detect replica set from hello response.
+        // Single-node replica sets (common in dev/test with Docker) have only one seed host
+        // and no configured RS name, so connect() sets replicaSet=false. The hello response
+        // from the server contains the actual setName — use it to upgrade to RS mode.
+        if (!isReplicaSet() && hello.getSetName() != null && !hello.getSetName().isEmpty()) {
+            log.info("Auto-detected replica set '{}' from hello response (host: {})",
+                     hello.getSetName(), hostConnected);
+            setReplicaSet(true);
+            setReplicaSetName(hello.getSetName());
+        }
+
         // Keep track of server-advertised vs reachable names.
         registerAlias(hello.getMe(), hostConnected);
 


### PR DESCRIPTION
Hi Stephan,

this is a follow-up to PR #147 that unfortunately got lost as a second iteration — we had prepared it but never submitted it.

PR #147 fixed the `connect()` logic so that a single-node RS is recognised when the caller passes a `replSet` name. However, there's a second scenario: when no RS name is configured at all (e.g. Testcontainers, Docker Compose setups), but the MongoDB server *is* actually running as a replica set. In that case `connect()` correctly sets `replicaSet=false` (no name, single host), but the subsequent hello handshake from the server contains the actual `setName`.

This PR adds an 11-line block to `handleHelloResult()` that upgrades to RS mode when the hello response advertises a `setName` and the driver isn't already in RS mode:

```java
if (!isReplicaSet() && hello.getSetName() != null && !hello.getSetName().isEmpty()) {
    log.info("Auto-detected replica set '{}' from hello response (host: {})",
             hello.getSetName(), hostConnected);
    setReplicaSet(true);
    setReplicaSetName(hello.getSetName());
}
```

This eliminates the need for the caller (e.g. Quarkus extension) to manually call `setReplicaSet(true)` after connect — the driver now self-corrects based on what the server actually reports.

No behaviour change for connections that already have `replicaSet=true`. The log line at INFO level makes it visible when auto-detection kicks in.

Cheers,
Heiko