### PR TITLE
fix: propagate connection swap from StoreMongoCommand to caller

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/commands/StoreMongoCommand.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/commands/StoreMongoCommand.java
@@ -30,8 +30,13 @@ public class StoreMongoCommand extends WriteMongoCommand<StoreMongoCommand> {
     @Override
     public Map<String, Object> execute() throws MorphiumDriverException {
         UpdateMongoCommand updateSettings = getUpdateMongoCommand();
-
         Map<String, Object> result = updateSettings.execute();
+        // WriteMongoCommand retry logic may swap the connection on the delegated
+        // command (e.g. on "not primary" or transient errors). Propagate the
+        // potentially new connection back so our caller releases the right one.
+        if (updateSettings.getConnection() != getConnection()) {
+            setConnection(updateSettings.getConnection());
+        }
         return result;
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/MorphiumWriterImpl.java
@@ -665,6 +665,8 @@ public class MorphiumWriterImpl implements MorphiumWriter, ShutdownListener {
                                     }
 
                                     Map<String, Object> ret = settings.execute();
+                                    // Track potential connection swap from retry logic
+                                    con = settings.getConnection();
                                 }
 
                                 var cache = morphium.getCache();


### PR DESCRIPTION
## Problem

`StoreMongoCommand.execute()` delegates to `UpdateMongoCommand` which inherits `WriteMongoCommand.execute()` retry logic. When a retry swaps the connection (e.g. on "not primary", error 251, or "being dropped" errors), the new connection is set on the inner `UpdateMongoCommand` but not propagated back to `StoreMongoCommand`.

This causes:
- `MorphiumWriterImpl` releases the **original** (already released) connection in its `finally` block
- The **new** connection leaks from the pool
- Under repeated failover/primary elections, pool exhaustion occurs

## Fix

1. **`StoreMongoCommand.execute()`**: After delegation, check if the connection was swapped and propagate it back.
2. **`MorphiumWriterImpl` (line 667)**: Re-read the connection from the command after `execute()` so the `finally` block releases the correct one.

## Test

The `executeAsync()` path is intentionally not modified — `WriteMongoCommand` does not override `executeAsync()`, so no retry connection swaps happen there.