### PR TITLE
Introduce field name translation in Aggregator pipeline stages

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
@@ -48,6 +48,11 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         setResultType(resultType);
     }
 
+    private String tf(String field) {
+        if (morphium.getARHelper().getField(type, field) == null) return field;
+        return morphium.getARHelper().getMongoFieldName(type, field);
+    }
+
     @Override
     public Collation getCollation() {
         return collation;
@@ -108,10 +113,11 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         Map<String, Object> p = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
+            String key = tf(e.getKey());
             if (e.getValue() instanceof Expr) {
-                p.put(e.getKey(), ((Expr) e.getValue()).toQueryObject());
+                p.put(key, ((Expr) e.getValue()).toQueryObject());
             } else {
-                p.put(e.getKey(), e.getValue());
+                p.put(key, e.getValue());
             }
         }
 
@@ -226,7 +232,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> unwind(String listField) {
-        Map<String, Object> o = UtilsMap.of("$unwind", listField);
+        Map<String, Object> o = UtilsMap.of("$unwind", tf(listField));
         params.add(o);
         return this;
     }
@@ -296,6 +302,9 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public Group<T, R> group(String id) {
+        if (id != null && id.startsWith("$")) {
+            id = "$" + tf(id.substring(1));
+        }
         Group<T, R> gr = new Group<>(this, id);
         groups.add(gr);
         return gr;
@@ -750,7 +759,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         Map<String, Object> m = UtilsMap.of("from", fromCollection);
 
         if (localField != null)
-            m.put("localField", localField);
+            m.put("localField", tf(localField));
 
         if (foreignField != null)
             m.put("foreignField", foreignField);
@@ -962,13 +971,13 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> unset(List<String> field) {
-        params.add(UtilsMap.of("$unset", field));
+        params.add(UtilsMap.of("$unset", field.stream().map(this::tf).collect(Collectors.toList())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unset(String... param) {
-        params.add(UtilsMap.of("$unset", Arrays.asList(param)));
+        params.add(UtilsMap.of("$unset", Arrays.stream(param).map(this::tf).collect(Collectors.toList())));
         return this;
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
@@ -38,6 +38,11 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         setResultType(resultType);
     }
 
+    private String tf(String field) {
+        if (morphium.getARHelper().getField(type, field) == null) return field;
+        return morphium.getARHelper().getMongoFieldName(type, field);
+    }
+
     @Override
     public Collation getCollation() {
         return collation;
@@ -112,7 +117,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         Map<String, Object> p = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
-            p.put(e.getKey(), e.getValue());
+            p.put(tf(e.getKey()), e.getValue());
         }
 
         Map<String, Object> map = UtilsMap.of("$project", p);
@@ -205,7 +210,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> unwind(String listField) {
-        Map<String, Object> o = UtilsMap.of("$unwind", listField);
+        Map<String, Object> o = UtilsMap.of("$unwind", tf(listField));
         params.add(o);
         return this;
     }
@@ -281,6 +286,9 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Group<T, R> group(String id) {
+        if (id != null && id.startsWith("$")) {
+            id = "$" + tf(id.substring(1));
+        }
         Group<T, R> gr = new Group<>(this, id);
         groups.add(gr);
         return gr;
@@ -631,7 +639,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         Map<String, Object> m = new HashMap<>(UtilsMap.of("from", fromCollection));
 
         if (localField != null) {
-            m.put("localField", localField);
+            m.put("localField", tf(localField));
         }
 
         if (foreignField != null) {
@@ -862,13 +870,13 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> unset(List<String> field) {
-        params.add(UtilsMap.of("$unset", field));
+        params.add(UtilsMap.of("$unset", field.stream().map(this::tf).collect(Collectors.toList())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unset(String... param) {
-        params.add(UtilsMap.of("$unset", Arrays.asList(param)));
+        params.add(UtilsMap.of("$unset", Arrays.stream(param).map(this::tf).collect(Collectors.toList())));
         return this;
     }
 

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
@@ -1,0 +1,95 @@
+package de.caluga.test.mongo.suite.inmem;
+
+import de.caluga.morphium.aggregation.Aggregator;
+import de.caluga.morphium.aggregation.Expr;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.annotations.caching.NoCache;
+import de.caluga.morphium.driver.MorphiumId;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that AggregatorImpl translates Java camelCase field names to their
+ * MongoDB equivalents when building the pipeline
+ */
+@SuppressWarnings("rawtypes")
+@Tag("inmemory")
+public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
+
+    @NoCache
+    @Entity(translateCamelCase = true)
+    public static class AggEntity {
+        @Id
+        private MorphiumId id;
+        private String firstName;
+        private String lastName;
+        private int itemCount;
+
+        public AggEntity() {}
+    }
+
+    private Map<String, Object> firstStage(Aggregator<AggEntity, Map> agg) {
+        List<Map<String, Object>> pipeline = agg.getPipeline();
+        assertFalse(pipeline.isEmpty(), "pipeline should have at least one stage");
+        return pipeline.get(0);
+    }
+
+    @Test
+    public void projectTranslatesCamelCaseFieldNames() {
+        Aggregator<AggEntity, Map> agg = morphium.createAggregator(AggEntity.class, Map.class);
+        agg.project("firstName", "lastName");
+
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey("$project"), "stage should be $project");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> projection = (Map<String, Object>) stage.get("$project");
+
+        assertTrue(projection.containsKey("first_name"), "firstName should be translated to first_name in pipeline");
+        assertTrue(projection.containsKey("last_name"), "lastName should be translated to last_name in pipeline");
+        assertFalse(projection.containsKey("firstName"), "untranslated firstName should not appear in pipeline");
+    }
+
+    @Test
+    public void projectWithExprTranslatesCamelCaseFieldName() {
+        Aggregator<AggEntity, Map> agg = morphium.createAggregator(AggEntity.class, Map.class);
+        agg.project("itemCount", Expr.field("item_count"));
+
+        Map<String, Object> stage = firstStage(agg);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> projection = (Map<String, Object>) stage.get("$project");
+
+        assertTrue(projection.containsKey("item_count"), "itemCount should be translated to item_count in pipeline");
+        assertFalse(projection.containsKey("itemCount"), "untranslated itemCount should not appear in pipeline");
+    }
+
+    @Test
+    public void unwindTranslatesCamelCaseFieldName() {
+        Aggregator<AggEntity, Map> agg = morphium.createAggregator(AggEntity.class, Map.class);
+        agg.unwind("firstName");
+
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey("$unwind"), "stage should be $unwind");
+        assertEquals("first_name", stage.get("$unwind"), "firstName should be translated to first_name in pipeline");
+    }
+
+    @Test
+    public void unsetTranslatesCamelCaseFieldNames() {
+        Aggregator<AggEntity, Map> agg = morphium.createAggregator(AggEntity.class, Map.class);
+        agg.unset("firstName", "lastName");
+
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey("$unset"), "stage should be $unset");
+        @SuppressWarnings("unchecked")
+        List<String> fields = (List<String>) stage.get("$unset");
+
+        assertTrue(fields.contains("first_name"), "firstName should be translated to first_name in pipeline");
+        assertTrue(fields.contains("last_name"), "lastName should be translated to last_name in pipeline");
+        assertFalse(fields.contains("firstName"), "untranslated firstName should not appear in pipeline");
+    }
+}

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/InMemAggregationTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/InMemAggregationTests.java
@@ -7,6 +7,7 @@ import de.caluga.morphium.aggregation.Expr;
 import de.caluga.morphium.annotations.Embedded;
 import de.caluga.morphium.annotations.Entity;
 import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.annotations.caching.NoCache;
 import de.caluga.morphium.driver.MorphiumId;
 import de.caluga.test.mongo.suite.data.ListContainer;
 import de.caluga.test.mongo.suite.data.UncachedObject;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -297,6 +299,77 @@ public class InMemAggregationTests extends MorphiumInMemTestBase {
         }
 
         log.info("$function graceful fallback test completed successfully");
+    }
+
+    @NoCache
+    @Entity
+    public static class TypeAggregation {
+        @Id
+        private String type;
+        private double totals;
+        private int count;
+
+        public String getType() { return type; }
+        public double getTotals() { return totals; }
+        public int getCount() { return count; }
+
+        public String toString() {
+            return String.format("typeAgg: %s:%d/%f", type, count, totals);
+        }
+    }
+
+    @Test
+    public void projectExcludeFieldNameTranslation() throws Exception {
+        for (int i = 0; i < 9; i++) {
+            morphium.store(new UncachedObject("mod" + (i % 3), i));
+        }
+
+        Aggregator<UncachedObject, TypeAggregation> agg =
+                morphium.createAggregator(UncachedObject.class, TypeAggregation.class);
+        agg.match(morphium.createQueryFor(UncachedObject.class).f("counter").gte(0));
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("strValue", 1);
+        map.put("counter", 1);
+        map.put("_id", 0);        // exclude — change key to "strValue" on str_value to see the bug
+        agg.project(map);
+
+        agg.group("$strValue").sum("totals", "$counter").sum("count", 1).end();
+
+        List<TypeAggregation> result = agg.aggregate();
+        assertEquals(3, result.size(), "should have 3 distinct str_value groups");
+        result.sort(Comparator.comparing(TypeAggregation::getType));
+        for (TypeAggregation ta : result) {
+            assertNotNull(ta.getType(), "group key must not be null — str_value was correctly projected");
+            assertEquals(3, ta.getCount(), "each group should contain 3 documents");
+        }
+    }
+
+    @Test
+    public void projectFieldNameTranslationSnakeCase() throws Exception {
+        for (int i = 0; i < 9; i++) {
+            morphium.store(new UncachedObject("mod" + (i % 3), i));
+        }
+
+        Aggregator<UncachedObject, TypeAggregation> agg =
+                morphium.createAggregator(UncachedObject.class, TypeAggregation.class);
+        agg.match(morphium.createQueryFor(UncachedObject.class).f("counter").gte(0));
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("str_value", 1);
+        map.put("counter", 1);
+        map.put("_id", 0);
+        agg.project(map);
+
+        agg.group("$str_value").sum("totals", "$counter").sum("count", 1).end();
+
+        List<TypeAggregation> result = agg.aggregate();
+        assertEquals(3, result.size(), "should have 3 distinct str_value groups");
+        result.sort(Comparator.comparing(TypeAggregation::getType));
+        for (TypeAggregation ta : result) {
+            assertNotNull(ta.getType(), "group key must not be null — str_value was correctly projected");
+            assertEquals(3, ta.getCount(), "each group should contain 3 documents");
+        }
     }
 
     @Test


### PR DESCRIPTION
# fix: translate field names in Aggregator pipeline stages (#198)

## Problem

When building an aggregation pipeline using Java camelCase field names (e.g. `strValue`), the pipeline stages were forwarding those names verbatim to MongoDB. For entities with `translateCamelCase = true`, MongoDB stores the field as `str_value`, so references like `"strValue"` in `$project`, `$group`, `$unwind`, `$unset`, or `$lookup` would silently produce wrong results — fields not excluded, group keys resolving to `null`, lookups failing to join.

The same class of bug was previously fixed for `Query.distinct()` in #197.

## Changes

### `AggregatorImpl` and `InMemAggregator`

Both implementations receive the same fix to keep their behaviour in sync.

A private `tf(String field)` helper is added to each class. It delegates to `ARHelper.getMongoFieldName()` when the field exists on the source entity, and returns the name unchanged otherwise (so already-translated snake_case names pass through safely).

`tf()` is now applied in:

| Stage / method | What is translated |
|---|---|
| `project(Map)` | every projection key |
| `unwind(String)` | the unwound field name |
| `group(String id)` | the `$fieldRef` in the group ID |
| `lookup(…, localField, …)` | the local join field |
| `unset(List)` / `unset(String...)` | every field in the unset list |

### New tests

**`AggregatorFieldNameTranslationTest`** (new file) — unit tests that assert the pipeline `Map` contains translated keys before any execution:
- `projectTranslatesCamelCaseFieldNames` — `$project` keys
- `projectWithExprTranslatesCamelCaseFieldName` — `$project` with `Expr`
- `unwindTranslatesCamelCaseFieldName` — `$unwind` value
- `unsetTranslatesCamelCaseFieldNames` — `$unset` list

**`InMemAggregationTests`** — two end-to-end tests over the in-memory driver:
- `projectExcludeFieldNameTranslation` — uses Java camelCase names (`strValue`, `$strValue`) through `$project` → `$group`; verifies 3 groups × 3 documents each
- `projectFieldNameTranslationSnakeCase` — same pipeline with MongoDB snake_case names (`str_value`, `$str_value`); verifies backward compatibility

## Behaviour

Callers may now pass either the Java field name or the MongoDB field name to any of the affected methods — both are accepted and produce a correctly translated pipeline. There is no breaking change.
