### PR TITLE
fix: remove dead writeErrors checks after InsertMongoCommand.execute()

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -347,13 +347,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                                     settings.releaseConnection();
                                     settings = null;
                                     con = null;
-
-                                    if (writeResult.containsKey("writeErrors")) {
-                                        int failedWrites = ((List) writeResult.get("writeErrors")).size();
-                                        int success = (int) writeResult.get("n");
-                                        //                                    con.release();
-                                        throw new RuntimeException("Failed to write: " + failedWrites + " - succeeded: " + success);
-                                    }
                                 }
                             } finally {
                                 if (settings != null) {
@@ -733,12 +726,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                                 insert.releaseConnection();
                                 insert = null;
                                 con = null;
-
-                                if (result.containsKey("writeErrors")) {
-                                    int failedWrites = ((List) result.get("writeErrors")).size();
-                                    int success = (int) result.get("n");
-                                    throw new RuntimeException("Failed to write: " + failedWrites + " - succeeded: " + success);
-                                }
                             } finally {
                                 if (insert != null) {
                                     insert.releaseConnection();


### PR DESCRIPTION
`InsertMongoCommand.execute()` (line 71) already checks for `writeErrors` in the result map and throws a `MorphiumDriverException` with structured error details. The two identical checks in `MorphiumWriterImpl` — at the `store()` path (line ~347) and the `storeList()` path (line ~733) — run *after* `execute()` returns. Since `execute()` never returns when writeErrors are present, both blocks are unreachable dead code.

**What this PR does:**
- Removes both unreachable `writeErrors` check blocks from `MorphiumWriterImpl`

No behavioral change. The error handling path through `InsertMongoCommand.execute()` is strictly better (throws `MorphiumDriverException` with structured `getWriteErrors()` instead of a bare `RuntimeException` with only a message string).