### PR TITLE
feat(classgraph): add ClassGraphCache.preRegister() to inject build-time discovered class names

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/ClassGraphCache.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/ClassGraphCache.java
@@ -4,9 +4,12 @@ import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ClassInfoList;
 import io.github.classgraph.ScanResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -15,6 +18,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * Morphium instance creation.
  */
 public final class ClassGraphCache {
+
+    private static final Logger log = LoggerFactory.getLogger(ClassGraphCache.class);
 
     private static volatile List<String> allClassNames;
     private static volatile ScanResult cachedScanResult;
@@ -73,6 +78,37 @@ public final class ClassGraphCache {
      */
     public static ClassInfoList getSubclassInfoOf(String className) {
         return getScanResult().getSubclasses(className);
+    }
+
+    /**
+     * Pre-populate the annotation cache with a known list of class names.
+     *
+     * <p>Must be called <em>before</em> the first call to
+     * {@link #getClassesWithAnnotation(String)} for the same annotation name.
+     * When an entry is already present in the cache the pre-registered list wins
+     * (the {@code computeIfAbsent} in {@code getClassesWithAnnotation} will find
+     * the existing entry and skip the ClassGraph scan entirely).
+     *
+     * <p>Calling this method with an empty list is valid and intentional: it puts
+     * an empty entry into the cache, which causes {@code getClassesWithAnnotation}
+     * to return the empty list without triggering a live ClassGraph scan.
+     *
+     * <p>Primary use-case: Quarkus native image. ClassGraph finds nothing at
+     * runtime because there is no live classpath; this method lets the
+     * quarkus-morphium extension inject the Jandex-discovered class names that
+     * were collected at build time.
+     *
+     * @param annotationName fully qualified annotation class name (must not be null)
+     * @param classNames     list of class names to register (must not be null)
+     */
+    public static void preRegister(String annotationName, List<String> classNames) {
+        Objects.requireNonNull(annotationName, "annotationName must not be null");
+        Objects.requireNonNull(classNames, "classNames must not be null");
+        if (classNames.isEmpty()) {
+            log.warn("preRegister called with empty class list for annotation {} — "
+                    + "ClassGraph scan will be skipped but no classes are registered", annotationName);
+        }
+        classesWithAnnotation.put(annotationName, List.copyOf(classNames));
     }
 
     /**

--- a/morphium-core/src/main/java/de/caluga/morphium/ClassGraphCache.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/ClassGraphCache.java
@@ -83,15 +83,18 @@ public final class ClassGraphCache {
     /**
      * Pre-populate the annotation cache with a known list of class names.
      *
-     * <p>Must be called <em>before</em> the first call to
-     * {@link #getClassesWithAnnotation(String)} for the same annotation name.
-     * When an entry is already present in the cache the pre-registered list wins
-     * (the {@code computeIfAbsent} in {@code getClassesWithAnnotation} will find
-     * the existing entry and skip the ClassGraph scan entirely).
+     * <p>Intended to be called <em>before</em> the first call to
+     * {@link #getClassesWithAnnotation(String)} for the same annotation name. The cache is
+     * treated as write-once: this method only inserts when no entry exists yet
+     * ({@code putIfAbsent}). An already-present entry — whether from a previous
+     * {@code preRegister} or from a live scan via {@code getClassesWithAnnotation} — is kept
+     * unchanged, so the cache stays immutable after initialization and is safe to call from a
+     * concurrent startup sequence.
      *
-     * <p>Calling this method with an empty list is valid and intentional: it puts
-     * an empty entry into the cache, which causes {@code getClassesWithAnnotation}
-     * to return the empty list without triggering a live ClassGraph scan.
+     * <p>Calling this method with an empty list is valid and intentional: it seeds an empty
+     * entry, which causes {@code getClassesWithAnnotation} to return the empty list without
+     * triggering a live ClassGraph scan. The empty-list warning is logged only when the empty
+     * entry was actually inserted (i.e. no entry existed yet).
      *
      * <p>Primary use-case: Quarkus native image. ClassGraph finds nothing at
      * runtime because there is no live classpath; this method lets the
@@ -104,11 +107,11 @@ public final class ClassGraphCache {
     public static void preRegister(String annotationName, List<String> classNames) {
         Objects.requireNonNull(annotationName, "annotationName must not be null");
         Objects.requireNonNull(classNames, "classNames must not be null");
-        if (classNames.isEmpty()) {
+        List<String> previous = classesWithAnnotation.putIfAbsent(annotationName, List.copyOf(classNames));
+        if (previous == null && classNames.isEmpty()) {
             log.warn("preRegister called with empty class list for annotation {} — "
                     + "ClassGraph scan will be skipped but no classes are registered", annotationName);
         }
-        classesWithAnnotation.put(annotationName, List.copyOf(classNames));
     }
 
     /**

--- a/morphium-core/src/main/java/de/caluga/morphium/ClassGraphCache.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/ClassGraphCache.java
@@ -25,6 +25,14 @@ public final class ClassGraphCache {
     private static volatile ScanResult cachedScanResult;
     private static final Map<String, List<String>> classesWithAnnotation = new ConcurrentHashMap<>();
     private static final Map<String, List<String>> subclassesOf = new ConcurrentHashMap<>();
+    /**
+     * Build-time pre-registered class names per annotation. Unlike {@link #classesWithAnnotation}
+     * (a scan cache cleared by {@link #invalidate()}), this map survives invalidation and always
+     * takes precedence over a live scan — mirroring the {@code preRegisteredTypeIds} hook in
+     * {@code AnnotationAndReflectionHelper}. This keeps a Quarkus native image scan-free even
+     * after a cache invalidation, where a live scan would silently find nothing.
+     */
+    private static final Map<String, List<String>> preRegisteredClassesWithAnnotation = new ConcurrentHashMap<>();
     private static final Object lock = new Object();
 
     private ClassGraphCache() {}
@@ -45,9 +53,16 @@ public final class ClassGraphCache {
 
     /**
      * Get class names annotated with the given annotation.
-     * Results are cached after first lookup.
+     *
+     * <p>A build-time pre-registration via {@link #preRegisterClassesWithAnnotation(String, List)}
+     * always wins and is returned without a live scan. Otherwise the result is taken from (or
+     * computed into) the scan cache on first lookup.
      */
     public static List<String> getClassesWithAnnotation(String annotationName) {
+        List<String> preRegistered = preRegisteredClassesWithAnnotation.get(annotationName);
+        if (preRegistered != null) {
+            return preRegistered;
+        }
         return classesWithAnnotation.computeIfAbsent(annotationName, name -> {
             ClassInfoList list = getScanResult().getClassesWithAnnotation(name);
             return List.copyOf(list.getNames());
@@ -81,41 +96,43 @@ public final class ClassGraphCache {
     }
 
     /**
-     * Pre-populate the annotation cache with a known list of class names.
+     * Pre-register the class names annotated with a given annotation, collected at build time.
      *
-     * <p>Intended to be called <em>before</em> the first call to
-     * {@link #getClassesWithAnnotation(String)} for the same annotation name. The cache is
-     * treated as write-once: this method only inserts when no entry exists yet
-     * ({@code putIfAbsent}). An already-present entry — whether from a previous
-     * {@code preRegister} or from a live scan via {@code getClassesWithAnnotation} — is kept
-     * unchanged, so the cache stays immutable after initialization and is safe to call from a
-     * concurrent startup sequence.
+     * <p>A pre-registration always takes precedence over a live ClassGraph scan in
+     * {@link #getClassesWithAnnotation(String)} and, unlike the scan cache, <strong>survives
+     * {@link #invalidate()}</strong> — it is re-applied on the next lookup. This mirrors the
+     * {@code registerTypeIds()} hook in {@code AnnotationAndReflectionHelper} and keeps a Quarkus
+     * native image scan-free even across invalidations, where a live scan would silently find
+     * nothing.
      *
-     * <p>Calling this method with an empty list is valid and intentional: it seeds an empty
-     * entry, which causes {@code getClassesWithAnnotation} to return the empty list without
-     * triggering a live ClassGraph scan. The empty-list warning is logged only when the empty
-     * entry was actually inserted (i.e. no entry existed yet).
+     * <p>Last call wins: a later pre-registration for the same annotation replaces the previous
+     * one. An empty list is valid and intentional — it pins an empty result and skips the live
+     * scan (e.g. an app with no {@code @Capped}/{@code @Driver}/{@code @Messaging} classes).
      *
-     * <p>Primary use-case: Quarkus native image. ClassGraph finds nothing at
-     * runtime because there is no live classpath; this method lets the
-     * quarkus-morphium extension inject the Jandex-discovered class names that
-     * were collected at build time.
+     * <p>Note: this hook only covers the name-based {@link #getClassesWithAnnotation(String)}
+     * path. {@link #getClassInfoWithAnnotation(String)} (used by the startup index check) and the
+     * {@code subclassesOf} cache still require a live scan; native-image callers that must avoid
+     * any scan should account for those paths separately.
      *
      * @param annotationName fully qualified annotation class name (must not be null)
-     * @param classNames     list of class names to register (must not be null)
+     * @param classNames     list of class names to register (must not be null; may be empty)
      */
-    public static void preRegister(String annotationName, List<String> classNames) {
+    public static void preRegisterClassesWithAnnotation(String annotationName, List<String> classNames) {
         Objects.requireNonNull(annotationName, "annotationName must not be null");
         Objects.requireNonNull(classNames, "classNames must not be null");
-        List<String> previous = classesWithAnnotation.putIfAbsent(annotationName, List.copyOf(classNames));
-        if (previous == null && classNames.isEmpty()) {
-            log.warn("preRegister called with empty class list for annotation {} — "
-                    + "ClassGraph scan will be skipped but no classes are registered", annotationName);
+        preRegisteredClassesWithAnnotation.put(annotationName, List.copyOf(classNames));
+        if (classNames.isEmpty()) {
+            log.debug("preRegisterClassesWithAnnotation: empty class list for annotation {} — "
+                    + "live scan skipped, no classes registered for it", annotationName);
         }
     }
 
     /**
      * Force cache invalidation. Useful for testing or hot-reload scenarios.
+     *
+     * <p>Clears the scan result and the scan caches. Build-time pre-registrations made via
+     * {@link #preRegisterClassesWithAnnotation(String, List)} are intentionally <strong>kept</strong>,
+     * so they keep taking effect after a re-scan. Use {@link #clearPreRegistrations()} to drop them.
      */
     public static void invalidate() {
         synchronized (lock) {
@@ -127,5 +144,13 @@ public final class ClassGraphCache {
             subclassesOf.clear();
             allClassNames = null;
         }
+    }
+
+    /**
+     * Drop all build-time pre-registrations. Mainly for tests and hot-reload scenarios where the
+     * set of entities changes; ordinary {@link #invalidate()} deliberately keeps them.
+     */
+    public static void clearPreRegistrations() {
+        preRegisteredClassesWithAnnotation.clear();
     }
 }

--- a/morphium-core/src/main/java/de/caluga/morphium/ClassGraphCache.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/ClassGraphCache.java
@@ -28,9 +28,10 @@ public final class ClassGraphCache {
     /**
      * Build-time pre-registered class names per annotation. Unlike {@link #classesWithAnnotation}
      * (a scan cache cleared by {@link #invalidate()}), this map survives invalidation and always
-     * takes precedence over a live scan — mirroring the {@code preRegisteredTypeIds} hook in
-     * {@code AnnotationAndReflectionHelper}. This keeps a Quarkus native image scan-free even
-     * after a cache invalidation, where a live scan would silently find nothing.
+     * takes precedence over a live scan. This follows the same pattern as the
+     * {@code preRegisteredTypeIds} hook in {@code AnnotationAndReflectionHelper} (a separate map
+     * that survives cache invalidation), and keeps a Quarkus native image scan-free even after a
+     * cache invalidation, where a live scan would silently find nothing.
      */
     private static final Map<String, List<String>> preRegisteredClassesWithAnnotation = new ConcurrentHashMap<>();
     private static final Object lock = new Object();
@@ -100,14 +101,18 @@ public final class ClassGraphCache {
      *
      * <p>A pre-registration always takes precedence over a live ClassGraph scan in
      * {@link #getClassesWithAnnotation(String)} and, unlike the scan cache, <strong>survives
-     * {@link #invalidate()}</strong> — it is re-applied on the next lookup. This mirrors the
-     * {@code registerTypeIds()} hook in {@code AnnotationAndReflectionHelper} and keeps a Quarkus
-     * native image scan-free even across invalidations, where a live scan would silently find
-     * nothing.
+     * {@link #invalidate()}</strong> — it is re-applied on the next lookup. This follows the same
+     * pattern as the {@code registerTypeIds()} hook in {@code AnnotationAndReflectionHelper} (a
+     * separate map that survives cache invalidation) and keeps a Quarkus native image scan-free
+     * even across invalidations, where a live scan would silently find nothing.
+     *
+     * <p>Note the empty-list semantics differ from {@code registerTypeIds()}, which only skips the
+     * scan when its map is non-empty: here an empty list is valid and intentional — it pins an
+     * empty result and skips the live scan (e.g. an app with no
+     * {@code @Capped}/{@code @Driver}/{@code @Messaging} classes).
      *
      * <p>Last call wins: a later pre-registration for the same annotation replaces the previous
-     * one. An empty list is valid and intentional — it pins an empty result and skips the live
-     * scan (e.g. an app with no {@code @Capped}/{@code @Driver}/{@code @Messaging} classes).
+     * one.
      *
      * <p>Note: this hook only covers the name-based {@link #getClassesWithAnnotation(String)}
      * path. {@link #getClassInfoWithAnnotation(String)} (used by the startup index check) and the

--- a/morphium-core/src/test/java/de/caluga/test/morphium/ClassGraphCachePreRegisterTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/ClassGraphCachePreRegisterTest.java
@@ -1,0 +1,60 @@
+package de.caluga.test.morphium;
+
+import de.caluga.morphium.ClassGraphCache;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the write-once semantics of {@link ClassGraphCache#preRegister(String, java.util.List)}:
+ * a pre-registered entry must not be overwritten by a later preRegister, keeping the cache
+ * immutable after initialization (addresses the Copilot review note on PR #200).
+ */
+@Tag("core")
+public class ClassGraphCachePreRegisterTest {
+
+    // unique, made-up annotation names so we never hit a real ClassGraph scan
+    private static final String ANNO = "de.caluga.test.NoSuchAnnotation_PreRegisterTest";
+    private static final String ANNO_EMPTY = "de.caluga.test.NoSuchAnnotation_PreRegisterEmptyTest";
+
+    @BeforeEach
+    @AfterEach
+    public void reset() {
+        ClassGraphCache.invalidate();
+    }
+
+    @Test
+    public void preRegisterSeedsTheCache() {
+        ClassGraphCache.preRegister(ANNO, List.of("com.example.A", "com.example.B"));
+        assertEquals(List.of("com.example.A", "com.example.B"),
+                ClassGraphCache.getClassesWithAnnotation(ANNO));
+    }
+
+    @Test
+    public void secondPreRegisterDoesNotOverwrite() {
+        ClassGraphCache.preRegister(ANNO, List.of("com.example.A"));
+        // a later call must NOT replace the existing entry (write-once)
+        ClassGraphCache.preRegister(ANNO, List.of("com.example.X", "com.example.Y"));
+        assertEquals(List.of("com.example.A"),
+                ClassGraphCache.getClassesWithAnnotation(ANNO),
+                "an already-registered entry must be kept unchanged");
+    }
+
+    @Test
+    public void emptyPreRegisterSkipsScanAndReturnsEmpty() {
+        ClassGraphCache.preRegister(ANNO_EMPTY, List.of());
+        assertTrue(ClassGraphCache.getClassesWithAnnotation(ANNO_EMPTY).isEmpty(),
+                "an empty pre-registration must return empty without a live scan");
+    }
+
+    @Test
+    public void preRegisterRejectsNullArguments() {
+        assertThrows(NullPointerException.class, () -> ClassGraphCache.preRegister(null, List.of()));
+        assertThrows(NullPointerException.class, () -> ClassGraphCache.preRegister(ANNO, null));
+    }
+}

--- a/morphium-core/src/test/java/de/caluga/test/morphium/ClassGraphCachePreRegisterTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/ClassGraphCachePreRegisterTest.java
@@ -11,14 +11,14 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Verifies the write-once semantics of {@link ClassGraphCache#preRegister(String, java.util.List)}:
- * a pre-registered entry must not be overwritten by a later preRegister, keeping the cache
- * immutable after initialization (addresses the Copilot review note on PR #200).
+ * Pins the contract of {@link ClassGraphCache#preRegisterClassesWithAnnotation(String, List)}:
+ * pre-registrations win over a live scan, follow last-write-wins, accept an empty list, and
+ * survive {@link ClassGraphCache#invalidate()} (addresses the review feedback on PR #200).
  */
 @Tag("core")
 public class ClassGraphCachePreRegisterTest {
 
-    // unique, made-up annotation names so we never hit a real ClassGraph scan
+    // unique, made-up annotation names so we never trigger a real ClassGraph scan
     private static final String ANNO = "de.caluga.test.NoSuchAnnotation_PreRegisterTest";
     private static final String ANNO_EMPTY = "de.caluga.test.NoSuchAnnotation_PreRegisterEmptyTest";
 
@@ -26,35 +26,57 @@ public class ClassGraphCachePreRegisterTest {
     @AfterEach
     public void reset() {
         ClassGraphCache.invalidate();
+        ClassGraphCache.clearPreRegistrations();
     }
 
     @Test
-    public void preRegisterSeedsTheCache() {
-        ClassGraphCache.preRegister(ANNO, List.of("com.example.A", "com.example.B"));
+    public void preRegisterSeedsTheLookup() {
+        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO, List.of("com.example.A", "com.example.B"));
         assertEquals(List.of("com.example.A", "com.example.B"),
                 ClassGraphCache.getClassesWithAnnotation(ANNO));
     }
 
     @Test
-    public void secondPreRegisterDoesNotOverwrite() {
-        ClassGraphCache.preRegister(ANNO, List.of("com.example.A"));
-        // a later call must NOT replace the existing entry (write-once)
-        ClassGraphCache.preRegister(ANNO, List.of("com.example.X", "com.example.Y"));
-        assertEquals(List.of("com.example.A"),
+    public void lastPreRegisterWins() {
+        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO, List.of("com.example.A"));
+        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO, List.of("com.example.X", "com.example.Y"));
+        assertEquals(List.of("com.example.X", "com.example.Y"),
                 ClassGraphCache.getClassesWithAnnotation(ANNO),
-                "an already-registered entry must be kept unchanged");
+                "a later pre-registration must replace the previous one (last-write-wins)");
     }
 
     @Test
     public void emptyPreRegisterSkipsScanAndReturnsEmpty() {
-        ClassGraphCache.preRegister(ANNO_EMPTY, List.of());
+        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO_EMPTY, List.of());
         assertTrue(ClassGraphCache.getClassesWithAnnotation(ANNO_EMPTY).isEmpty(),
                 "an empty pre-registration must return empty without a live scan");
     }
 
     @Test
+    public void preRegistrationSurvivesInvalidate() {
+        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO, List.of("com.example.A"));
+        // invalidate() drops the scan caches but must keep build-time pre-registrations,
+        // otherwise the next lookup would fall back to a live scan (empty in a native image).
+        ClassGraphCache.invalidate();
+        assertEquals(List.of("com.example.A"),
+                ClassGraphCache.getClassesWithAnnotation(ANNO),
+                "pre-registered entries must survive invalidate()");
+    }
+
+    @Test
+    public void clearPreRegistrationsDropsThem() {
+        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO_EMPTY, List.of());
+        ClassGraphCache.clearPreRegistrations();
+        // ANNO_EMPTY was made-up and not on the classpath, so after clearing, the lookup falls
+        // back to a live scan that finds nothing — still empty, but no longer pinned.
+        assertTrue(ClassGraphCache.getClassesWithAnnotation(ANNO_EMPTY).isEmpty());
+    }
+
+    @Test
     public void preRegisterRejectsNullArguments() {
-        assertThrows(NullPointerException.class, () -> ClassGraphCache.preRegister(null, List.of()));
-        assertThrows(NullPointerException.class, () -> ClassGraphCache.preRegister(ANNO, null));
+        assertThrows(NullPointerException.class,
+                () -> ClassGraphCache.preRegisterClassesWithAnnotation(null, List.of()));
+        assertThrows(NullPointerException.class,
+                () -> ClassGraphCache.preRegisterClassesWithAnnotation(ANNO, null));
     }
 }

--- a/morphium-core/src/test/java/de/caluga/test/morphium/ClassGraphCachePreRegisterTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/ClassGraphCachePreRegisterTest.java
@@ -65,11 +65,28 @@ public class ClassGraphCachePreRegisterTest {
 
     @Test
     public void clearPreRegistrationsDropsThem() {
-        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO_EMPTY, List.of());
+        // Pin a NON-empty list. ANNO is a made-up annotation not on the classpath, so once the
+        // pre-registration is cleared the lookup falls back to a live scan that finds nothing.
+        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO, List.of("com.example.A"));
+        assertEquals(List.of("com.example.A"), ClassGraphCache.getClassesWithAnnotation(ANNO),
+                "sanity: the pre-registration is in effect before clearing");
+
         ClassGraphCache.clearPreRegistrations();
-        // ANNO_EMPTY was made-up and not on the classpath, so after clearing, the lookup falls
-        // back to a live scan that finds nothing — still empty, but no longer pinned.
-        assertTrue(ClassGraphCache.getClassesWithAnnotation(ANNO_EMPTY).isEmpty());
+
+        assertTrue(ClassGraphCache.getClassesWithAnnotation(ANNO).isEmpty(),
+                "after clearPreRegistrations() the pinned entry must be gone (scan finds nothing)");
+    }
+
+    @Test
+    public void preRegisterOverridesAnAlreadyScannedEntry() {
+        // Populate the scan cache FIRST (made-up annotation -> scan yields empty, cached as empty).
+        assertTrue(ClassGraphCache.getClassesWithAnnotation(ANNO).isEmpty(),
+                "sanity: a live scan for a made-up annotation yields empty");
+
+        // A pre-registration AFTER the scan must still win.
+        ClassGraphCache.preRegisterClassesWithAnnotation(ANNO, List.of("com.example.A"));
+        assertEquals(List.of("com.example.A"), ClassGraphCache.getClassesWithAnnotation(ANNO),
+                "a pre-registration must override an already-scanned (cached) entry");
     }
 
     @Test


### PR DESCRIPTION
Hi Stephan,

erst mal: wir haben uns lange nicht mehr bei dir gemeldet, und ganz herzlichen
Dank für den WRITE-Zugriff auf Morphium! Den wissen wir sehr zu schätzen.

Damit es klar ist: wir nutzen den Zugriff selbstverständlich nicht, um direkt auf
deine Branches zu pushen. Wir stellen wie gewohnt **Merge Requests** gegen das
Morphium-Hauptprojekt und überlassen dir Review und Merge, so wie auch hier.

## What
Adds a small public API to `ClassGraphCache`:

```java
public static void preRegister(String annotationName, List<String> classNames)
```

It pre-populates the annotation cache with a known list of class names **before**
the first `getClassesWithAnnotation(...)` call for that annotation. When an entry is
already present, the live ClassGraph scan for that annotation is skipped entirely.

## Why
Frameworks that know all relevant classes at build time should not pay for — or
even be able to rely on, a runtime ClassGraph scan. The concrete driver is
**Quarkus native image**: there is no live classpath at runtime, so ClassGraph
finds nothing. The quarkus-morphium extension collects all `@Entity`/`@Embedded`/
`@Capped`/driver/messaging class names via Jandex at build time and needs a way to
hand them to morphium so the cache is correct without a scan.

This is the annotation-cache counterpart to the existing `registerTypeIds()`
pre-registration hook in `AnnotationAndReflectionHelper` (PR #166): same idea,
inject build-time knowledge to avoid a runtime scan, but for a different, currently
unreachable cache (`ClassGraphCache.classesWithAnnotation`, which is private and only
filled lazily via a live scan). The two hooks are complementary, not overlapping.

## Behaviour notes
- Calling with an **empty list** is valid and intentional: it puts an empty entry
  into the cache, so `getClassesWithAnnotation()` returns empty without a live scan.
  A `WARN` is logged in that case so the situation is visible.
- Both arguments are null-checked (`Objects.requireNonNull`).
- The stored list is copied defensively (`List.copyOf`).
- No behaviour change for existing callers: if `preRegister()` is never called,
  `getClassesWithAnnotation()` works exactly as before (lazy `computeIfAbsent` scan).

## Scope
- One file changed: `morphium-core/.../ClassGraphCache.java` (+36 lines).
- No API removed, no signature changed, no dependency added (slf4j already present).

## Testing
Built `morphium-core` against this change and verified the downstream
quarkus-morphium extension now compiles and resolves the cache without a runtime
scan (it previously depended on this method existing). Happy to add a focused unit
test for `preRegister` (empty list / precedence over scan) if you'd like it in this PR.

## Eine Bitte / ein Gesprächsangebot
Wir würden uns freuen, bei Gelegenheit einmal mit dir zu sprechen, **wann und in
welcher Form** man `morphium-jakarta-data` als **optionales Modul** direkt in
Morphium integrieren könnte. Aktuell pflegen wir es als eigenständiges Projekt; eine
Integration als optionales Modul (analog zu den bestehenden Erweiterungspunkten)
würde die Versionierung und die Abhängigkeiten für Downstream-Projekte wie
quarkus-morphium und spring-boot-morphium deutlich vereinfachen. Ganz wie es für
dich und das Projekt am besten passt, wir richten uns gern nach dir.

Viele Grüße aus Stuttgart,
Heiko!
