### PR TITLE
feat: storeList() with continueOnError for partial-failure batch stores

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/FailedStore.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/FailedStore.java
@@ -1,0 +1,40 @@
+package de.caluga.morphium;
+
+/**
+ * Represents a single failure from a {@code storeList()} call with
+ * {@code continueOnError=true}.
+ *
+ * @param <T> the entity type
+ */
+public class FailedStore<T> {
+
+    private final int index;
+    private final T entity;
+    private final Exception cause;
+
+    public FailedStore(int index, T entity, Exception cause) {
+        this.index = index;
+        this.entity = entity;
+        this.cause = cause;
+    }
+
+    /** The index of the entity in the original list. */
+    public int getIndex() {
+        return index;
+    }
+
+    /** The entity that failed to store. */
+    public T getEntity() {
+        return entity;
+    }
+
+    /** The exception that caused the failure (typically {@link VersionMismatchException}). */
+    public Exception getCause() {
+        return cause;
+    }
+
+    @Override
+    public String toString() {
+        return "FailedStore{index=" + index + ", entity=" + entity + ", cause=" + cause.getMessage() + "}";
+    }
+}

--- a/morphium-core/src/main/java/de/caluga/morphium/Morphium.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/Morphium.java
@@ -2745,6 +2745,25 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
         }
     }
 
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T> List<FailedStore<T>> storeList(List<T> lst, String collection, boolean continueOnError) {
+        if (lst == null || lst.isEmpty()) {
+            return List.of();
+        }
+        // Group by writer class to handle mixed-type lists correctly
+        Map<MorphiumWriter, List<T>> byWriter = new LinkedHashMap<>();
+        for (T o : lst) {
+            MorphiumWriter w = getWriterForClass(o.getClass());
+            byWriter.computeIfAbsent(w, k -> new ArrayList<>()).add(o);
+        }
+        List<FailedStore<T>> allFailures = new ArrayList<>();
+        for (Map.Entry<MorphiumWriter, List<T>> entry : byWriter.entrySet()) {
+            allFailures.addAll(entry.getKey().storeList(entry.getValue(), collection, continueOnError));
+        }
+        return allFailures;
+    }
+
     //////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////
     //////////////////////////////

--- a/morphium-core/src/main/java/de/caluga/morphium/MorphiumBase.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/MorphiumBase.java
@@ -656,6 +656,26 @@ public abstract class MorphiumBase {
     public <T> void storeList(List<T> lst, String collection, AsyncOperationCallback<T> callback) {
         saveList(lst, collection, callback);
     }
+
+    /**
+     * Stores all elements, optionally continuing on version conflicts.
+     * <p>
+     * When {@code continueOnError} is {@code true}, entities that fail due to
+     * {@link VersionMismatchException} are collected as {@link FailedStore} entries
+     * instead of aborting the batch. Successfully stored entities are committed.
+     *
+     * @return empty list if all stored successfully, otherwise the failures
+     */
+    public <T> List<FailedStore<T>> storeList(List<T> lst, boolean continueOnError) {
+        return storeList(lst, null, continueOnError);
+    }
+
+    /**
+     * Stores all elements into the given collection, optionally continuing on version conflicts.
+     *
+     * @return empty list if all stored successfully, otherwise the failures
+     */
+    public abstract <T> List<FailedStore<T>> storeList(List<T> lst, String collection, boolean continueOnError);
     /**
      * Stores a single Object. Clears the corresponding cache
      *

--- a/morphium-core/src/main/java/de/caluga/morphium/VersionMismatchException.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/VersionMismatchException.java
@@ -14,13 +14,20 @@ public class VersionMismatchException extends RuntimeException {
 
     private final Object entityId;
     private final long expectedVersion;
+    private final int listIndex;
 
     public VersionMismatchException(Object entityId, long expectedVersion) {
+        this(entityId, expectedVersion, -1);
+    }
+
+    public VersionMismatchException(Object entityId, long expectedVersion, int listIndex) {
         super("Optimistic locking conflict for entity id=" + entityId
             + ": expected version " + expectedVersion
-            + " but document was already modified by another writer");
+            + " but document was already modified by another writer"
+            + (listIndex >= 0 ? " (list index " + listIndex + ")" : ""));
         this.entityId = entityId;
         this.expectedVersion = expectedVersion;
+        this.listIndex = listIndex;
     }
 
     /** The {@code @Id} value of the conflicting entity. */
@@ -31,5 +38,13 @@ public class VersionMismatchException extends RuntimeException {
     /** The version the caller expected to be current in the database. */
     public long getExpectedVersion() {
         return expectedVersion;
+    }
+
+    /**
+     * The index of the entity in the list passed to {@code store(List)},
+     * or {@code -1} if the exception was thrown from a single-entity store.
+     */
+    public int getListIndex() {
+        return listIndex;
     }
 }

--- a/morphium-core/src/main/java/de/caluga/morphium/writer/BufferedMorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/BufferedMorphiumWriterImpl.java
@@ -1335,6 +1335,11 @@ public class BufferedMorphiumWriterImpl implements MorphiumWriter, ShutdownListe
     }
 
     @Override
+    public <T> List<FailedStore<T>> storeList(List<T> lst, String collectionName, boolean continueOnError) {
+        return directWriter.storeList(lst, collectionName, continueOnError);
+    }
+
+    @Override
     public <T> Map<String, Object> explainRemove(ExplainVerbosity verbosity, T o, String Collection) {
         return directWriter.explainRemove(verbosity, o, Collection);
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriter.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriter.java
@@ -1,5 +1,6 @@
 package de.caluga.morphium.writer;
 
+import de.caluga.morphium.FailedStore;
 import de.caluga.morphium.IndexDescription;
 import de.caluga.morphium.Morphium;
 import de.caluga.morphium.MorphiumStorageListener;
@@ -40,6 +41,26 @@ public interface MorphiumWriter {
 
 
     <T> void store(List<T> lst, String collectionName, AsyncOperationCallback<T> callback);
+
+    /**
+     * Stores a list of entities with optional continue-on-error semantics.
+     * <p>
+     * When {@code continueOnError} is {@code true}, version conflicts on individual
+     * {@link de.caluga.morphium.annotations.Version @Version}-annotated entities are
+     * collected as {@link FailedStore} entries instead of aborting the batch.
+     * Entities that succeed are committed; entities that fail are reported in the return list.
+     * Note: only optimistic-locking failures on versioned entities are collected — failures
+     * during bulk inserts or non-versioned updates propagate as exceptions.
+     * <p>
+     * When {@code continueOnError} is {@code false}, the first version conflict
+     * throws {@link de.caluga.morphium.VersionMismatchException}.
+     * <p>
+     * Unlike {@link #store(List, String, AsyncOperationCallback)}, this method runs
+     * synchronously on the caller's thread without retry or async callback support.
+     *
+     * @return empty list if all entities stored successfully, otherwise the failures
+     */
+    <T> List<FailedStore<T>> storeList(List<T> lst, String collectionName, boolean continueOnError);
 
     <T> void insert(List<T> lst, String collectionName, AsyncOperationCallback<T> callback);
     /**

--- a/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.json.simple.parser.JSONParser;
 
 import de.caluga.morphium.Collation;
+import de.caluga.morphium.FailedStore;
 import de.caluga.morphium.IndexDescription;
 import de.caluga.morphium.Morphium;
 import de.caluga.morphium.MorphiumStorageListener;
@@ -785,6 +787,261 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
             };
             submitAndBlockIfNecessary(callback, r);
         }
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T> List<FailedStore<T>> storeList(List<T> lst, String cln, boolean continueOnError) {
+        List<FailedStore<T>> failures = new ArrayList<>();
+        if (lst.isEmpty()) {
+            return failures;
+        }
+
+        Map<Class, List<Map<String, Object>>> newElementsToInsert = new HashMap<>();
+        Map<Class, List<Map<String, Object>>> toUpdate = new HashMap<>();
+        // Track versioned entities together with their original list index
+        Map<Class, List<Object[]>> toVersionedUpdate = new HashMap<>(); // Object[] = {entity, Integer index}
+        // Track isNew status per entity for correct firePostStore calls
+        Map<Object, Boolean> isNewMap = new HashMap<>();
+        // Track failed entity identities (identity-based) for excluding from firePostStore
+        Set<Object> failedEntities = new HashSet<>();
+        // Map original list index to resolved (unwrapped) entity reference
+        Object[] resolvedEntities = new Object[lst.size()];
+
+        if (morphium.isAutoValuesEnabledForThread()) {
+            try {
+                morphium.setAutoValuesBatch(lst);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("could not set @AutoSequence values!", e);
+            }
+        }
+
+        for (int i = 0; i < lst.size(); i++) {
+            Object o = lst.get(i);
+            Class type = morphium.getARHelper().getRealClass(o.getClass());
+
+            if (!morphium.getARHelper().isAnnotationPresentInHierarchy(type, Entity.class)) {
+                logger.error("Not an entity! Storing not possible! Even not in list!");
+                continue;
+            }
+
+            morphium.inc(StatisticKeys.WRITES);
+            o = morphium.getARHelper().getRealObject(o);
+
+            if (o == null) {
+                logger.warn("Illegal Reference? - cannot store Lazy-Loaded / Partial Update Proxy without delegate!");
+                continue;
+            }
+            resolvedEntities[i] = o;
+
+            boolean isn = morphium.getId(o) == null;
+            if (morphium.isAutoValuesEnabledForThread()) {
+                try {
+                    isn = morphium.setAutoValues(o);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("could not set auto variable!", e);
+                }
+            }
+
+            if (!isn) {
+                List<String> vf = morphium.getARHelper().getFields(type, Version.class);
+                if (!vf.isEmpty()) {
+                    Object rawV = morphium.getARHelper().getValue(o, vf.get(0));
+                    long cv = rawV instanceof Number ? ((Number) rawV).longValue() : 0L;
+                    if (cv == 0L) {
+                        isn = true;
+                    }
+                }
+            }
+
+            isNewMap.put(o, isn);
+
+            if (isn) {
+                initVersionFieldForInsert(o);
+                try {
+                    setIdIfNull(o);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+                morphium.firePreStore(o, true);
+                newElementsToInsert.putIfAbsent(o.getClass(), new ArrayList<>());
+                newElementsToInsert.get(o.getClass()).add(morphium.getMapper().serialize(o));
+            } else {
+                morphium.firePreStore(o, false);
+                List<String> vFields = morphium.getARHelper().getFields(type, Version.class);
+                if (!vFields.isEmpty()) {
+                    toVersionedUpdate.putIfAbsent(o.getClass(), new ArrayList<>());
+                    toVersionedUpdate.get(o.getClass()).add(new Object[]{o, i});
+                } else {
+                    toUpdate.putIfAbsent(o.getClass(), new ArrayList<>());
+                    toUpdate.get(o.getClass()).add(morphium.getMapper().serialize(o));
+                }
+            }
+        }
+
+        // Process versioned updates with optimistic locking
+        for (Map.Entry<Class, List<Object[]>> es : toVersionedUpdate.entrySet()) {
+            Class c = es.getKey();
+            List<String> vFields = morphium.getARHelper().getFields(c, Version.class);
+            if (vFields.isEmpty()) {
+                continue;
+            }
+            String javaVersionField = vFields.get(0);
+            Field versionField = morphium.getARHelper().getField(c, javaVersionField);
+            if (versionField != null && versionField.getType() != long.class && versionField.getType() != Long.class) {
+                throw new IllegalArgumentException("@Version field '" + javaVersionField + "' on " + c.getName()
+                        + " must be of type long or Long, but is " + versionField.getType().getName());
+            }
+            String mongoVersionField = morphium.getARHelper().getMongoFieldName(c, javaVersionField);
+            WriteConcern wc = morphium.getWriteConcernForClass(c);
+            String coll = cln != null ? cln : morphium.getMapper().getCollectionName(c);
+            checkIndexAndCaps(c, coll, null);
+
+            for (Object[] pair : es.getValue()) {
+                Object entity = pair[0];
+                int listIndex = (int) pair[1];
+
+                Object entityId = morphium.getId(entity);
+                Object rawVersion = morphium.getARHelper().getValue(entity, javaVersionField);
+                long currentVersion = rawVersion instanceof Number ? ((Number) rawVersion).longValue() : 0L;
+
+                Map<String, Object> serialized = new LinkedHashMap<>(morphium.getMapper().serialize(entity));
+                serialized.remove("_id");
+                serialized.remove(mongoVersionField);
+
+                Map<String, Object> filter = Doc.of("$and", java.util.List.of(
+                    Doc.of("_id", entityId),
+                    Doc.of(mongoVersionField, currentVersion)));
+                Map<String, Object> update = Doc.of(
+                    "$set", serialized,
+                    "$inc", Doc.of(mongoVersionField, 1L));
+
+                MongoConnection con = null;
+                UpdateMongoCommand upd = null;
+                try {
+                    con = morphium.getDriver().getPrimaryConnection(wc);
+                    upd = new UpdateMongoCommand(con)
+                        .setDb(morphium.getConfig().connectionSettings().getDatabase())
+                        .setColl(coll);
+                    upd.addUpdate(filter, update, null, false, false, null, null, null);
+                    Map<String, Object> result = upd.execute();
+
+                    int matched = result.get("n") instanceof Number n ? n.intValue() : 0;
+                    if (matched == 0) {
+                        var ex = new VersionMismatchException(entityId, currentVersion, listIndex);
+                        if (!continueOnError) {
+                            throw ex;
+                        }
+                        failures.add(new FailedStore<>(listIndex, (T) entity, ex));
+                        failedEntities.add(entity);
+                        continue;
+                    }
+                    morphium.getARHelper().setValue(entity, currentVersion + 1L, javaVersionField);
+
+                    var cache = morphium.getCache();
+                    if (cache != null) {
+                        cache.clearCacheIfNecessary(c);
+                    }
+                } catch (Exception e) {
+                    if (!continueOnError) {
+                        if (e instanceof RuntimeException re) throw re;
+                        throw new RuntimeException(e);
+                    }
+                    failures.add(new FailedStore<>(listIndex, (T) entity, e));
+                    failedEntities.add(entity);
+                } finally {
+                    if (upd != null) {
+                        upd.releaseConnection();
+                    } else if (con != null) {
+                        morphium.getDriver().releaseConnection(con);
+                    }
+                }
+            }
+        }
+
+        // Process non-versioned updates (bulk store)
+        for (Map.Entry<Class, List<Map<String, Object>>> es : toUpdate.entrySet()) {
+            Class c = es.getKey();
+            WriteConcern wc = morphium.getWriteConcernForClass(c);
+            String coll = cln != null ? cln : morphium.getMapper().getCollectionName(c);
+            checkIndexAndCaps(c, coll, null);
+            MongoConnection con = null;
+            StoreMongoCommand settings = null;
+            List<Map<String, Object>> batch = new ArrayList<>(es.getValue());
+            try {
+                con = morphium.getDriver().getPrimaryConnection(wc);
+                while (!batch.isEmpty()) {
+                    settings = new StoreMongoCommand(con).setDb(morphium.getConfig().connectionSettings().getDatabase()).setColl(coll);
+                    if (batch.size() > morphium.getConfig().getCursorBatchSize()) {
+                        settings.setDocuments(batch.subList(0, morphium.getConfig().getCursorBatchSize()));
+                        batch = batch.subList(morphium.getConfig().getCursorBatchSize(), batch.size());
+                    } else {
+                        settings.setDocuments(batch);
+                        batch = new ArrayList<>();
+                    }
+                    if (wc != null) {
+                        settings.setWriteConcern(wc.asMap());
+                    }
+                    settings.execute();
+                }
+                var cache = morphium.getCache();
+                if (cache != null) {
+                    cache.clearCacheIfNecessary(c);
+                }
+            } finally {
+                if (settings != null) {
+                    settings.releaseConnection();
+                } else if (con != null) {
+                    morphium.getDriver().releaseConnection(con);
+                }
+            }
+        }
+
+        // Process new inserts (bulk insert)
+        for (Map.Entry<Class, List<Map<String, Object>>> es : newElementsToInsert.entrySet()) {
+            Class c = es.getKey();
+            WriteConcern wc = morphium.getWriteConcernForClass(c);
+            String coll = cln != null ? cln : morphium.getMapper().getCollectionName(c);
+            checkIndexAndCaps(c, coll, null);
+            InsertMongoCommand insert = null;
+            MongoConnection con = null;
+            try {
+                con = morphium.getDriver().getPrimaryConnection(wc);
+                insert = new InsertMongoCommand(con);
+                insert.setDb(morphium.getDatabase());
+                insert.setColl(coll);
+                insert.setDocuments(es.getValue());
+                insert.setOrdered(false);
+                if (wc != null) {
+                    insert.setWriteConcern(wc.asMap());
+                }
+                insert.execute();
+                insert.releaseConnection();
+                insert = null;
+                con = null;
+            } finally {
+                if (insert != null) {
+                    insert.releaseConnection();
+                } else if (con != null) {
+                    morphium.getDriver().releaseConnection(con);
+                }
+            }
+            var cache = morphium.getCache();
+            if (cache != null) {
+                cache.clearCacheIfNecessary(c);
+            }
+        }
+
+        // Fire postStore only for successfully stored entities, with correct isNew flag.
+        // Use the resolved references stored during classification to ensure identity consistency.
+        for (int i = 0; i < lst.size(); i++) {
+            Object resolved = resolvedEntities[i];
+            if (resolved != null && !failedEntities.contains(resolved)) {
+                Boolean isn = isNewMap.get(resolved);
+                morphium.firePostStore(resolved, isn != null && isn);
+            }
+        }
+        return failures;
     }
 
     @Override

--- a/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -82,6 +82,21 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
     private Morphium morphium;
     private int maximumRetries = 10;
     private int pause = 250;
+
+    /**
+     * Result of classifying a single entity for store operations.
+     * Determines whether the entity should be inserted (new) or updated (existing),
+     * and whether it requires versioned (optimistic locking) update handling.
+     *
+     * @param entity         the resolved (unwrapped) entity reference
+     * @param type           the real entity class
+     * @param isNew          true if the entity should be inserted, false for update
+     * @param isVersioned    true if the entity has a @Version field and is not new
+     * @param originalIndex  the entity's position in the original input list
+     */
+    private record ClassifiedEntity(Object entity, Class<?> type, boolean isNew,
+                                     boolean isVersioned, int originalIndex) {
+    }
     private ThreadPoolExecutor executor = null;
 
     @Override
@@ -498,8 +513,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                         // System.out.println(System.currentTimeMillis()+" - storing" );
                         Map<Class, List<Map<String, Object>>> toUpdate = new HashMap<>();
                         Map<Class, List<Map<String, Object>>> newElementsToInsert = new HashMap<>();
-                        // Versioned-update entities keep their original objects so that
-                        // we can read currentVersion, apply the filter, and increment in-memory.
                         Map<Class, List<Object>> toVersionedUpdate = new HashMap<>();
 
                         if (morphium.isAutoValuesEnabledForThread()) {
@@ -510,62 +523,17 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                             }
                         }
 
-                        // HashMap<Object, Boolean> isNew = new HashMap<>();
-                        for (int i = 0; i < lst.size(); i++) {
-                            Object o = lst.get(i);
-                            Class type = morphium.getARHelper().getRealClass(o.getClass());
-
-                            if (!morphium.getARHelper().isAnnotationPresentInHierarchy(type, Entity.class)) {
-                                logger.error("Not an entity! Storing not possible! Even not in" + " list!");
-                                continue;
-                            }
-
-                            morphium.inc(StatisticKeys.WRITES);
-                            o = morphium.getARHelper().getRealObject(o);
-
-                            if (o == null) {
-                                logger.warn("Illegal Reference? - cannot store Lazy-Loaded /" + " Partial Update Proxy without delegate!");
-                                return;
-                            }
-
-                            boolean isn = morphium.getId(o) == null;
-
-                            if (morphium.isAutoValuesEnabledForThread()) {
-                                isn = morphium.setAutoValues(o);
-                            }
-
-                            // For versioned entities with pre-set IDs but version == 0,
-                            // treat as new (INSERT) rather than existing (UPDATE).
-                            // Version 0 means the entity has never been persisted.
-                            if (!isn) {
-                                List<String> vf = morphium.getARHelper().getFields(type, Version.class);
-                                if (!vf.isEmpty()) {
-                                    Object rawV = morphium.getARHelper().getValue(o, vf.get(0));
-                                    long cv = rawV instanceof Number ? ((Number) rawV).longValue() : 0L;
-                                    if (cv == 0L) {
-                                        isn = true;
-                                    }
-                                }
-                            }
-
-                            if (isn) {
-                                // INSERT: initialise @Version field to 1L before serialisation
-                                initVersionFieldForInsert(o);
-                                setIdIfNull(o);
-                                morphium.firePreStore(o, isn);
-                                newElementsToInsert.putIfAbsent(o.getClass(), new ArrayList<>());
-                                newElementsToInsert.get(o.getClass()).add(morphium.getMapper().serialize(o));
+                        List<ClassifiedEntity> classified = classifyEntities(lst);
+                        for (ClassifiedEntity ce : classified) {
+                            if (ce.isNew()) {
+                                newElementsToInsert.computeIfAbsent(ce.entity().getClass(), k -> new ArrayList<>())
+                                    .add(morphium.getMapper().serialize(ce.entity()));
+                            } else if (ce.isVersioned()) {
+                                toVersionedUpdate.computeIfAbsent(ce.entity().getClass(), k -> new ArrayList<>())
+                                    .add(ce.entity());
                             } else {
-                                morphium.firePreStore(o, isn);
-                                List<String> vFields = morphium.getARHelper().getFields(type, Version.class);
-                                if (!vFields.isEmpty()) {
-                                    // UPDATE with optimistic locking – handled per-entity below
-                                    toVersionedUpdate.putIfAbsent(o.getClass(), new ArrayList<>());
-                                    toVersionedUpdate.get(o.getClass()).add(o);
-                                } else {
-                                    toUpdate.putIfAbsent(o.getClass(), new ArrayList<>());
-                                    toUpdate.get(o.getClass()).add(morphium.getMapper().serialize(o));
-                                }
+                                toUpdate.computeIfAbsent(ce.entity().getClass(), k -> new ArrayList<>())
+                                    .add(morphium.getMapper().serialize(ce.entity()));
                             }
                         }
                         // Process versioned updates with optimistic locking
@@ -600,7 +568,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                                 // InMemoryDriver's matchesQuery returns after the first field,
                                 // so a flat multi-field map would only check _id and ignore the
                                 // version condition.  Real MongoDB also handles $and correctly.
-                                Map<String, Object> filter = Doc.of("$and", java.util.List.of(
+                                Map<String, Object> filter = Doc.of("$and", List.of(
                                     Doc.of("_id", entityId),
                                     Doc.of(mongoVersionField, currentVersion)));
                                 Map<String, Object> update = Doc.of(
@@ -776,35 +744,21 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
         }
     }
 
-    @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public <T> List<FailedStore<T>> storeList(List<T> lst, String cln, boolean continueOnError) {
-        List<FailedStore<T>> failures = new ArrayList<>();
-        if (lst.isEmpty()) {
-            return failures;
-        }
+    /**
+     * Classifies each entity in the list as new (insert) or existing (update/versioned-update).
+     * Handles entity resolution (unwrapping proxies), auto-value assignment, version-0 detection,
+     * and {@code firePreStore} invocation.
+     *
+     * <p>For new entities, the @Version field is initialised to 1 and an ID is assigned if null.</p>
+     *
+     * @param entities the entities to classify
+     * @return list of classified entities (may be shorter than input if entities are skipped)
+     */
+    private List<ClassifiedEntity> classifyEntities(List<?> entities) {
+        List<ClassifiedEntity> result = new ArrayList<>(entities.size());
 
-        Map<Class, List<Map<String, Object>>> newElementsToInsert = new HashMap<>();
-        Map<Class, List<Map<String, Object>>> toUpdate = new HashMap<>();
-        // Track versioned entities together with their original list index
-        Map<Class, List<Object[]>> toVersionedUpdate = new HashMap<>(); // Object[] = {entity, Integer index}
-        // Track isNew status per entity for correct firePostStore calls
-        Map<Object, Boolean> isNewMap = new HashMap<>();
-        // Track failed entity identities (identity-based) for excluding from firePostStore
-        Set<Object> failedEntities = new HashSet<>();
-        // Map original list index to resolved (unwrapped) entity reference
-        Object[] resolvedEntities = new Object[lst.size()];
-
-        if (morphium.isAutoValuesEnabledForThread()) {
-            try {
-                morphium.setAutoValuesBatch(lst);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException("could not set @AutoSequence values!", e);
-            }
-        }
-
-        for (int i = 0; i < lst.size(); i++) {
-            Object o = lst.get(i);
+        for (int i = 0; i < entities.size(); i++) {
+            Object o = entities.get(i);
             Class type = morphium.getARHelper().getRealClass(o.getClass());
 
             if (!morphium.getARHelper().isAnnotationPresentInHierarchy(type, Entity.class)) {
@@ -819,7 +773,6 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                 logger.warn("Illegal Reference? - cannot store Lazy-Loaded / Partial Update Proxy without delegate!");
                 continue;
             }
-            resolvedEntities[i] = o;
 
             boolean isn = morphium.getId(o) == null;
             if (morphium.isAutoValuesEnabledForThread()) {
@@ -830,6 +783,10 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                 }
             }
 
+            // For versioned entities with pre-set IDs but version == 0,
+            // treat as new (INSERT) rather than existing (UPDATE).
+            // Version 0 means the entity has never been persisted.
+            boolean isVersioned = false;
             if (!isn) {
                 List<String> vf = morphium.getARHelper().getFields(type, Version.class);
                 if (!vf.isEmpty()) {
@@ -837,11 +794,11 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                     long cv = rawV instanceof Number ? ((Number) rawV).longValue() : 0L;
                     if (cv == 0L) {
                         isn = true;
+                    } else {
+                        isVersioned = true;
                     }
                 }
             }
-
-            isNewMap.put(o, isn);
 
             if (isn) {
                 initVersionFieldForInsert(o);
@@ -850,24 +807,52 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                 } catch (IllegalAccessException e) {
                     throw new RuntimeException(e);
                 }
-                morphium.firePreStore(o, true);
-                newElementsToInsert.putIfAbsent(o.getClass(), new ArrayList<>());
-                newElementsToInsert.get(o.getClass()).add(morphium.getMapper().serialize(o));
+            }
+            morphium.firePreStore(o, isn);
+
+            result.add(new ClassifiedEntity(o, type, isn, isVersioned, i));
+        }
+        return result;
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T> List<FailedStore<T>> storeList(List<T> lst, String cln, boolean continueOnError) {
+        List<FailedStore<T>> failures = new ArrayList<>();
+        if (lst.isEmpty()) {
+            return failures;
+        }
+
+        Map<Class, List<Map<String, Object>>> newElementsToInsert = new HashMap<>();
+        Map<Class, List<Map<String, Object>>> toUpdate = new HashMap<>();
+        Map<Class, List<ClassifiedEntity>> toVersionedUpdate = new HashMap<>();
+        // Track failed entity identities (identity-based) for excluding from firePostStore
+        Set<Object> failedEntities = new HashSet<>();
+
+        if (morphium.isAutoValuesEnabledForThread()) {
+            try {
+                morphium.setAutoValuesBatch(lst);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("could not set @AutoSequence values!", e);
+            }
+        }
+
+        List<ClassifiedEntity> classified = classifyEntities(lst);
+        for (ClassifiedEntity ce : classified) {
+            if (ce.isNew()) {
+                newElementsToInsert.computeIfAbsent(ce.entity().getClass(), k -> new ArrayList<>())
+                    .add(morphium.getMapper().serialize(ce.entity()));
+            } else if (ce.isVersioned()) {
+                toVersionedUpdate.computeIfAbsent(ce.entity().getClass(), k -> new ArrayList<>())
+                    .add(ce);
             } else {
-                morphium.firePreStore(o, false);
-                List<String> vFields = morphium.getARHelper().getFields(type, Version.class);
-                if (!vFields.isEmpty()) {
-                    toVersionedUpdate.putIfAbsent(o.getClass(), new ArrayList<>());
-                    toVersionedUpdate.get(o.getClass()).add(new Object[]{o, i});
-                } else {
-                    toUpdate.putIfAbsent(o.getClass(), new ArrayList<>());
-                    toUpdate.get(o.getClass()).add(morphium.getMapper().serialize(o));
-                }
+                toUpdate.computeIfAbsent(ce.entity().getClass(), k -> new ArrayList<>())
+                    .add(morphium.getMapper().serialize(ce.entity()));
             }
         }
 
         // Process versioned updates with optimistic locking
-        for (Map.Entry<Class, List<Object[]>> es : toVersionedUpdate.entrySet()) {
+        for (Map.Entry<Class, List<ClassifiedEntity>> es : toVersionedUpdate.entrySet()) {
             Class c = es.getKey();
             List<String> vFields = morphium.getARHelper().getFields(c, Version.class);
             if (vFields.isEmpty()) {
@@ -884,9 +869,9 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
             String coll = cln != null ? cln : morphium.getMapper().getCollectionName(c);
             checkIndexAndCaps(c, coll, null);
 
-            for (Object[] pair : es.getValue()) {
-                Object entity = pair[0];
-                int listIndex = (int) pair[1];
+            for (ClassifiedEntity ce : es.getValue()) {
+                Object entity = ce.entity();
+                int listIndex = ce.originalIndex();
 
                 Object entityId = morphium.getId(entity);
                 Object rawVersion = morphium.getARHelper().getValue(entity, javaVersionField);
@@ -896,7 +881,7 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                 serialized.remove("_id");
                 serialized.remove(mongoVersionField);
 
-                Map<String, Object> filter = Doc.of("$and", java.util.List.of(
+                Map<String, Object> filter = Doc.of("$and", List.of(
                     Doc.of("_id", entityId),
                     Doc.of(mongoVersionField, currentVersion)));
                 Map<String, Object> update = Doc.of(
@@ -1020,12 +1005,9 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
         }
 
         // Fire postStore only for successfully stored entities, with correct isNew flag.
-        // Use the resolved references stored during classification to ensure identity consistency.
-        for (int i = 0; i < lst.size(); i++) {
-            Object resolved = resolvedEntities[i];
-            if (resolved != null && !failedEntities.contains(resolved)) {
-                Boolean isn = isNewMap.get(resolved);
-                morphium.firePostStore(resolved, isn != null && isn);
+        for (ClassifiedEntity ce : classified) {
+            if (!failedEntities.contains(ce.entity())) {
+                morphium.firePostStore(ce.entity(), ce.isNew());
             }
         }
         return failures;

--- a/morphium-core/src/test/java/de/caluga/test/morphium/StoreListContinueOnErrorTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/StoreListContinueOnErrorTest.java
@@ -1,0 +1,349 @@
+package de.caluga.test.morphium;
+
+import de.caluga.morphium.FailedStore;
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.MorphiumConfig;
+import de.caluga.morphium.VersionMismatchException;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.annotations.Property;
+import de.caluga.morphium.annotations.Version;
+import de.caluga.morphium.driver.MorphiumId;
+import de.caluga.morphium.driver.inmem.InMemoryDriver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@code storeList(List, String, boolean continueOnError)}.
+ * All tests run with InMemoryDriver — no MongoDB required.
+ */
+@Tag("inmemory")
+public class StoreListContinueOnErrorTest {
+
+    @Entity(collectionName = "versioned_item")
+    public static class VersionedItem {
+        @Id
+        public MorphiumId id;
+
+        @Version
+        @Property(fieldName = "version")
+        public long version;
+
+        public String name;
+
+        public VersionedItem() {}
+
+        public VersionedItem(String name) {
+            this.name = name;
+        }
+    }
+
+    @Entity(collectionName = "plain_item")
+    public static class PlainItem {
+        @Id
+        public MorphiumId id;
+
+        public String value;
+
+        public PlainItem() {}
+
+        public PlainItem(String value) {
+            this.value = value;
+        }
+    }
+
+    private Morphium morphium;
+
+    @BeforeEach
+    public void setup() {
+        MorphiumConfig cfg = new MorphiumConfig("storelist_test_db", 10, 10_000, 1_000);
+        cfg.driverSettings().setDriverName(InMemoryDriver.driverName);
+        morphium = new Morphium(cfg);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (morphium != null) {
+            morphium.close();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Empty list returns empty failures
+    // -----------------------------------------------------------------------
+    @Test
+    public void emptyList_returnsEmptyFailures() {
+        List<VersionedItem> empty = new ArrayList<>();
+        List<FailedStore<VersionedItem>> failures = morphium.storeList(empty, true);
+        assertThat(failures).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. All new entities — all succeed, no failures
+    // -----------------------------------------------------------------------
+    @Test
+    public void allNewEntities_noFailures() {
+        List<VersionedItem> items = List.of(
+            new VersionedItem("a"),
+            new VersionedItem("b"),
+            new VersionedItem("c")
+        );
+
+        List<FailedStore<VersionedItem>> failures = morphium.storeList(items, true);
+
+        assertThat(failures).isEmpty();
+        for (VersionedItem item : items) {
+            assertThat(item.id).isNotNull();
+            assertThat(item.version).isEqualTo(1L);
+            // Verify round-trip: version in DB matches in-memory
+            VersionedItem fromDb = morphium.createQueryFor(VersionedItem.class)
+                .f("id").eq(item.id).get();
+            assertThat(fromDb).isNotNull();
+            assertThat(fromDb.version).isEqualTo(1L);
+        }
+        // Verify persisted
+        long count = morphium.createQueryFor(VersionedItem.class).countAll();
+        assertThat(count).isEqualTo(3);
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. continueOnError=true: one stale entity, rest succeed
+    // -----------------------------------------------------------------------
+    @Test
+    public void continueOnError_collectsVersionConflict() {
+        // Store 3 entities
+        VersionedItem a = new VersionedItem("a");
+        VersionedItem b = new VersionedItem("b");
+        VersionedItem c = new VersionedItem("c");
+        morphium.store(a);
+        morphium.store(b);
+        morphium.store(c);
+        assertThat(a.version).isEqualTo(1L);
+        assertThat(b.version).isEqualTo(1L);
+        assertThat(c.version).isEqualTo(1L);
+
+        // Simulate concurrent modification: update b behind our back
+        VersionedItem bConcurrent = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(b.id).get();
+        bConcurrent.name = "b-concurrent";
+        morphium.store(bConcurrent); // b is now version 2 in DB
+
+        // Our 'b' still has version 1 — stale
+        a.name = "a-updated";
+        b.name = "b-stale-update";
+        c.name = "c-updated";
+
+        List<VersionedItem> batch = List.of(a, b, c);
+        List<FailedStore<VersionedItem>> failures = morphium.storeList(batch, true);
+
+        // b should have failed
+        assertThat(failures).hasSize(1);
+        FailedStore<VersionedItem> failed = failures.get(0);
+        assertThat(failed.getEntity()).isSameAs(b);
+        assertThat(failed.getIndex()).isEqualTo(1); // index in original list
+        assertThat(failed.getCause()).isInstanceOf(VersionMismatchException.class);
+
+        // a and c should have been updated
+        assertThat(a.version).isEqualTo(2L);
+        assertThat(c.version).isEqualTo(2L);
+        // b's version should NOT have been incremented
+        assertThat(b.version).isEqualTo(1L);
+
+        // Verify in DB
+        VersionedItem aDb = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(a.id).get();
+        assertThat(aDb.name).isEqualTo("a-updated");
+        assertThat(aDb.version).isEqualTo(2L);
+
+        VersionedItem bDb = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(b.id).get();
+        assertThat(bDb.name).isEqualTo("b-concurrent"); // not our stale update
+        assertThat(bDb.version).isEqualTo(2L);
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. continueOnError=false: throws VersionMismatchException with listIndex
+    // -----------------------------------------------------------------------
+    @Test
+    public void failFast_throwsVersionMismatchWithIndex() {
+        VersionedItem a = new VersionedItem("a");
+        VersionedItem b = new VersionedItem("b");
+        morphium.store(a);
+        morphium.store(b);
+
+        // Make 'a' stale
+        VersionedItem aConcurrent = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(a.id).get();
+        aConcurrent.name = "a-concurrent";
+        morphium.store(aConcurrent);
+
+        a.name = "a-stale";
+        b.name = "b-ok";
+        List<VersionedItem> batch = List.of(a, b);
+
+        assertThatThrownBy(() -> morphium.storeList(batch, false))
+            .isInstanceOf(VersionMismatchException.class)
+            .satisfies(ex -> {
+                VersionMismatchException vme = (VersionMismatchException) ex;
+                assertThat(vme.getListIndex()).isEqualTo(0);
+                assertThat(vme.getExpectedVersion()).isEqualTo(1L);
+            });
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. All entities fail — all collected in failures list
+    // -----------------------------------------------------------------------
+    @Test
+    public void allEntitiesFail_allInFailuresList() {
+        VersionedItem a = new VersionedItem("a");
+        VersionedItem b = new VersionedItem("b");
+        morphium.store(a);
+        morphium.store(b);
+
+        // Make both stale
+        VersionedItem aCon = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(a.id).get();
+        aCon.name = "a-con";
+        morphium.store(aCon);
+
+        VersionedItem bCon = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(b.id).get();
+        bCon.name = "b-con";
+        morphium.store(bCon);
+
+        a.name = "a-stale";
+        b.name = "b-stale";
+
+        List<FailedStore<VersionedItem>> failures = morphium.storeList(List.of(a, b), true);
+
+        assertThat(failures).hasSize(2);
+        assertThat(failures.get(0).getIndex()).isEqualTo(0);
+        assertThat(failures.get(0).getEntity()).isSameAs(a);
+        assertThat(failures.get(1).getIndex()).isEqualTo(1);
+        assertThat(failures.get(1).getEntity()).isSameAs(b);
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Mixed new + versioned-update entities in one batch
+    // -----------------------------------------------------------------------
+    @Test
+    public void mixedNewAndUpdate_handledCorrectly() {
+        // Store one existing entity
+        VersionedItem existing = new VersionedItem("existing");
+        morphium.store(existing);
+        assertThat(existing.version).isEqualTo(1L);
+
+        // Create a new entity
+        VersionedItem brandNew = new VersionedItem("brand-new");
+
+        // Update existing
+        existing.name = "existing-updated";
+
+        List<VersionedItem> batch = List.of(brandNew, existing);
+        List<FailedStore<VersionedItem>> failures = morphium.storeList(batch, true);
+
+        assertThat(failures).isEmpty();
+        assertThat(brandNew.id).isNotNull();
+        assertThat(brandNew.version).isEqualTo(1L);
+        assertThat(existing.version).isEqualTo(2L);
+
+        long count = morphium.createQueryFor(VersionedItem.class).countAll();
+        assertThat(count).isEqualTo(2);
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. Non-versioned entities with storeList — should work like normal store
+    // -----------------------------------------------------------------------
+    @Test
+    public void nonVersionedEntities_storeNormally() {
+        PlainItem p1 = new PlainItem("one");
+        PlainItem p2 = new PlainItem("two");
+
+        List<FailedStore<PlainItem>> failures = morphium.storeList(List.of(p1, p2), true);
+
+        assertThat(failures).isEmpty();
+        assertThat(p1.id).isNotNull();
+        assertThat(p2.id).isNotNull();
+
+        long count = morphium.createQueryFor(PlainItem.class).countAll();
+        assertThat(count).isEqualTo(2);
+    }
+
+    // -----------------------------------------------------------------------
+    // 8. Convenience method storeList(List, boolean) delegates correctly
+    // -----------------------------------------------------------------------
+    @Test
+    public void convenienceMethod_worksWithoutCollectionName() {
+        VersionedItem item = new VersionedItem("test");
+        List<FailedStore<VersionedItem>> failures = morphium.storeList(List.of(item), true);
+
+        assertThat(failures).isEmpty();
+        assertThat(item.id).isNotNull();
+        assertThat(item.version).isEqualTo(1L);
+        // Round-trip verification
+        VersionedItem fromDb = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(item.id).get();
+        assertThat(fromDb).isNotNull();
+        assertThat(fromDb.version).isEqualTo(1L);
+    }
+
+    // -----------------------------------------------------------------------
+    // 9. Version conflict with null collection name produces correct FailedStore
+    // -----------------------------------------------------------------------
+    @Test
+    public void versionConflict_withNullCollection_producesCorrectFailure() {
+        VersionedItem item = new VersionedItem("original");
+        morphium.store(item);
+
+        // Make stale
+        VersionedItem concurrent = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(item.id).get();
+        concurrent.name = "concurrent";
+        morphium.store(concurrent);
+
+        item.name = "stale";
+        List<FailedStore<VersionedItem>> failures = morphium.storeList(List.of(item), null, true);
+
+        assertThat(failures).hasSize(1);
+        assertThat(failures.get(0).getIndex()).isEqualTo(0);
+        assertThat(failures.get(0).getEntity()).isSameAs(item);
+        assertThat(failures.get(0).getCause()).isInstanceOf(VersionMismatchException.class);
+    }
+
+    // -----------------------------------------------------------------------
+    // 10. Fail-fast with stale entity at list index > 0
+    // -----------------------------------------------------------------------
+    @Test
+    public void failFast_staleAtIndexOne_throwsWithCorrectIndex() {
+        VersionedItem a = new VersionedItem("a");
+        VersionedItem b = new VersionedItem("b");
+        morphium.store(a);
+        morphium.store(b);
+
+        // Make 'b' (index 1) stale
+        VersionedItem bConcurrent = morphium.createQueryFor(VersionedItem.class)
+            .f("id").eq(b.id).get();
+        bConcurrent.name = "b-concurrent";
+        morphium.store(bConcurrent);
+
+        a.name = "a-ok";
+        b.name = "b-stale";
+        List<VersionedItem> batch = List.of(a, b);
+
+        assertThatThrownBy(() -> morphium.storeList(batch, false))
+            .isInstanceOf(VersionMismatchException.class)
+            .satisfies(ex -> {
+                VersionMismatchException vme = (VersionMismatchException) ex;
+                assertThat(vme.getListIndex()).isEqualTo(1);
+                assertThat(vme.getExpectedVersion()).isEqualTo(1L);
+            });
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `storeList(List<T>, String, boolean continueOnError)` method that optionally
collects version conflicts as `FailedStore<T>` entries instead of aborting the entire batch.

You suggested this in PR #185 (comment on the `store(List)` optimistic
locking enhancement): a `storeList()` variant where `continueOnError=true` collects
`VersionMismatchException`s and returns them, while successfully stored entities are committed.

### Changes

- **`FailedStore<T>`** — new DTO holding the original list `index`, the `entity`, and the `cause`
- **`VersionMismatchException`** — extended with `listIndex` field (`-1` for single-entity stores)
- **`MorphiumWriter.storeList(List, String, boolean)`** — new interface method
- **`MorphiumWriterImpl`** — full implementation with:
  - Entity classification into new-insert / versioned-update / non-versioned-update buckets
  - Per-entity optimistic locking for `@Version` entities with index tracking
  - Correct `firePreStore`/`firePostStore` lifecycle (postStore excluded for failed entities)
- **`BufferedMorphiumWriterImpl`** — delegates to `directWriter`
- **`MorphiumBase` / `Morphium`** — convenience methods with per-class writer routing

### Behaviour

| `continueOnError` | Version conflict | Result |
|---|---|---|
| `false` | First conflict | `VersionMismatchException` thrown (with `listIndex`) |
| `true` | Any conflict | Collected in `List<FailedStore<T>>`, other entities committed |

Non-versioned bulk insert/update failures always propagate as exceptions (documented in Javadoc).

### Tests

10 InMemoryDriver tests covering:
- Empty list, all-new entities (with DB round-trip verification)
- Single conflict with `continueOnError=true` (correct index, entity, cause)
- Fail-fast with `continueOnError=false` (correct `listIndex` in exception)
- All entities fail — all in failures list
- Mixed new + versioned-update in one batch
- Non-versioned entities
- Convenience method without collection name
- Version conflict with null collection name
- Fail-fast with stale entity at index > 0