### PR TITLE
fix: align ConnectionTestBase SASL check with Cosmos DB fallback

### DIFF
--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/ConnectionTestBase.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/ConnectionTestBase.java
@@ -18,7 +18,10 @@ public class ConnectionTestBase {
         con.setCredentials("admin", "test", "test");
         var hello = con.connect(new DriverMock(), "localhost", 27017);
         if (hello.getSaslSupportedMechs() == null || hello.getSaslSupportedMechs().isEmpty()) {
-            throw new MorphiumDriverException("Authentication failure!");
+            // Cosmos DB (and potentially other wire-compatible servers) may not return
+            // saslSupportedMechs. SingleMongoConnection.connect() already handles this
+            // by falling back to SCRAM-SHA-256, so authentication succeeded at this point.
+            log.warn("Server did not advertise SASL mechanisms — authentication used SCRAM-SHA-256 fallback");
         }
         return con;
     }


### PR DESCRIPTION
Hi Stephan,

as you pointed out in your PR #167 review, `ConnectionTestBase.getConnection()` has the same hard-fail pattern for missing `saslSupportedMechs`. Since `SingleMongoConnection.connect()` now handles this internally by falling back to SCRAM-SHA-256, the exception here is a false positive — authentication has already succeeded at that point.

Replaced the exception with a warning log to match the production behavior. Admittedly, integration tests hitting this path via Cosmos DB are rather hypothetical since there's no local Cosmos DB emulator available — but it keeps the test code aligned with the production logic and avoids a confusing hard-fail if any other wire-compatible server omits `saslSupportedMechs`.

Best regards!