### PR TITLE
fix: produce structured writeErrors for insert duplicate-key violations

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/MorphiumDriverException.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/MorphiumDriverException.java
@@ -2,6 +2,7 @@ package de.caluga.morphium.driver;/**
  * Created by stephan on 09.11.15.
  */
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -30,6 +31,7 @@ public class MorphiumDriverException extends RuntimeException {
     private Map<String, Object> query;
     private Object mongoCode;
     private Object mongoReason;
+    private List<Map<String, Object>> writeErrors;
 
     public MorphiumDriverException(String message) {
         super(message);
@@ -91,5 +93,13 @@ public class MorphiumDriverException extends RuntimeException {
     @SuppressWarnings("unused")
     public void setQuery(Map<String, Object> query) {
         this.query = query;
+    }
+
+    public List<Map<String, Object>> getWriteErrors() {
+        return writeErrors;
+    }
+
+    public void setWriteErrors(List<Map<String, Object>> writeErrors) {
+        this.writeErrors = writeErrors;
     }
 }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/commands/InsertMongoCommand.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/commands/InsertMongoCommand.java
@@ -81,7 +81,9 @@ public class InsertMongoCommand extends WriteMongoCommand<InsertMongoCommand> {
                 msg.append(":");
                 msg.append(err.get("errmsg"));
             }
-            throw new MorphiumDriverException(msg.toString());
+            var ex = new MorphiumDriverException(msg.toString());
+            ex.setWriteErrors(writeErrors);
+            throw ex;
         }
         return writeResult;
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -3743,8 +3743,10 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
                                 && (options.get("unique").equals("true") || options.get("unique").equals(true))) {
                             // checking fields
                             Map<String, Object> indexKey = new HashMap<>(idx);
+                            List<Map<String, Object>> duplicateDocs = new ArrayList<>();
 
-                            for (var o : objs) {
+                            for (int objIdx = 0; objIdx < objs.size(); objIdx++) {
+                                var o = objs.get(objIdx);
                                 var q = Doc.of();
 
                                 for (String k : indexKey.keySet()) {
@@ -3766,12 +3768,17 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
 
                                 if (existsMatchingDocument(db, collection, q)) {
                                     log.error("Cannot store - unique index!");
-                                    writeErrors.add(o);
+                                    writeErrors.add(Doc.of(
+                                        "index", objIdx,
+                                        "code", 11000,
+                                        "errmsg", "E11000 duplicate key error"
+                                    ));
+                                    duplicateDocs.add(o);
                                 }
                             }
 
-                            errors = errors + writeErrors.size();
-                            objs.removeAll(writeErrors);
+                            errors = errors + duplicateDocs.size();
+                            objs.removeAll(duplicateDocs);
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

Insert operations that hit duplicate-key violations do not expose structured
error information to callers, making it impossible to distinguish error types
programmatically (e.g. `code == 11000` for duplicates).

Three issues contribute:

1. **`MorphiumDriverException`** lost its `writeErrors` field during the
   checked → unchecked exception migration — callers can no longer call
   `getWriteErrors()` after catching the exception.

2. **`InsertMongoCommand.execute()`** throws `MorphiumDriverException`
   without attaching the writeErrors list, even though the server response
   contains it.

3. **`InMemoryDriver.insert()`** adds the raw document object to the
   writeErrors list on unique index violations instead of a proper error
   document. The list entries lack `code`, `index`, and `errmsg` fields,
   so any code checking `error.get("code")` gets null.

## Fix

- **`MorphiumDriverException`**: restore `writeErrors` field with
  getter/setter
- **`InsertMongoCommand`**: attach writeErrors to the exception before
  throwing
- **`InMemoryDriver`**: produce `{ "index": N, "code": 11000, "errmsg":
  "E11000 duplicate key error" }` — consistent with MongoDB wire protocol
  and with the existing update error path (~line 4241)

3 files changed, 24 insertions, 5 deletions.

## Testing

All existing Morphium tests pass. The InMemoryDriver fix specifically
enables tests that rely on `code == 11000` detection for duplicate-key
handling during ordered/unordered bulk inserts.