### PR TITLE
fix: prevent null collation from being sent in write commands

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/commands/StoreMongoCommand.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/commands/StoreMongoCommand.java
@@ -51,7 +51,7 @@ public class StoreMongoCommand extends WriteMongoCommand<StoreMongoCommand> {
             up.put("u", Doc.of("$set", o));
             up.put("upsert", true);
             up.put("multi", false);
-            up.put("collation", null);
+            //up.put("collation",collationDocument);
             //up.put("arrayFilters",list of arrayfilters)
             //up.put("hint",indexInfo);
             //up.put("c",variablesDocument);

--- a/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
@@ -1564,7 +1564,7 @@ public class Query<T> implements Cloneable {
                         Object id = getARHelper().getId(unmarshall);
                         // Cannot use store, as this would trigger an update of last changed...
                         settings = new UpdateMongoCommand(con).setDb(getDB()).setColl(getCollectionName()).setUpdates(Arrays.asList(Doc.of("q", Doc.of("_id", id), "u",
-                            Doc.of("$set", Doc.of(ctf, currentTime)), "multi", false, "collation", collation != null ? Doc.of(collation.toQueryObject()) : null)));
+                            Doc.of("$set", Doc.of(ctf, currentTime)), "multi", false).addIfNotNull("collation", collation != null ? Doc.of(collation.toQueryObject()) : null)));
                         settings.execute();
                         settings.releaseConnection();
                         settings = null;

--- a/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -1369,7 +1369,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
             String collectionName = q.getCollectionName();
             var limit = q.getLimit();
             settings = new DeleteMongoCommand(con).setColl(collectionName).setDb(getDbName())
-            .setDeletes(Arrays.asList(Doc.of("q", q.toQueryObject(), "limit", limit, "collation", q.getCollation() == null ? null : q.getCollation().toQueryObject())));
+            .setDeletes(Arrays.asList(Doc.of("q", q.toQueryObject(), "limit", limit).addIfNotNull("collation", q.getCollation() == null ? null : q.getCollation().toQueryObject())));
             return settings.explain(verbosity);
         } finally {
             if (settings != null) {
@@ -1421,7 +1421,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                     }
 
                     settings = new DeleteMongoCommand(con).setColl(collectionName).setDb(getDbName())
-                    .setDeletes(Arrays.asList(Doc.of("q", q.toQueryObject(), "limit", limit, "collation", q.getCollation() == null ? null : q.getCollation().toQueryObject())));
+                    .setDeletes(Arrays.asList(Doc.of("q", q.toQueryObject(), "limit", limit).addIfNotNull("collation", q.getCollation() == null ? null : q.getCollation().toQueryObject())));
 
                     if (wc != null) {
                         settings.setWriteConcern(wc.asMap());


### PR DESCRIPTION
## Problem

CosmosDB (MongoDB API) rejects write commands containing an explicit
`collation: null` field with Error 9 (`Unrecognized field: 'collation'`).
Standard MongoDB silently ignores this, CosmosDB does not — breaking all
store, delete, and update operations when no collation is set.

## Root cause

`Doc.of("collation", null)` produces `{ "collation": null }` — the field
is present with an explicit null value. CosmosDB sees an unsupported field
and rejects the entire command.

Four code paths were affected:

- **`StoreMongoCommand`** — dead placeholder `put("collation", null)`
  unconditionally included in every upsert sub-document
- **`MorphiumWriterImpl`** (2×) — delete paths passed collation via
  `Doc.of()` even when null
- **`Query`** — update path same pattern

## Fix

Use `addIfNotNull("collation", ...)` instead of `Doc.of(... "collation", value)`.
When collation is null, the key is omitted entirely from the command document.

3 files changed, 4 insertions, 4 deletions.

## Testing

Verified against Azure CosmosDB (MongoDB API, China region). All existing
Morphium tests pass unchanged — collation behavior is identical when a
non-null collation is set.