### PR TITLE
fix: implement ordered=false insert semantics in InMemoryDriver

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -1475,8 +1475,9 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
         // log.info(cmd.getCommandName() + " - incoming (" +
         // cmd.getClass().getSimpleName() + ")");
         int ret = commandNumber.incrementAndGet();
+        boolean ordered = cmd.getOrdered() == null || cmd.getOrdered();
         List<Map<String, Object>> writeErrors = insert(cmd.getDb(), cmd.getColl(), cmd.getDocuments(),
-            cmd.getWriteConcern());
+            cmd.getWriteConcern(), ordered);
         var m = prepareResult();
         m.put("n", cmd.getDocuments().size() - writeErrors.size());
         if (writeErrors.size() != 0) {
@@ -3723,6 +3724,12 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
     @SuppressWarnings("unchecked")
     public List<Map<String, Object>> insert(String db, String collection, List<Map<String, Object>> objs,
                                             Map<String, Object> wc) throws MorphiumDriverException {
+        return insert(db, collection, objs, wc, true);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public List<Map<String, Object>> insert(String db, String collection, List<Map<String, Object>> objs,
+                                            Map<String, Object> wc, boolean ordered) throws MorphiumDriverException {
         // log.debug("insert() called: db={}, coll={}, thread={}", db, collection,
         // Thread.currentThread().getName());
         java.util.concurrent.locks.ReadWriteLock lock = getCollectionLock(db, collection);
@@ -3797,15 +3804,25 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
             }
 
             // Check new objects for duplicates in O(M) time instead of O(N*M)
-            for (Map<String, Object> o : objs) {
-                if (o.get("_id") != null) {
-                    if (existingIds.contains(o.get("_id"))) {
+            List<Map<String, Object>> idDuplicates = new ArrayList<>();
+            int baseIndex = objs.size() - (objs.size()); // recalculate because unique-index check may have removed items
+            for (int objIdx = 0; objIdx < objs.size(); objIdx++) {
+                Map<String, Object> o = objs.get(objIdx);
+                if (o.get("_id") != null && existingIds.contains(o.get("_id"))) {
+                    if (ordered) {
                         throw new MorphiumDriverException("Duplicate _id! " + o.get("_id"), null);
                     }
+                    writeErrors.add(Doc.of(
+                        "index", objIdx,
+                        "code", 11000,
+                        "errmsg", "E11000 duplicate key error collection: " + db + "." + collection + " dup key: { _id: " + o.get("_id") + " }"
+                    ));
+                    idDuplicates.add(o);
+                    continue;
                 }
-
                 o.putIfAbsent("_id", new ObjectId());
             }
+            objs.removeAll(idDuplicates);
             // collectionData already retrieved above
             if (cappedCollections.containsKey(db) && cappedCollections.get(db).containsKey(collection)) {
                 while (!collectionData.isEmpty() && cappedCollections.get(db).get(collection).containsKey("max")

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/InMemoryDriverOrderedInsertTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/InMemoryDriverOrderedInsertTest.java
@@ -1,0 +1,168 @@
+package de.caluga.test.mongo.suite.inmem;
+
+import de.caluga.morphium.driver.Doc;
+import de.caluga.morphium.driver.MorphiumDriverException;
+import de.caluga.morphium.driver.commands.InsertMongoCommand;
+import de.caluga.morphium.driver.inmem.InMemoryDriver;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for ordered vs. unordered insert semantics in InMemoryDriver.
+ *
+ * <p>With {@code ordered=true} (the default), the first duplicate _id or unique
+ * index violation causes an immediate {@link MorphiumDriverException}.
+ *
+ * <p>With {@code ordered=false}, violations are collected as structured
+ * {@code writeErrors} ({@code index}, {@code code}, {@code errmsg}) and
+ * processing continues with the remaining documents.
+ */
+@Tag("inmemory")
+class InMemoryDriverOrderedInsertTest extends MorphiumInMemTestBase {
+
+    private static final String DB = "test";
+    private static final String COLL = "ordered_insert_test";
+
+    @Test
+    void orderedInsert_throwsOnDuplicateId() throws Exception {
+        var driver = (InMemoryDriver) morphium.getDriver();
+        var id = new ObjectId();
+
+        driver.insert(DB, COLL, List.of(Doc.of("_id", id, "value", 1)), null, true);
+
+        assertThatThrownBy(() ->
+            driver.insert(DB, COLL, List.of(Doc.of("_id", id, "value", 2)), null, true)
+        ).isInstanceOf(MorphiumDriverException.class)
+         .hasMessageContaining("Duplicate");
+    }
+
+    @Test
+    void unorderedInsert_collectsDuplicateIdAsWriteError() throws Exception {
+        var driver = (InMemoryDriver) morphium.getDriver();
+        var existingId = new ObjectId();
+        var newId = new ObjectId();
+
+        driver.insert(DB, COLL, List.of(Doc.of("_id", existingId, "value", 1)), null, true);
+
+        List<Map<String, Object>> docs = new ArrayList<>();
+        docs.add(Doc.of("_id", existingId, "value", "duplicate"));
+        docs.add(Doc.of("_id", newId, "value", "valid"));
+
+        List<Map<String, Object>> writeErrors = driver.insert(DB, COLL, docs, null, false);
+
+        assertThat(writeErrors).hasSize(1);
+        assertThat(writeErrors.get(0).get("code")).isEqualTo(11000);
+        assertThat(writeErrors.get(0).get("errmsg").toString()).contains("dup key");
+
+        // The valid document should have been inserted
+        var results = driver.find(DB, COLL, Doc.of("_id", newId), null, null, 0, 1);
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).get("value")).isEqualTo("valid");
+    }
+
+    @Test
+    void unorderedInsert_continuesAfterMultipleDuplicates() throws Exception {
+        var driver = (InMemoryDriver) morphium.getDriver();
+        var id1 = new ObjectId();
+        var id2 = new ObjectId();
+
+        driver.insert(DB, COLL, List.of(
+            Doc.of("_id", id1, "value", "existing1"),
+            Doc.of("_id", id2, "value", "existing2")
+        ), null, true);
+
+        var newId = new ObjectId();
+        List<Map<String, Object>> docs = new ArrayList<>();
+        docs.add(Doc.of("_id", id1, "value", "dup1"));
+        docs.add(Doc.of("_id", newId, "value", "new"));
+        docs.add(Doc.of("_id", id2, "value", "dup2"));
+
+        List<Map<String, Object>> writeErrors = driver.insert(DB, COLL, docs, null, false);
+
+        assertThat(writeErrors).hasSize(2);
+        assertThat(writeErrors).allSatisfy(err ->
+            assertThat((int) err.get("code")).isEqualTo(11000)
+        );
+
+        // Only the non-duplicate should be in the collection
+        var results = driver.find(DB, COLL, Doc.of("_id", newId), null, null, 0, 1);
+        assertThat(results).hasSize(1);
+    }
+
+    @Test
+    void unorderedInsert_noDuplicates_insertsAll() throws Exception {
+        var driver = (InMemoryDriver) morphium.getDriver();
+
+        List<Map<String, Object>> docs = new ArrayList<>();
+        docs.add(Doc.of("value", "a"));
+        docs.add(Doc.of("value", "b"));
+        docs.add(Doc.of("value", "c"));
+
+        List<Map<String, Object>> writeErrors = driver.insert(DB, COLL, docs, null, false);
+
+        assertThat(writeErrors).isEmpty();
+        var all = driver.find(DB, COLL, Doc.of(), null, null, 0, 100);
+        assertThat(all).hasSize(3);
+    }
+
+    @Test
+    void orderedInsert_viaCommand_stopsAtFirstDuplicate() throws Exception {
+        var driver = (InMemoryDriver) morphium.getDriver();
+        var existingId = new ObjectId();
+
+        driver.insert(DB, COLL, List.of(Doc.of("_id", existingId, "value", 1)), null, true);
+
+        var cmd = new InsertMongoCommand(driver.getPrimaryConnection(null));
+        cmd.setDb(DB);
+        cmd.setColl(COLL);
+        cmd.setDocuments(List.of(
+            Doc.of("_id", existingId, "value", "dup"),
+            Doc.of("value", "should-not-be-inserted")
+        ));
+        cmd.setOrdered(true);
+
+        assertThatThrownBy(cmd::execute)
+            .isInstanceOf(MorphiumDriverException.class);
+    }
+
+    @Test
+    void unorderedInsert_viaCommand_collectsErrorsAndInserts() throws Exception {
+        var driver = (InMemoryDriver) morphium.getDriver();
+        var existingId = new ObjectId();
+        var newId = new ObjectId();
+
+        driver.insert(DB, COLL, List.of(Doc.of("_id", existingId, "value", 1)), null, true);
+
+        var con = driver.getPrimaryConnection(null);
+        var cmd = new InsertMongoCommand(con);
+        cmd.setDb(DB);
+        cmd.setColl(COLL);
+        cmd.setDocuments(new ArrayList<>(List.of(
+            Doc.of("_id", existingId, "value", "dup"),
+            Doc.of("_id", newId, "value", "valid")
+        )));
+        cmd.setOrdered(false);
+
+        // InsertMongoCommand.execute() throws on writeErrors but the valid doc is still inserted
+        assertThatThrownBy(cmd::execute)
+            .isInstanceOf(MorphiumDriverException.class)
+            .satisfies(ex -> {
+                var driverEx = (MorphiumDriverException) ex;
+                assertThat(driverEx.getWriteErrors()).hasSize(1);
+                assertThat((int) driverEx.getWriteErrors().get(0).get("code")).isEqualTo(11000);
+            });
+
+        // The valid document should have been inserted despite the error
+        var results = driver.find(DB, COLL, Doc.of("_id", newId), null, null, 0, 1);
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).get("value")).isEqualTo("valid");
+    }
+}


### PR DESCRIPTION
The InMemoryDriver's `insert()` always uses ordered=true semantics — a duplicate `_id` throws `MorphiumDriverException` immediately and aborts the entire batch. With `ordered=false`, MongoDB collects violations as structured writeErrors and continues processing the remaining documents.

**What this PR does:**
- Adds an `insert(db, coll, objs, wc, boolean ordered)` overload to `InMemoryDriver`
- `ordered=true` (default): existing behavior — stop at first `_id` duplicate, throw immediately
- `ordered=false`: collect `_id` duplicates as `{index, code:11000, errmsg}` writeErrors, skip the duplicate, continue with remaining documents
- `runCommand(InsertMongoCommand)` reads `cmd.getOrdered()` and passes the flag through
- Existing `insert(db, coll, objs, wc)` delegates to `insert(..., true)` for backward compatibility

**Tests:** 6 new test cases in `InMemoryDriverOrderedInsertTest`:
- ordered insert throws on duplicate _id
- unordered insert collects duplicate _id as writeError and inserts valid docs
- unordered insert handles multiple duplicates in one batch
- unordered insert with no duplicates inserts all
- ordered via InsertMongoCommand stops at first duplicate
- unordered via InsertMongoCommand throws MorphiumDriverException with structured writeErrors, valid docs still inserted

Builds on top of #187 (structured writeErrors in InsertMongoCommand) — the unique index pre-check path already uses the same `{index, code, errmsg}` format.