### PR TITLE
fix: Cosmos DB compatibility — SCRAM fallback + HelloResult type handling

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/HelloResult.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/HelloResult.java
@@ -63,7 +63,16 @@ public class HelloResult {
             try {
                 if (msg.containsKey(f.getName())) {
                     f.setAccessible(true);
-                    f.set(ret, msg.get(f.getName()));
+                    Object value = msg.get(f.getName());
+                    // Cosmos DB returns localTime as Long (epoch millis) instead of Date
+                    if (value instanceof Long && f.getType().equals(Date.class)) {
+                        value = new Date((Long) value);
+                    }
+                    // Cosmos DB may return saslSupportedMechs as a single String instead of List
+                    if (value instanceof String && f.getType().equals(List.class)) {
+                        value = List.of((String) value);
+                    }
+                    f.set(ret, value);
                 }
             } catch (Exception e) {
                 //something went wrong...

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnection.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnection.java
@@ -259,13 +259,14 @@ public class SingleMongoConnection implements MongoConnection {
             // Standard SCRAM-SHA-1 / SCRAM-SHA-256 authentication
             SaslAuthCommand auth = new SaslAuthCommand(this);
 
-            if (hello.getSaslSupportedMechs() == null || hello.getSaslSupportedMechs().isEmpty()) {
-                throw new MorphiumDriverException("Authentication failed - no mechanisms offered!");
-            }
-
             auth.setUser(user).setDb(authDb).setPassword(password);
 
-            if (hello.getSaslSupportedMechs().contains("SCRAM-SHA-256")) {
+            if (hello.getSaslSupportedMechs() == null || hello.getSaslSupportedMechs().isEmpty()) {
+                // Cosmos DB does not return saslSupportedMechs in hello response —
+                // default to SCRAM-SHA-256 which is the standard mechanism.
+                log.warn("No SASL mechanisms offered by server — defaulting to SCRAM-SHA-256");
+                auth.setMechanism("SCRAM-SHA-256");
+            } else if (hello.getSaslSupportedMechs().contains("SCRAM-SHA-256")) {
                 auth.setMechanism("SCRAM-SHA-256");
             } else {
                 auth.setMechanism("SCRAM-SHA-1");

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/HelloResultTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/HelloResultTest.java
@@ -1,0 +1,136 @@
+package de.caluga.test.morphium.driver;
+
+import de.caluga.morphium.driver.Doc;
+import de.caluga.morphium.driver.wire.HelloResult;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+public class HelloResultTest {
+
+    @Test
+    public void testFromMsgStandardMongoDB() {
+        // Standard MongoDB hello response — all types correct
+        Doc msg = Doc.of("helloOk", true, "isWritablePrimary", true,
+                "maxBsonObjectSize", 16777216, "maxMessageSizeBytes", 48000000)
+            .add("localTime", new Date(1711200000000L))
+            .add("minWireVersion", 0)
+            .add("maxWireVersion", 21)
+            .add("readOnly", false)
+            .add("ok", 1.0)
+            .add("saslSupportedMechs", List.of("SCRAM-SHA-256", "SCRAM-SHA-1"));
+
+        HelloResult result = HelloResult.fromMsg(msg);
+
+        assertNotNull(result);
+        assertTrue(result.isOk());
+        assertEquals(true, result.getHelloOk());
+        assertEquals(true, result.getWritablePrimary());
+        assertEquals(new Date(1711200000000L), result.getLocalTime());
+        assertEquals(List.of("SCRAM-SHA-256", "SCRAM-SHA-1"), result.getSaslSupportedMechs());
+        assertEquals(0, result.getMinWireVersion());
+        assertEquals(21, result.getMaxWireVersion());
+    }
+
+    @Test
+    public void testFromMsgCosmosDBLocalTimeAsLong() {
+        // Cosmos DB returns localTime as Long (epoch millis) instead of Date
+        long epochMillis = 1711200000000L;
+        Doc msg = Doc.of("helloOk", true, "localTime", epochMillis, "ok", 1.0);
+
+        HelloResult result = HelloResult.fromMsg(msg);
+
+        assertNotNull(result);
+        assertNotNull(result.getLocalTime(), "localTime should be converted from Long to Date");
+        assertEquals(new Date(epochMillis), result.getLocalTime());
+    }
+
+    @Test
+    public void testFromMsgCosmosDBSaslMechsAsString() {
+        // Cosmos DB may return saslSupportedMechs as a single String instead of List
+        Doc msg = Doc.of("helloOk", true, "saslSupportedMechs", "SCRAM-SHA-256", "ok", 1.0);
+
+        HelloResult result = HelloResult.fromMsg(msg);
+
+        assertNotNull(result);
+        assertNotNull(result.getSaslSupportedMechs(), "saslSupportedMechs should be converted from String to List");
+        assertEquals(List.of("SCRAM-SHA-256"), result.getSaslSupportedMechs());
+    }
+
+    @Test
+    public void testFromMsgCosmosDBBothTypeMismatches() {
+        // Cosmos DB response with both type mismatches at once
+        long epochMillis = 1711200000000L;
+        Doc msg = Doc.of("helloOk", true, "isWritablePrimary", true,
+                "localTime", epochMillis, "saslSupportedMechs", "SCRAM-SHA-256")
+            .add("maxWireVersion", 13)
+            .add("ok", 1.0);
+
+        HelloResult result = HelloResult.fromMsg(msg);
+
+        assertNotNull(result);
+        assertEquals(new Date(epochMillis), result.getLocalTime());
+        assertEquals(List.of("SCRAM-SHA-256"), result.getSaslSupportedMechs());
+        assertEquals(13, result.getMaxWireVersion());
+        assertTrue(result.isOk());
+    }
+
+    @Test
+    public void testFromMsgNoSaslMechanisms() {
+        // Cosmos DB may not return saslSupportedMechs at all
+        Doc msg = Doc.of("helloOk", true, "isWritablePrimary", true, "ok", 1.0);
+
+        HelloResult result = HelloResult.fromMsg(msg);
+
+        assertNotNull(result);
+        assertNull(result.getSaslSupportedMechs(), "Missing field should remain null");
+    }
+
+    @Test
+    public void testFromMsgNullReturnsNull() {
+        assertNull(HelloResult.fromMsg(null));
+    }
+
+    @Test
+    public void testToMsgRoundTrip() {
+        HelloResult original = new HelloResult()
+            .setHelloOk(true)
+            .setWritablePrimary(true)
+            .setMaxBsonObjectSize(16777216)
+            .setMaxMessageSizeBytes(48000000)
+            .setLocalTime(new Date(1711200000000L))
+            .setSaslSupportedMechs(List.of("SCRAM-SHA-256"))
+            .setMinWireVersion(0)
+            .setMaxWireVersion(21)
+            .setOk(1.0);
+
+        Map<String, Object> msg = original.toMsg();
+        HelloResult restored = HelloResult.fromMsg(msg);
+
+        assertEquals(original.getHelloOk(), restored.getHelloOk());
+        assertEquals(original.getWritablePrimary(), restored.getWritablePrimary());
+        assertEquals(original.getMaxBsonObjectSize(), restored.getMaxBsonObjectSize());
+        assertEquals(original.getLocalTime(), restored.getLocalTime());
+        assertEquals(original.getSaslSupportedMechs(), restored.getSaslSupportedMechs());
+        assertEquals(original.getMinWireVersion(), restored.getMinWireVersion());
+        assertEquals(original.getMaxWireVersion(), restored.getMaxWireVersion());
+        assertTrue(restored.isOk());
+    }
+
+    @Test
+    public void testFromMsgMorphiumServerBackwardCompat() {
+        // Old servers send "morphiumServer" instead of "poppyDB"
+        Doc msg = Doc.of("helloOk", true, "morphiumServer", true, "ok", 1.0);
+
+        HelloResult result = HelloResult.fromMsg(msg);
+
+        assertNotNull(result);
+        assertEquals(true, result.getPoppyDB());
+    }
+}


### PR DESCRIPTION
Hi Stephan,

we ran into this when deploying against Azure Cosmos DB (MongoDB API) in China.

## Problem

Two issues prevent Morphium from connecting to Azure Cosmos DB for MongoDB:

### 1. No SASL mechanism fallback
Cosmos DB does not include `saslSupportedMechs` in its `hello` response. `SingleMongoConnection.getHelloResult()` throws `"Authentication failed - no mechanisms offered!"` on every connection attempt, which prevents the application from starting entirely.

### 2. HelloResult type mismatches
Cosmos DB returns non-standard types in the `hello` response that cause `IllegalArgumentException` in the reflection-based `fromMsg()` parser:
- `localTime` is returned as `Long` (epoch millis) instead of `Date`
- `saslSupportedMechs` is returned as a single `String` instead of `List<String>`

These silently fail (caught exception), leaving fields as `null` — which then cascades into issue 1 even when Cosmos DB does advertise a mechanism.

## Fix

**Commit 1 — SCRAM fallback** (`SingleMongoConnection.java`):
Instead of throwing when no mechanisms are advertised, default to SCRAM-SHA-256. This is consistent with the MongoDB spec: SCRAM-SHA-256 is the default mechanism for MongoDB 4.0+ and is the only mechanism Cosmos DB supports for password auth.

**Commit 2 — Type coercion** (`HelloResult.java`):
Add type conversion in `fromMsg()` before setting fields via reflection:
- `Long` → `new Date(longValue)` for `Date` fields
- `String` → `List.of(stringValue)` for `List` fields

**Commit 3 — Unit tests** (`HelloResultTest.java`):
8 unit tests covering the type coercion, standard MongoDB responses, round-trip serialization, and edge cases (missing fields, null input).

## Test plan

- [x] `mvn clean install -DskipTests` compiles cleanly
- [x] 8 new unit tests pass (`HelloResultTest`, tag `core`)
- [x] Tested against Azure Cosmos DB for MongoDB (China region, port 10255) — connection succeeds, Quarkus starts in 22s
- [x] No behavioral change for standard MongoDB (fields are only converted when types don't match)

Cheers,
Heiko