### PR TITLE
fix: ensure read-your-writes consistency after transaction commit

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/Morphium.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/Morphium.java
@@ -3090,6 +3090,11 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
     }
 
     public void commitTransaction() {
+        // Flush any buffered writes so they become part of the transaction
+        // before it is committed. Without this, entities annotated with
+        // @WriteBuffer could remain in the buffer and never be included
+        // in the transaction.
+        flush();
         getDriver().commitTransaction();
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/DriverBase.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/DriverBase.java
@@ -62,6 +62,21 @@ public abstract class DriverBase implements MorphiumDriver {
 
     private ThreadLocal<MorphiumTransactionContext> transactionContext = new ThreadLocal<>();
 
+    /**
+     * Tracks when the last transaction commit occurred on the current thread.
+     * Used by {@code getReadConnection()} to enforce PRIMARY reads for a brief
+     * window after a commit, ensuring read-your-writes consistency on replica sets.
+     */
+    private final ThreadLocal<Long> lastCommitTimestampMs = ThreadLocal.withInitial(() -> 0L);
+
+    /**
+     * Duration (in milliseconds) after a transaction commit during which reads
+     * are forced to the PRIMARY node. This avoids stale reads from secondaries
+     * that have not yet replicated the committed data.
+     * <p>Default: 5 000 ms (5 seconds).</p>
+     */
+    private long readAfterWriteWindowMs = 5000;
+
     private String authDb = null;
     private String user;
     private String password;
@@ -630,6 +645,31 @@ public abstract class DriverBase implements MorphiumDriver {
 
     protected void clearTransactionContext() {
         transactionContext.remove();
+    }
+
+    /**
+     * Records the current time as the moment of the last transaction commit
+     * on this thread. Called by driver implementations after a successful commit.
+     */
+    protected void markTransactionCommitted() {
+        lastCommitTimestampMs.set(System.currentTimeMillis());
+    }
+
+    /**
+     * Returns {@code true} if a transaction was committed on this thread
+     * within the {@link #readAfterWriteWindowMs} window.
+     */
+    public boolean isInReadAfterWriteWindow() {
+        long elapsed = System.currentTimeMillis() - lastCommitTimestampMs.get();
+        return elapsed >= 0 && elapsed < readAfterWriteWindowMs;
+    }
+
+    public long getReadAfterWriteWindowMs() {
+        return readAfterWriteWindowMs;
+    }
+
+    public void setReadAfterWriteWindowMs(long readAfterWriteWindowMs) {
+        this.readAfterWriteWindowMs = readAfterWriteWindowMs;
     }
 
     public abstract void watch(WatchCommand settings) throws MorphiumDriverException;

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/PooledDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/PooledDriver.java
@@ -1093,6 +1093,13 @@ public class PooledDriver extends DriverBase {
                 type = ReadPreferenceType.PRIMARY;
             }
 
+            // Force PRIMARY reads shortly after a transaction commit to ensure
+            // read-your-writes consistency. On replica sets, secondaries may not
+            // have replicated the committed data yet.
+            if (type != ReadPreferenceType.PRIMARY && isInReadAfterWriteWindow()) {
+                type = ReadPreferenceType.PRIMARY;
+            }
+
             // Force PRIMARY reads for InMemory backend (PoppyDB) to ensure read-your-writes consistency
             // InMemory backend replication is eventually consistent, so NEAREST/SECONDARY reads may return stale data
             if (inMemoryBackend && type != ReadPreferenceType.PRIMARY) {
@@ -1616,6 +1623,7 @@ public class PooledDriver extends DriverBase {
             cmd.execute();
         } finally {
             clearTransactionContext();
+            markTransactionCommitted();
             releaseConnection(con);
         }
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnectDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnectDriver.java
@@ -537,6 +537,7 @@ public class SingleMongoConnectDriver extends DriverBase {
         var cmd = new CommitTransactionCommand(connection).setTxnNumber(ctx.getTxnNumber()).setAutocommit(false).setLsid(ctx.getLsid());
         cmd.execute();
         clearTransactionContext();
+        markTransactionCommitted();
     }
 
     @Override


### PR DESCRIPTION
Hi Stephan,

We ran into a subtle read-after-write consistency issue on replica sets: immediately after `commitTransaction()`, queries could be routed to a secondary that hadn't replicated the committed data yet - returning 0 results for documents that were just written inside the transaction.

**Root cause:** After `commitTransaction()` completes, the transaction context is cleared and subsequent reads fall back to the configured `ReadPreference` (e.g. `NEAREST` or `SECONDARY_PREFERRED`). On a replica set, the secondary may lag behind by a few hundred milliseconds, so reads issued right after commit can hit stale data.

A second issue: if entities use `@WriteBuffer`, the buffered writes were never flushed before `commitTransaction()`, so they silently fell outside the transaction boundary.

**The fix has two parts:**

1. **`Morphium.commitTransaction()` — flush before commit:**
```java
public void commitTransaction() {
    flush();  // ensure @WriteBuffer entities are included
    getDriver().commitTransaction();
}
```

2. **`DriverBase` / `PooledDriver` — read-after-write window:**
After a successful commit, the driver records `lastCommitTimestampMs` on the current thread. For a configurable window (default 5s), `getReadConnection()` forces reads to PRIMARY:
```java
if (type != ReadPreferenceType.PRIMARY && isInReadAfterWriteWindow()) {
    type = ReadPreferenceType.PRIMARY;
}
```
This is applied in both `PooledDriver` and `SingleMongoConnectDriver`.

**Files changed:**
- `Morphium.java` - `flush()` call before `getDriver().commitTransaction()`
- `DriverBase.java` - `ThreadLocal<Long> lastCommitTimestampMs`, `markTransactionCommitted()`, `isInReadAfterWriteWindow()`, configurable `readAfterWriteWindowMs`
- `PooledDriver.java` - PRIMARY enforcement in `getReadConnection()`, `markTransactionCommitted()` after commit
- `SingleMongoConnectDriver.java` - `markTransactionCommitted()` after commit

The window is conservative (5s default) and only activates on the thread that committed the transaction, so it has zero impact on other threads or non-transactional workloads.

Cheers,
Heiko