### PR TITLE
fix: add missing return after saveList() in save(T, String, AsyncOperationCallback)

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/MorphiumBase.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/MorphiumBase.java
@@ -702,8 +702,10 @@ public abstract class MorphiumBase {
     public <T> void save(T o, String collection, final AsyncOperationCallback<T> callback) {
         if (o instanceof List) {
             saveList((List) o, collection, callback);
+            return;
         } else if (o instanceof Collection) {
             saveList(new ArrayList<>((Collection) o), collection, callback);
+            return;
         }
 
         // Orphan removal: collect old references before store

--- a/morphium-core/src/test/java/de/caluga/test/morphium/SaveListWithCollectionTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/SaveListWithCollectionTest.java
@@ -1,0 +1,77 @@
+package de.caluga.test.morphium;
+
+import de.caluga.test.mongo.suite.data.UncachedObject;
+import de.caluga.test.mongo.suite.inmem.MorphiumInMemTestBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for missing {@code return} in
+ * {@code MorphiumBase.save(T o, String collection, AsyncOperationCallback callback)}.
+ *
+ * Before the fix, passing a List to {@code save(list, collection, null)} would
+ * first correctly call {@code saveList()}, then fall through and attempt to
+ * treat the List itself as an entity — causing exceptions or silent corruption.
+ *
+ * @see <a href="https://github.com/sboesebeck/morphium/issues/XXX">GitHub Issue</a>
+ */
+class SaveListWithCollectionTest extends MorphiumInMemTestBase {
+
+    private static final String COLLECTION = "uncached_object";
+
+    @Test
+    void save_list_with_collection_should_not_fall_through() {
+        var o1 = new UncachedObject("one", 1);
+        var o2 = new UncachedObject("two", 2);
+
+        // This calls save(T o, String collection, callback) with a List — the buggy path
+        morphium.store(Arrays.asList(o1, o2), COLLECTION);
+
+        var result = morphium.createQueryFor(UncachedObject.class)
+                .setCollectionName(COLLECTION)
+                .asList();
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(UncachedObject::getStrValue)
+                .containsExactlyInAnyOrder("one", "two");
+    }
+
+    @Test
+    void save_collection_with_collection_should_not_fall_through() {
+        var o1 = new UncachedObject("alpha", 10);
+        var o2 = new UncachedObject("beta", 20);
+
+        // HashSet is a Collection but not a List — tests the else-if branch
+        var set = new HashSet<>(Arrays.asList(o1, o2));
+        morphium.store(set, COLLECTION);
+
+        var result = morphium.createQueryFor(UncachedObject.class)
+                .setCollectionName(COLLECTION)
+                .asList();
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(UncachedObject::getStrValue)
+                .containsExactlyInAnyOrder("alpha", "beta");
+    }
+
+    @Test
+    void save_single_entity_with_collection_still_works() {
+        var o1 = new UncachedObject("single", 99);
+
+        // Single entity path must still work after the fix
+        morphium.store(o1, COLLECTION);
+
+        var result = morphium.createQueryFor(UncachedObject.class)
+                .setCollectionName(COLLECTION)
+                .asList();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getStrValue()).isEqualTo("single");
+    }
+}


### PR DESCRIPTION
## Summary

Hey Stephan! Found a small but sneaky bug in `MorphiumBase.save()` while working with the `store(list, collection)` path.

The three-argument `save(T o, String collection, AsyncOperationCallback callback)` (line 702) correctly delegates to `saveList()` when the object is a `List` or `Collection`, but unlike the other two `save()` overloads (lines 669 and 684 — which use an `else` block) it is missing `return` statements after the delegation. This causes the code to fall through and additionally attempt to treat the List/Collection itself as a single entity — calling `getARHelper().getId()` on a List and then `insert()`/`store()` with it.

The bug also affects the convenience wrappers `store(T o, String collection)` and `store(T o, String collection, callback)` since they delegate to the same method.

## Motivation

The two other `save()` overloads handle this correctly with an `else` block, so this looks like it was just missed when the three-argument variant was added. In practice, calling `store(list, "myCollection")` would save the list elements correctly via `saveList()`, but then crash or silently misbehave when the code falls through to the single-entity path.

## Changes

| File | Change |
|------|--------|
| `MorphiumBase.java` | Add `return;` after both `saveList()` calls in the three-argument `save()` |
| `SaveListWithCollectionTest.java` | 3 InMem regression tests covering List, Collection (HashSet), and single-entity paths |

## Impact

| Method | Before fix | After fix |
|--------|-----------|-----------|
| `save(list)` | OK (has else) | OK |
| `save(list, callback)` | OK (has else) | OK |
| `save(list, collection, callback)` | **Bug** — falls through | **Fixed** — returns |
| `store(list, collection)` | **Bug** — delegates to above | **Fixed** |
| `store(list, collection, callback)` | **Bug** — delegates to above | **Fixed** |

## Test plan

- [x] 3 regression tests (InMem): List path, Collection (Set) path, single entity path
- [x] All tests pass, no regressions