### PR TITLE
fix: use error code instead of string match for transient error 251

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/commands/WriteMongoCommand.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/commands/WriteMongoCommand.java
@@ -88,7 +88,8 @@ public abstract class WriteMongoCommand<T extends MongoCommand> extends MongoCom
                     setConnection(drv.getPrimaryConnection(null));
                     // retrying
                     return execute();
-                } else if (e instanceof MorphiumDriverNetworkException && errMsg.contains("251")
+                } else if (e instanceof MorphiumDriverNetworkException
+                    && e.getMongoCode() instanceof Number mc && mc.intValue() == 251
                     && attempts++ < maxAttempts) {
                     // Error 251 (NoSuchTransaction): connection had a poisoned server-side session.
                     // The connection was already closed by checkForError/readSingleAnswer.

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnection.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnection.java
@@ -606,19 +606,20 @@ public class SingleMongoConnection implements MongoConnection {
             String errmsg = (String) reply.getFirstDoc().get("errmsg");
             Object codeObj = reply.getFirstDoc().get("code");
             int code = codeObj instanceof Number ? ((Number) codeObj).intValue() : -1;
-            // Format consistently with checkForError(): "Error: <code> - <msg>"
-            // WriteMongoCommand detects transient errors via contains("251"),
-            // which only works with this format.
             String formattedMsg = "Error: " + code + " - " + errmsg;
 
             // Error 251 (NoSuchTransaction): close poisoned connection, throw retriable exception
             if (code == 251) {
                 log.warn("Transient transaction error on connection (code 251) — closing connection: {}", errmsg);
                 close();
-                throw new MorphiumDriverNetworkException(formattedMsg);
+                var ex = new MorphiumDriverNetworkException(formattedMsg);
+                ex.setMongoCode(code);
+                throw ex;
             }
 
-            throw new MorphiumDriverException(formattedMsg);
+            var ex = new MorphiumDriverException(formattedMsg);
+            ex.setMongoCode(codeObj);
+            throw ex;
         }
 
         return reply.getFirstDoc();
@@ -868,10 +869,14 @@ public class SingleMongoConnection implements MongoConnection {
             if (code == 251) {
                 log.warn("Transient transaction error on connection (code 251) — closing connection: {}", errmsg);
                 close();
-                throw new MorphiumDriverNetworkException(errmsg);
+                var ex = new MorphiumDriverNetworkException(errmsg);
+                ex.setMongoCode(code);
+                throw ex;
             }
 
-            throw new MorphiumDriverException(errmsg);
+            var ex = new MorphiumDriverException(errmsg);
+            ex.setMongoCode(codeObj);
+            throw ex;
         }
     }
 


### PR DESCRIPTION
Hi Stephan,

you mentioned in your PR #160 review that `errMsg.contains("251")` in `WriteMongoCommand` is fragile — a port number or other context could theoretically contain "251". Here's the proper fix:

## Summary

- **`SingleMongoConnection`**: `checkForError()` and `readSingleAnswer()` now set `mongoCode` on all thrown exceptions — the field already existed on `MorphiumDriverException` but was never populated
- **`WriteMongoCommand`**: replaces `errMsg.contains("251")` with `e.getMongoCode() instanceof Number mc && mc.intValue() == 251` — proper integer comparison instead of string matching

## Test plan

- [x] `mvn clean install -DskipTests` compiles cleanly
- [ ] Existing tests (no new ones needed — behavior is identical, only the detection method is more robust)

Cheers!