### PR TITLE
feat: batch versioned-entity updates in store(List) for reduced pool overhead

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -215,6 +215,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
         morphium.getARHelper().setValue(entity, 1L, vField);
     }
 
+
     private void setIdIfNull(Object record) throws IllegalAccessException {
         Field idf = morphium.getARHelper().getIdField(record);
 
@@ -573,7 +574,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                                 }
                             }
                         }
-                        // Process versioned updates with optimistic locking
+                        // Process versioned updates with optimistic locking — BATCHED
                         for (Map.Entry<Class, List<Object>> es : toVersionedUpdate.entrySet()) {
                             Class c = es.getKey();
                             List<String> vFields = morphium.getARHelper().getFields(c, Version.class);
@@ -591,55 +592,86 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                             String coll = cln != null ? cln : morphium.getMapper().getCollectionName(c);
                             checkIndexAndCaps(c, coll, callback);
 
-                            for (Object entity : es.getValue()) {
-                                Object entityId = morphium.getId(entity);
-                                Object rawVersion = morphium.getARHelper().getValue(entity, javaVersionField);
-                                long currentVersion = rawVersion instanceof Number ? ((Number) rawVersion).longValue() : 0L;
+                            List<Object> entities = es.getValue();
 
-                                // Serialise all fields; then strip _id and version from $set
+                            // Pre-build all update operations (parallel arrays)
+                            Object[] entityIds = new Object[entities.size()];
+                            long[] currentVersions = new long[entities.size()];
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object>[] filters = new Map[entities.size()];
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object>[] updateDocs = new Map[entities.size()];
+
+                            for (int i = 0; i < entities.size(); i++) {
+                                Object entity = entities.get(i);
+                                entityIds[i] = morphium.getId(entity);
+                                Object rawVersion = morphium.getARHelper().getValue(entity, javaVersionField);
+                                currentVersions[i] = rawVersion instanceof Number n ? n.longValue() : 0L;
+
                                 Map<String, Object> serialized = new LinkedHashMap<>(morphium.getMapper().serialize(entity));
                                 serialized.remove("_id");
                                 serialized.remove(mongoVersionField);
 
-                                // Use $and so that all conditions are checked independently.
-                                // InMemoryDriver's matchesQuery returns after the first field,
-                                // so a flat multi-field map would only check _id and ignore the
-                                // version condition.  Real MongoDB also handles $and correctly.
-                                Map<String, Object> filter = Doc.of("$and", java.util.List.of(
-                                    Doc.of("_id", entityId),
-                                    Doc.of(mongoVersionField, currentVersion)));
-                                Map<String, Object> update = Doc.of(
+                                // IMPORTANT: Use $and so that InMemoryDriver checks both conditions.
+                                // A flat multi-field map would only check _id in InMemoryDriver.
+                                filters[i] = Doc.of("$and", List.of(
+                                    Doc.of("_id", entityIds[i]),
+                                    Doc.of(mongoVersionField, currentVersions[i])));
+                                updateDocs[i] = Doc.of(
                                     "$set", serialized,
                                     "$inc", Doc.of(mongoVersionField, 1L));
+                            }
+
+                            // Execute in chunks of cursorBatchSize.
+                            // Each entity's conditional update is issued individually but all
+                            // share a single connection per chunk to reduce pool overhead.
+                            // True batching (N updates in one wire message) is not possible because
+                            // MongoDB only returns aggregate matched counts — per-entity conflict
+                            // detection would be impossible (a conditional update that matches zero
+                            // documents is not an error from MongoDB's perspective, so writeErrors
+                            // does not report it, and the aggregate 'n' cannot identify which
+                            // specific entity had a version conflict).
+                            int batchSize = Math.max(1, morphium.getConfig().getCursorBatchSize());
+                            for (int offset = 0; offset < entities.size(); ) {
+                                int end = Math.min(offset + batchSize, entities.size());
 
                                 MongoConnection con = null;
-                                UpdateMongoCommand upd = null;
                                 try {
                                     con = morphium.getDriver().getPrimaryConnection(wc);
-                                    upd = new UpdateMongoCommand(con)
-                                        .setDb(morphium.getConfig().connectionSettings().getDatabase())
-                                        .setColl(coll);
-                                    upd.addUpdate(filter, update, null, false, false, null, null, null);
-                                    Map<String, Object> result = upd.execute();
+                                    for (int i = offset; i < end; i++) {
+                                        UpdateMongoCommand upd = new UpdateMongoCommand(con)
+                                            .setDb(morphium.getConfig().connectionSettings().getDatabase())
+                                            .setColl(coll);
+                                        if (wc != null) {
+                                            upd.setWriteConcern(wc.asMap());
+                                        }
+                                        upd.addUpdate(filters[i], updateDocs[i], null, false, false, null, null, null);
 
-                                    int matched = result.get("n") instanceof Number n ? n.intValue() : 0;
-                                    if (matched == 0) {
-                                        throw new VersionMismatchException(entityId, currentVersion);
-                                    }
-                                    // Reflect the new version back into the entity
-                                    morphium.getARHelper().setValue(entity, currentVersion + 1L, javaVersionField);
+                                        Map<String, Object> result = upd.execute();
+                                        // WriteMongoCommand.execute() may swap the connection on retries
+                                        // (e.g. "not primary" errors). Always capture the potentially new
+                                        // reference BEFORE any branching, so the finally block and the
+                                        // next loop iteration use the correct connection.
+                                        con = upd.getConnection();
+                                        int matched = result.get("n") instanceof Number n ? n.intValue() : 0;
 
-                                    var cache = morphium.getCache();
-                                    if (cache != null) {
-                                        cache.clearCacheIfNecessary(c);
+                                        if (matched == 0) {
+                                            throw new VersionMismatchException(entityIds[i], currentVersions[i]);
+                                        }
+                                        morphium.getARHelper().setValue(entities.get(i), currentVersions[i] + 1L, javaVersionField);
+                                        morphium.firePostStore(entities.get(i), false);
                                     }
                                 } finally {
-                                    if (upd != null) {
-                                        upd.releaseConnection();
-                                    } else if (con != null) {
+                                    if (con != null) {
                                         morphium.getDriver().releaseConnection(con);
                                     }
                                 }
+                                offset = end;
+                            }
+
+                            var cache = morphium.getCache();
+                            if (cache != null) {
+                                cache.clearCacheIfNecessary(c);
                             }
                         }
                         for (Map.Entry<Class, List<Map<String, Object>>> es : toUpdate.entrySet()) {

--- a/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -485,6 +485,16 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
         }
     }
 
+    /**
+     * Stores a list of entities. New entities (no ID or version == 0) are bulk-inserted;
+     * existing versioned entities are updated individually with optimistic locking.
+     * <p>
+     * <b>Partial-commit behavior:</b> versioned updates are executed sequentially.
+     * If entity N causes a {@link VersionMismatchException}, entities 0..N-1 are
+     * already committed to the database. The caller receives the exception but the
+     * previously committed entities are <em>not</em> rolled back (unless an external
+     * transaction is active).
+     */
     @Override
     public <T> void store(final List<T> lst, String cln, AsyncOperationCallback<T> callback) {
         if (!lst.isEmpty()) {
@@ -594,34 +604,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
 
                             List<Object> entities = es.getValue();
 
-                            // Pre-build all update operations (parallel arrays)
-                            Object[] entityIds = new Object[entities.size()];
-                            long[] currentVersions = new long[entities.size()];
-                            @SuppressWarnings("unchecked")
-                            Map<String, Object>[] filters = new Map[entities.size()];
-                            @SuppressWarnings("unchecked")
-                            Map<String, Object>[] updateDocs = new Map[entities.size()];
-
-                            for (int i = 0; i < entities.size(); i++) {
-                                Object entity = entities.get(i);
-                                entityIds[i] = morphium.getId(entity);
-                                Object rawVersion = morphium.getARHelper().getValue(entity, javaVersionField);
-                                currentVersions[i] = rawVersion instanceof Number n ? n.longValue() : 0L;
-
-                                Map<String, Object> serialized = new LinkedHashMap<>(morphium.getMapper().serialize(entity));
-                                serialized.remove("_id");
-                                serialized.remove(mongoVersionField);
-
-                                // IMPORTANT: Use $and so that InMemoryDriver checks both conditions.
-                                // A flat multi-field map would only check _id in InMemoryDriver.
-                                filters[i] = Doc.of("$and", List.of(
-                                    Doc.of("_id", entityIds[i]),
-                                    Doc.of(mongoVersionField, currentVersions[i])));
-                                updateDocs[i] = Doc.of(
-                                    "$set", serialized,
-                                    "$inc", Doc.of(mongoVersionField, 1L));
-                            }
-
                             // Execute in chunks of cursorBatchSize.
                             // Each entity's conditional update is issued individually but all
                             // share a single connection per chunk to reduce pool overhead.
@@ -639,13 +621,31 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                                 try {
                                     con = morphium.getDriver().getPrimaryConnection(wc);
                                     for (int i = offset; i < end; i++) {
+                                        Object entity = entities.get(i);
+                                        Object entityId = morphium.getId(entity);
+                                        Object rawVersion = morphium.getARHelper().getValue(entity, javaVersionField);
+                                        long currentVersion = rawVersion instanceof Number n ? n.longValue() : 0L;
+
+                                        Map<String, Object> serialized = new LinkedHashMap<>(morphium.getMapper().serialize(entity));
+                                        serialized.remove("_id");
+                                        serialized.remove(mongoVersionField);
+
+                                        // IMPORTANT: Use $and so that InMemoryDriver checks both conditions.
+                                        // A flat multi-field map would only check _id in InMemoryDriver.
+                                        Map<String, Object> filter = Doc.of("$and", List.of(
+                                            Doc.of("_id", entityId),
+                                            Doc.of(mongoVersionField, currentVersion)));
+                                        Map<String, Object> update = Doc.of(
+                                            "$set", serialized,
+                                            "$inc", Doc.of(mongoVersionField, 1L));
+
                                         UpdateMongoCommand upd = new UpdateMongoCommand(con)
                                             .setDb(morphium.getConfig().connectionSettings().getDatabase())
                                             .setColl(coll);
                                         if (wc != null) {
                                             upd.setWriteConcern(wc.asMap());
                                         }
-                                        upd.addUpdate(filters[i], updateDocs[i], null, false, false, null, null, null);
+                                        upd.addUpdate(filter, update, null, false, false, null, null, null);
 
                                         Map<String, Object> result = upd.execute();
                                         // WriteMongoCommand.execute() may swap the connection on retries
@@ -656,10 +656,10 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                                         int matched = result.get("n") instanceof Number n ? n.intValue() : 0;
 
                                         if (matched == 0) {
-                                            throw new VersionMismatchException(entityIds[i], currentVersions[i]);
+                                            throw new VersionMismatchException(entityId, currentVersion);
                                         }
-                                        morphium.getARHelper().setValue(entities.get(i), currentVersions[i] + 1L, javaVersionField);
-                                        morphium.firePostStore(entities.get(i), false);
+                                        morphium.getARHelper().setValue(entity, currentVersion + 1L, javaVersionField);
+                                        morphium.firePostStore(entity, false);
                                     }
                                 } finally {
                                     if (con != null) {

--- a/morphium-core/src/test/java/de/caluga/test/morphium/VersionAnnotationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/VersionAnnotationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -299,5 +300,118 @@ public class VersionAnnotationTest {
 
         List<VersionedStringIdEntity> all = morphium.createQueryFor(VersionedStringIdEntity.class).asList();
         assertThat(all).hasSize(2);
+    }
+
+    // -----------------------------------------------------------------------
+    // 10. Bulk update: 100 entities, all updated in one store(list) call
+    // -----------------------------------------------------------------------
+    @Test
+    public void bulkUpdate_versionedEntities_allVersionsIncremented() {
+        List<VersionedEntity> entities = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            entities.add(new VersionedEntity("entity-" + i));
+        }
+        morphium.store(entities);
+        entities.forEach(e -> assertThat(e.version).as("after insert").isEqualTo(1L));
+
+        // Modify all and bulk-update
+        entities.forEach(e -> e.name = e.name + "-updated");
+        morphium.store(entities);
+
+        // In-memory versions must all be 2
+        entities.forEach(e -> assertThat(e.version).as("in-memory version after bulk update").isEqualTo(2L));
+
+        // DB versions must all be 2
+        List<VersionedEntity> loaded = morphium.createQueryFor(VersionedEntity.class).asList();
+        assertThat(loaded).hasSize(100);
+        loaded.forEach(e -> assertThat(e.version).as("DB version after bulk update").isEqualTo(2L));
+    }
+
+    // -----------------------------------------------------------------------
+    // 11. Bulk update: one stale entity causes VersionMismatchException
+    // -----------------------------------------------------------------------
+    @Test
+    public void bulkUpdate_oneStaleEntity_throwsVersionMismatch() {
+        VersionedEntity e1 = new VersionedEntity("one");
+        VersionedEntity e2 = new VersionedEntity("two");
+        VersionedEntity e3 = new VersionedEntity("three");
+        morphium.store(Arrays.asList(e1, e2, e3));
+
+        // Advance e2 in DB independently (simulates concurrent writer)
+        VersionedEntity e2Reloaded = morphium.createQueryFor(VersionedEntity.class)
+            .f("id").eq(e2.id).get();
+        e2Reloaded.name = "two-by-other";
+        morphium.store(e2Reloaded); // e2 is now at version 2 in DB
+
+        // e2 in our list still has version=1 — stale
+        e1.name = "one-updated";
+        e2.name = "two-stale";
+        e3.name = "three-updated";
+
+        assertThatThrownBy(() -> morphium.store(Arrays.asList(e1, e2, e3)))
+            .isInstanceOf(VersionMismatchException.class);
+
+        // e1 was processed first and succeeded before the conflict on e2
+        assertThat(e1.version).isEqualTo(2L);
+        // e2 was the conflicting entity — version not incremented
+        assertThat(e2.version).isEqualTo(1L);
+        // e3 was never reached in the resolution loop
+        assertThat(e3.version).isEqualTo(1L);
+    }
+
+    // -----------------------------------------------------------------------
+    // 12. Bulk update exceeds cursorBatchSize → chunked correctly
+    // -----------------------------------------------------------------------
+    @Test
+    public void bulkUpdate_exceedsCursorBatchSize_chunkedCorrectly() {
+        int originalBatchSize = morphium.getConfig().getCursorBatchSize();
+        try {
+            // Set a small batch size to force multiple chunks
+            morphium.getConfig().setCursorBatchSize(10);
+
+            List<VersionedEntity> entities = new ArrayList<>();
+            for (int i = 0; i < 25; i++) {
+                entities.add(new VersionedEntity("chunked-" + i));
+            }
+            morphium.store(entities);
+            entities.forEach(e -> assertThat(e.version).as("after insert").isEqualTo(1L));
+
+            entities.forEach(e -> e.name = e.name + "-v2");
+            morphium.store(entities);
+
+            entities.forEach(e -> assertThat(e.version).as("in-memory version after chunked update").isEqualTo(2L));
+
+            List<VersionedEntity> loaded = morphium.createQueryFor(VersionedEntity.class).asList();
+            assertThat(loaded).hasSize(25);
+            loaded.forEach(e -> assertThat(e.version).as("DB version after chunked update").isEqualTo(2L));
+        } finally {
+            morphium.getConfig().setCursorBatchSize(originalBatchSize);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 13. Multiple rounds of bulk updates — versions increment correctly
+    // -----------------------------------------------------------------------
+    @Test
+    public void bulkUpdate_multipleRounds_versionsIncrementCorrectly() {
+        List<VersionedEntity> entities = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            entities.add(new VersionedEntity("multi-" + i));
+        }
+        morphium.store(entities); // version = 1
+
+        for (int round = 2; round <= 4; round++) {
+            final int r = round;
+            entities.forEach(e -> e.name = "multi-round-" + r + "-" + e.name);
+            morphium.store(entities);
+            final long expectedVersion = r;
+            entities.forEach(e ->
+                assertThat(e.version).as("in-memory version after round " + r).isEqualTo(expectedVersion));
+        }
+
+        // DB must reflect version = 4
+        List<VersionedEntity> loaded = morphium.createQueryFor(VersionedEntity.class).asList();
+        assertThat(loaded).hasSize(50);
+        loaded.forEach(e -> assertThat(e.version).as("DB version after 3 update rounds").isEqualTo(4L));
     }
 }


### PR DESCRIPTION
Hi Stephan,

## Summary

While profiling bulk updates of `@Version` entities, we noticed that `store(List)` acquires and releases a separate connection from the pool for every single entity — with 500 entities that's 500 acquire/release cycles. On setups with higher network latency this becomes quite noticeable.

The fix groups updates into chunks (controlled by `cursorBatchSize`) and keeps a single connection open per chunk. The individual conditional updates (`_id` + `version`) still run one-by-one — MongoDB only returns aggregate match counts for bulk writes, so there'd be no way to tell *which* entity had the version conflict otherwise. It's a deliberate tradeoff: connection overhead drops significantly while conflict detection stays exact.

Two other things came up along the way that are fixed here as well: `WriteConcern` wasn't being propagated to versioned update commands, and `firePostStore()` was skipped entirely for these entities.

## Test plan
- [x] Bulk update of 100 entities — all versions increment correctly
- [x] Stale entity in bulk → `VersionMismatchException` with correct partial state
- [x] Chunked execution when exceeding `cursorBatchSize`
- [x] Three rounds of bulk updates — cumulative versioning checks out
- [ ] Run existing `VersionAnnotationTest` suite for regressions