### PR TITLE
fix: thread-safety in AnnotationAndReflectionHelper and ObjectMapperImpl

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/AnnotationAndReflectionHelper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/AnnotationAndReflectionHelper.java
@@ -42,7 +42,7 @@ public class AnnotationAndReflectionHelper {
     private final Map < Class<?>, List<Field >> fieldListCache;
     private final ConcurrentHashMap < Class<?>, Map<Class<? extends Annotation >, Annotation >> annotationCache;
     private final Map < Class<?>, Map<String, String >> fieldNameCache;
-    private static ConcurrentHashMap<String, String> classNameByType;
+    private static volatile ConcurrentHashMap<String, String> classNameByType;
     private Map<String, Field> fieldCache;
     private Map<String, List<String>> fieldAnnotationListCache;
     private Map<Class<?>, Map < Class<? extends Annotation >, Method >> lifeCycleMethods;
@@ -65,8 +65,13 @@ public class AnnotationAndReflectionHelper {
         this.fieldNameCache = new ConcurrentHashMap<>();
 
         if (classNameByType == null) {
-            classNameByType = new ConcurrentHashMap<>();
-            init();
+            synchronized (AnnotationAndReflectionHelper.class) {
+                if (classNameByType == null) {
+                    ConcurrentHashMap<String, String> tmp = new ConcurrentHashMap<>();
+                    init(tmp);
+                    classNameByType = tmp; // volatile write AFTER population
+                }
+            }
         }
     }
 
@@ -82,7 +87,7 @@ public class AnnotationAndReflectionHelper {
     public void disableConvertCamelCase() {
         ccc = false;
     }
-    private void init() {
+    private void init(ConcurrentHashMap<String, String> target) {
         //initializing type IDs
         try (ScanResult scanResult =
                                     new ClassGraph()
@@ -106,10 +111,10 @@ public class AnnotationAndReflectionHelper {
                         for (AnnotationParameterValue param : ai.getParameterValues()) {
                             //logger.info("Class " + cn + "   Param " + param.getName() + " = " + param.getValue());
                             if (param.getName().equals("typeId")) {
-                                classNameByType.put(param.getValue().toString(), cn);
+                                target.put(param.getValue().toString(), cn);
                             }
 
-                            classNameByType.put(cn, cn);
+                            target.put(cn, cn);
                         }
                     }
                 }

--- a/morphium-core/src/main/java/de/caluga/morphium/ObjectMapperImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/ObjectMapperImpl.java
@@ -89,11 +89,11 @@ public class ObjectMapperImpl implements MorphiumObjectMapper {
     private final JSONParser jsonParser = new JSONParser();
 
     private final ArrayList < Class<?>> mongoTypes;
-    private AnnotationAndReflectionHelper annotationHelper = new AnnotationAndReflectionHelper(true);
+    private volatile AnnotationAndReflectionHelper annotationHelper = new AnnotationAndReflectionHelper(true);
     private final Map < Class<?>, MorphiumTypeMapper> customMappers = new ConcurrentHashMap<>();
     private final Map < String, Class<?>> classByCollectionName = new ConcurrentHashMap<>();
     private static volatile Map<String, Class<?>> cachedClassByCollectionName = null;
-    private Morphium morphium;
+    private volatile Morphium morphium;
 
     // Tracks objects currently being serialized to detect circular @Reference chains
     private static final ThreadLocal<Set<Object>> serializingObjects =


### PR DESCRIPTION
Hi Stephan,

as discussed in #164 — here are the thread-safety bugfixes extracted into a standalone PR.

## Changes

**AnnotationAndReflectionHelper:**
- `classNameByType` is now `volatile` — ensures cross-thread visibility of the field reference
- Constructor uses proper double-checked locking (DCL) instead of the previous check-then-act pattern that allowed concurrent threads to both enter `init()`
- `init()` now populates a temporary map first, then assigns it via a single volatile write — prevents other threads from seeing a partially-populated map

**ObjectMapperImpl:**
- `morphium` field is now `volatile` — written in `setMorphium()`, read from other threads
- `annotationHelper` field is now `volatile` — written in `setMorphium()` and `setAnnotationHelper()`, read extensively

## Why this matters

Without `volatile`, the JMM does not guarantee that a write to these fields from one thread is visible to reads from other threads. In practice this can cause:
- Duplicate ClassGraph scans (wasted startup time)
- Stale reads of `null` for `morphium` or `annotationHelper` in concurrent scenarios

## Test plan

- Pure field-modifier changes, no behavioral change
- All existing tests continue to pass (InMemDriver)

Cheers,
Heiko