### PR TITLE
feat: add defaultQueryTimeoutMS to decouple query timeout from connection pool wait time

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
@@ -440,6 +440,11 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             .setExplain(isExplain())
             .setAllowDiskUse(isUseDisk());
 
+            int timeout = morphium.getConfig().connectionSettings().getDefaultQueryTimeoutMS();
+            if (timeout > 0) {
+                cmd.setMaxWaitTime(timeout);
+            }
+
             if (collation != null) cmd.setCollation(Doc.of(getCollation().toQueryObject()));
             if (morphium.getReadConcernForClass(getSearchType())!=null){
                 cmd.setReadConcern(Map.of("level",morphium.getReadConcernForClass(getSearchType()).name()));

--- a/morphium-core/src/main/java/de/caluga/morphium/config/ConnectionSettings.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/config/ConnectionSettings.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class ConnectionSettings extends Settings {
 
     private int maxWaitTime = 2000;
+    private int defaultQueryTimeoutMS = 0;
     private int connectionTimeout = 0;
     private int heartbeatFrequency = 1000;
     private int maxConnections = 250;
@@ -30,6 +31,26 @@ public class ConnectionSettings extends Settings {
         this.maxWaitTime = maxWaitTime;
         return this;
     }
+
+    /**
+     * Default server-side time limit (in milliseconds) for queries when no
+     * per-query {@code maxTimeMS} is set via {@code Query.setMaxTimeMS()}.
+     * <p>
+     * MongoDB enforces this as {@code maxTimeMS} across the entire cursor
+     * lifecycle (initial {@code find} + all {@code getMore} operations).
+     * <p>
+     * Default is {@code 0}, which means no server-side time limit
+     * (Morphium will set {@code noCursorTimeout} instead).
+     */
+    public int getDefaultQueryTimeoutMS() {
+        return defaultQueryTimeoutMS;
+    }
+
+    public ConnectionSettings setDefaultQueryTimeoutMS(int defaultQueryTimeoutMS) {
+        this.defaultQueryTimeoutMS = defaultQueryTimeoutMS;
+        return this;
+    }
+
     public int getConnectionTimeout() {
         return connectionTimeout;
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
@@ -2574,7 +2574,7 @@ public class Query<T> implements Cloneable {
 
     public int getMaxTimeMS() {
         if (maxTimeMS == null) {
-            return morphium.getConfig().connectionSettings().getMaxWaitTime();
+            return morphium.getConfig().connectionSettings().getDefaultQueryTimeoutMS();
         } else {
             return maxTimeMS;
         }

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/DefaultQueryTimeoutTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/DefaultQueryTimeoutTest.java
@@ -1,0 +1,116 @@
+package de.caluga.test.mongo.suite.inmem;
+
+import de.caluga.morphium.MorphiumConfig;
+import de.caluga.morphium.aggregation.AggregatorImpl;
+import de.caluga.morphium.driver.commands.AggregateMongoCommand;
+import de.caluga.morphium.query.Query;
+import de.caluga.test.mongo.suite.data.UncachedObject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for {@code ConnectionSettings.defaultQueryTimeoutMS} — verifies that the
+ * new setting is used as fallback for {@code Query.getMaxTimeMS()} and applied to
+ * aggregation commands, while per-query overrides still take precedence.
+ */
+@Tag("inmemory")
+public class DefaultQueryTimeoutTest extends MorphiumInMemTestBase {
+
+    @Test
+    public void queryFallsBackToDefaultQueryTimeoutMS() {
+        // Default is 0 (no limit)
+        Query<UncachedObject> q = morphium.createQueryFor(UncachedObject.class);
+        assertEquals(0, q.getMaxTimeMS(), "Default should be 0 (no limit)");
+    }
+
+    @Test
+    public void queryUsesConfiguredDefaultQueryTimeoutMS() {
+        morphium.getConfig().connectionSettings().setDefaultQueryTimeoutMS(45000);
+        try {
+            Query<UncachedObject> q = morphium.createQueryFor(UncachedObject.class);
+            assertEquals(45000, q.getMaxTimeMS(),
+                    "Query should fall back to defaultQueryTimeoutMS from config");
+        } finally {
+            morphium.getConfig().connectionSettings().setDefaultQueryTimeoutMS(0);
+        }
+    }
+
+    @Test
+    public void perQueryMaxTimeMSOverridesDefault() {
+        morphium.getConfig().connectionSettings().setDefaultQueryTimeoutMS(45000);
+        try {
+            Query<UncachedObject> q = morphium.createQueryFor(UncachedObject.class);
+            q.setMaxTimeMS(5000);
+            assertEquals(5000, q.getMaxTimeMS(),
+                    "Per-query setMaxTimeMS should override the config default");
+        } finally {
+            morphium.getConfig().connectionSettings().setDefaultQueryTimeoutMS(0);
+        }
+    }
+
+    @Test
+    public void queryDoesNotUseMaxWaitTimeAsFallback() {
+        // maxWaitTime is 1550 (set in MorphiumInMemTestBase.setup)
+        // With the fix, Query should NOT fall back to maxWaitTime
+        Query<UncachedObject> q = morphium.createQueryFor(UncachedObject.class);
+        assertEquals(0, q.getMaxTimeMS(),
+                "Query should NOT fall back to maxWaitTime (1550) — should use defaultQueryTimeoutMS (0)");
+    }
+
+    @Test
+    public void connectionSettingsDefaultIsZero() {
+        // Verify that a fresh ConnectionSettings has defaultQueryTimeoutMS = 0
+        MorphiumConfig cfg = new MorphiumConfig();
+        assertEquals(0, cfg.connectionSettings().getDefaultQueryTimeoutMS(),
+                "Default value of defaultQueryTimeoutMS should be 0");
+    }
+
+    @Test
+    public void connectionSettingsSetterAndGetter() {
+        MorphiumConfig cfg = new MorphiumConfig();
+        cfg.connectionSettings().setDefaultQueryTimeoutMS(60000);
+        assertEquals(60000, cfg.connectionSettings().getDefaultQueryTimeoutMS());
+        cfg.connectionSettings().setDefaultQueryTimeoutMS(0);
+        assertEquals(0, cfg.connectionSettings().getDefaultQueryTimeoutMS());
+    }
+
+    @Test
+    public void aggregatorImplAppliesDefaultQueryTimeoutMS() {
+        morphium.getConfig().connectionSettings().setDefaultQueryTimeoutMS(30000);
+        try {
+            createUncachedObjects(5);
+            // Use AggregatorImpl directly (not InMemAggregator) to test the timeout logic.
+            // InMemAggregator overrides getAggregateCmd() and does not apply timeouts
+            // (which is correct — InMem has no server-side maxTimeMS).
+            AggregatorImpl<UncachedObject, UncachedObject> agg = new AggregatorImpl<>(morphium, UncachedObject.class, UncachedObject.class);
+            agg.match(morphium.createQueryFor(UncachedObject.class));
+            AggregateMongoCommand cmd = agg.getAggregateCmd();
+            try {
+                assertEquals(Integer.valueOf(30000), cmd.getMaxWaitTime(),
+                        "Aggregation command should have defaultQueryTimeoutMS applied");
+            } finally {
+                cmd.releaseConnection();
+            }
+        } finally {
+            morphium.getConfig().connectionSettings().setDefaultQueryTimeoutMS(0);
+        }
+    }
+
+    @Test
+    public void aggregatorImplOmitsTimeoutWhenDefaultIsZero() {
+        morphium.getConfig().connectionSettings().setDefaultQueryTimeoutMS(0);
+        createUncachedObjects(5);
+        AggregatorImpl<UncachedObject, UncachedObject> agg = new AggregatorImpl<>(morphium, UncachedObject.class, UncachedObject.class);
+        agg.match(morphium.createQueryFor(UncachedObject.class));
+        AggregateMongoCommand cmd = agg.getAggregateCmd();
+        try {
+            assertNull(cmd.getMaxWaitTime(),
+                    "Aggregation command should NOT set maxWaitTime when defaultQueryTimeoutMS is 0");
+        } finally {
+            cmd.releaseConnection();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `ConnectionSettings.defaultQueryTimeoutMS` (default: `0` = no server-side time limit) as a dedicated config setting for query/aggregation execution timeouts, decoupling it from `maxWaitTime` which remains responsible for connection pool wait, driver-level timeouts, and change streams.

- `Query.getMaxTimeMS()` now falls back to `defaultQueryTimeoutMS` instead of `maxWaitTime`
- `AggregatorImpl.getAggregateCmd()` applies `defaultQueryTimeoutMS` to aggregate commands when > 0
- Per-query overrides via `Query.setMaxTimeMS()` still take precedence
- No breaking change — `maxWaitTime` behavior is unchanged for all existing use cases

## Motivation

`maxWaitTime` (default: 2000ms) was used as `maxTimeMS` on every MongoDB `find` command, limiting the server-side execution time across the entire cursor lifecycle (initial `find` + all `getMore` operations). With the 2s default, any query returning large result sets that needs > 2 seconds — including cursor iteration — gets killed with **Error 50 (`ExceededTimeLimit`)**. This is intermittent and hard to diagnose.

See #181 for the full root cause analysis and discussion.

## Changes

| File | Change |
|------|--------|
| `ConnectionSettings.java` | New field `defaultQueryTimeoutMS` (default `0`) with getter/setter |
| `Query.java` | `getMaxTimeMS()` falls back to `getDefaultQueryTimeoutMS()` instead of `getMaxWaitTime()` |
| `AggregatorImpl.java` | `getAggregateCmd()` applies `defaultQueryTimeoutMS` to aggregate commands |
| `DefaultQueryTimeoutTest.java` | 8 InMem test cases covering all scenarios |

## Test plan

- [x] 8 unit tests (InMem) covering Query fallback, per-query override, Aggregation, zero-default behavior
- [x] All existing tests pass (no regressions)

Resolves #181