### PR TITLE
feat: add registerTypeIds() pre-registration hook

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/AnnotationAndReflectionHelper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/AnnotationAndReflectionHelper.java
@@ -43,6 +43,7 @@ public class AnnotationAndReflectionHelper {
     private final ConcurrentHashMap < Class<?>, Map<Class<? extends Annotation >, Annotation >> annotationCache;
     private final Map < Class<?>, Map<String, String >> fieldNameCache;
     private static volatile ConcurrentHashMap<String, String> classNameByType;
+    private static volatile Map<String, String> preRegisteredTypeIds;
     private Map<String, Field> fieldCache;
     private Map<String, List<String>> fieldAnnotationListCache;
     private Map<Class<?>, Map < Class<? extends Annotation >, Method >> lifeCycleMethods;
@@ -87,8 +88,37 @@ public class AnnotationAndReflectionHelper {
     public void disableConvertCamelCase() {
         ccc = false;
     }
+    /**
+     * Pre-register entity type IDs so that the ClassGraph classpath scan can be skipped.
+     * Framework integrations (Quarkus, Spring Boot) call this before creating any Morphium instance.
+     * If the map is non-empty when the first AnnotationAndReflectionHelper is created,
+     * the ClassGraph scan is skipped entirely.
+     *
+     * @param typeIds map of typeId (or FQCN) to fully-qualified class name
+     */
+    public static void registerTypeIds(Map<String, String> typeIds) {
+        preRegisteredTypeIds = typeIds;
+    }
+
+    /**
+     * Resets the static type-ID cache so that the next {@code AnnotationAndReflectionHelper}
+     * instantiation re-initialises it (either from pre-registered IDs or via ClassGraph).
+     * Useful for hot-reload scenarios (e.g. Quarkus dev mode).
+     */
+    public static synchronized void clearTypeIdCache() {
+        classNameByType = null;
+    }
+
     private void init(ConcurrentHashMap<String, String> target) {
-        //initializing type IDs
+        // If type IDs were pre-registered by a framework, use them and skip ClassGraph scan
+        Map<String, String> pre = preRegisteredTypeIds;
+        if (pre != null && !pre.isEmpty()) {
+            target.putAll(pre);
+            logger.info("Using {} pre-registered entity type IDs, skipping ClassGraph scan", pre.size());
+            return;
+        }
+
+        //initializing type IDs via ClassGraph classpath scan
         try (ScanResult scanResult =
                                     new ClassGraph()
             //                     .verbose()             // Enable verbose logging


### PR DESCRIPTION
Hi Stephan,

this implements exactly what you proposed in #164 — a minimal pre-registration hook in `AnnotationAndReflectionHelper`.

## Changes

**~20 lines in `AnnotationAndReflectionHelper.java`:**

```java
private static volatile Map<String, String> preRegisteredTypeIds;

public static void registerTypeIds(Map<String, String> typeIds) {
    preRegisteredTypeIds = typeIds;
}

public static synchronized void clearTypeIdCache() {
    classNameByType = null;
}
```

In `init()`: if `preRegisteredTypeIds` is non-empty, use it and skip ClassGraph scan.

**Also includes the thread-safety fixes from PR #165** (volatile, proper DCL) since both touch the same code path. If #165 is merged first, I'll rebase to avoid duplication.

## What this enables

- **Quarkus extension** calls `registerTypeIds()` with Jandex-discovered entities at build time -> no ClassGraph scan at runtime -> GraalVM native works
- **Spring Boot module** calls `registerTypeIds()` with ClassGraph-scanned entities before Morphium starts -> avoids redundant scan
- **Standalone users** notice zero change — ClassGraph remains a normal dependency, the scan runs as before

## What this does NOT do

- ClassGraph stays non-optional (normal dependency)
- No EntityRegistry singleton, no ClassGraphHelper, no 3-tier discovery
- No breaking changes to any existing API

## Test plan

- Compilation verified, all existing tests pass
- Both quarkus-morphium and spring-boot-morphium already use this API and their tests pass

Cheers,
Heiko