### PR TITLE
fix(inmem): seed upserted document from equality predicates nested in $and

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -4165,8 +4165,16 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
      * recursively, so a filter like {@code {$and:[{_id:"x"},{expires_at:{$lte:now}}]}} still
      * seeds {@code _id:"x"} into the upserted document.
      *
-     * <p>{@code $or}/{@code $nor} are intentionally skipped: they are ambiguous (no single value
-     * is implied) and MongoDB does not seed from them either.
+     * <p><strong>Known divergences from the real server</strong> (acceptable for an in-memory
+     * test driver, documented so the parity claim above is not overstated):
+     * <ul>
+     *   <li>{@code $or}/{@code $nor} are skipped unconditionally. The real server seeds a
+     *       single-branch {@code $or} (e.g. {@code {$or:[{f:9}]}} → {@code f:9}), because its
+     *       optimizer collapses it to the child; multi-branch {@code $or} and any {@code $nor}
+     *       are never seeded. We do not special-case the single-branch collapse.</li>
+     *   <li>Null equality ({@code {f:null}} / {@code {f:{$eq:null}}}) is dropped here, whereas
+     *       the real server seeds a literal {@code null} — see {@link #seedField}.</li>
+     * </ul>
      *
      * @param filter the query filter
      * @param target the document being built for the upsert; mutated in place
@@ -4183,7 +4191,8 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
             if (isAndOperator(field)) {
                 collectFromAndBranches(predicate, target);
             } else if (isOperatorKey(field)) {
-                // other logical/operator keys ($or, $nor, $expr, ...) do not seed an upsert
+                // Logical/operator keys ($or, $nor, $expr, ...) are not seeded. NB: the real
+                // server does seed a single-branch $or; we deliberately do not (see Javadoc).
                 continue;
             } else {
                 seedField(field, predicate, target);
@@ -4205,10 +4214,16 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
     }
 
     /**
-     * Seeds a single field into the upsert document, applying MongoDB's rules:
-     * a scalar or {@code {$eq: value}} is an equality predicate and is copied; an operator
-     * predicate ({@code $lte}, {@code $gt}, {@code $in}, ...) is ignored; a {@code null} value
-     * removes the field.
+     * Seeds a single field into the upsert document. A scalar or {@code {$eq: value}} is an
+     * equality predicate and is copied; an operator predicate ({@code $lte}, {@code $gt},
+     * {@code $in}, ...) is ignored.
+     *
+     * <p><strong>Null equality deliberately diverges from the real server.</strong> MongoDB
+     * <em>does</em> seed null equality predicates ({@code {f:null}} → {@code f:null}, and even
+     * {@code {_id:{$eq:null}}} → literal {@code _id:null}). We drop the field instead, so for
+     * {@code _id} the driver generates a fresh id. Aligning would require special handling around
+     * fresh-id generation in {@code storeInternal}; null-equality upserts are rare and this
+     * matches the driver's prior behaviour, so the divergence is intentional.
      *
      * <p>Dotted field names (e.g. {@code "a.b"}) are seeded as nested documents
      * ({@code {a:{b:value}}}), matching MongoDB and the rest of the driver's path handling, so a
@@ -4216,6 +4231,7 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
      */
     private void seedField(String field, Object predicate, Map<String, Object> target) {
         if (predicate == null) {
+            // {field: null} — diverges from MongoDB (which seeds null); we leave the field unset.
             removeSeed(target, field);
             return;
         }
@@ -4224,9 +4240,8 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
             Map<String, Object> ops = asStringKeyedMap(predicate);
             if (ops.containsKey("$eq")) {
                 Object eqValue = ops.get("$eq");
-                // {field: {$eq: null}} carries no usable value to seed. Treat it like a null
-                // predicate (remove the field) so the field is left unset; for _id this lets the
-                // driver generate a fresh id rather than seeding an explicit null.
+                // {field: {$eq: null}} — same divergence as {field: null}: MongoDB would seed a
+                // literal null, we drop the field so an upserted _id still gets a fresh id.
                 if (eqValue == null) {
                     removeSeed(target, field);
                 } else {

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -4154,6 +4154,142 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
         return result;
     }
 
+    /**
+     * Seeds an upserted document with the equality predicates of a query filter, mirroring
+     * MongoDB's upsert behaviour.
+     *
+     * <p>Only equality predicates contribute to the new document: a plain scalar
+     * ({@code {field: value}}) or an explicit {@code {field: {$eq: value}}}. Operator
+     * predicates such as {@code $lte}, {@code $gt} or {@code $in} are ignored, exactly as the
+     * real server does. Equality fields nested inside an {@code $and} array are collected
+     * recursively, so a filter like {@code {$and:[{_id:"x"},{expires_at:{$lte:now}}]}} still
+     * seeds {@code _id:"x"} into the upserted document.
+     *
+     * <p>{@code $or}/{@code $nor} are intentionally skipped: they are ambiguous (no single value
+     * is implied) and MongoDB does not seed from them either.
+     *
+     * @param filter the query filter
+     * @param target the document being built for the upsert; mutated in place
+     */
+    private void collectUpsertEqualityFields(Map<String, Object> filter, Map<String, Object> target) {
+        if (filter == null) {
+            return;
+        }
+
+        for (Map.Entry<String, Object> entry : filter.entrySet()) {
+            String field = entry.getKey();
+            Object predicate = entry.getValue();
+
+            if (isAndOperator(field)) {
+                collectFromAndBranches(predicate, target);
+            } else if (isOperatorKey(field)) {
+                // other logical/operator keys ($or, $nor, $expr, ...) do not seed an upsert
+                continue;
+            } else {
+                seedField(field, predicate, target);
+            }
+        }
+    }
+
+    /** Recurse into every sub-filter of an {@code $and} array. */
+    private void collectFromAndBranches(Object andValue, Map<String, Object> target) {
+        if (!(andValue instanceof List<?> branches)) {
+            return;
+        }
+
+        for (Object branch : branches) {
+            if (branch instanceof Map<?, ?> subFilter) {
+                collectUpsertEqualityFields(asStringKeyedMap(subFilter), target);
+            }
+        }
+    }
+
+    /**
+     * Seeds a single field into the upsert document, applying MongoDB's rules:
+     * a scalar or {@code {$eq: value}} is an equality predicate and is copied; an operator
+     * predicate ({@code $lte}, {@code $gt}, {@code $in}, ...) is ignored; a {@code null} value
+     * removes the field.
+     *
+     * <p>Dotted field names (e.g. {@code "a.b"}) are seeded as nested documents
+     * ({@code {a:{b:value}}}), matching MongoDB and the rest of the driver's path handling, so a
+     * later query on {@code a.b} matches the upserted document.
+     */
+    private void seedField(String field, Object predicate, Map<String, Object> target) {
+        if (predicate == null) {
+            removeSeed(target, field);
+            return;
+        }
+
+        if (isOperatorPredicate(predicate)) {
+            Map<String, Object> ops = asStringKeyedMap(predicate);
+            if (ops.containsKey("$eq")) {
+                Object eqValue = ops.get("$eq");
+                // {field: {$eq: null}} carries no usable value to seed. Treat it like a null
+                // predicate (remove the field) so the field is left unset; for _id this lets the
+                // driver generate a fresh id rather than seeding an explicit null.
+                if (eqValue == null) {
+                    removeSeed(target, field);
+                } else {
+                    putSeed(target, field, eqValue);
+                }
+            }
+            // any other operator ($lte, $gt, $in, ...) implies no single value -> do not seed
+            return;
+        }
+
+        putSeed(target, field, predicate);
+    }
+
+    /** Writes a seeded value, expanding dotted field names into nested documents. */
+    private void putSeed(Map<String, Object> target, String field, Object value) {
+        if (field.indexOf('.') >= 0) {
+            setByPath(target, field, value);
+        } else {
+            target.put(field, value);
+        }
+    }
+
+    /** Removes a seeded field, honouring dotted field names. */
+    private void removeSeed(Map<String, Object> target, String field) {
+        if (field.indexOf('.') >= 0) {
+            removeByPath(target, field);
+        } else {
+            target.remove(field);
+        }
+    }
+
+    private boolean isAndOperator(String field) {
+        return "$and".equals(field);
+    }
+
+    private boolean isOperatorKey(String field) {
+        return field.startsWith("$");
+    }
+
+    /**
+     * A predicate is an operator predicate when it is a map with at least one operator key
+     * ({@code $eq}, {@code $lte}, ...). A plain value or an empty map ({@code {}}) is treated as
+     * a scalar equality value, not an operator predicate.
+     */
+    private boolean isOperatorPredicate(Object predicate) {
+        if (!(predicate instanceof Map<?, ?> map) || map.isEmpty()) {
+            return false;
+        }
+
+        for (Object key : map.keySet()) {
+            if (key instanceof String s && s.startsWith("$")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asStringKeyedMap(Object map) {
+        return (Map<String, Object>) map;
+    }
+
     @SuppressWarnings({"ConstantConditions", "unchecked"})
     private Map<String, Object> updateInternal(String db, String collection, Map<String, Object> query,
             Map<String, Object> sort, Map<String, Object> op, boolean multiple, boolean upsert,
@@ -4173,20 +4309,13 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
             }
 
             if (upsert && lst.isEmpty()) {
-                lst.add(new HashMap<>());
-
-                for (String k : query.keySet()) {
-                    if (k.startsWith("$")) {
-                        continue;
-                    }
-
-                    if (query.get(k) != null) {
-                        lst.get(0).put(k, query.get(k));
-                    } else {
-                        lst.get(0).remove(k);
-                    }
-                }
-
+                Map<String, Object> upsertDoc = new HashMap<>();
+                // MongoDB seeds an upserted document with the equality predicates from the
+                // query filter. Collect them — including those nested inside $and — so that
+                // e.g. {$and:[{_id:"x"},{expires_at:{$lte:now}}]} still seeds _id:"x".
+                // Operator predicates ($lte, $gt, $in, ...) are NOT applied, matching MongoDB.
+                collectUpsertEqualityFields(query, upsertDoc);
+                lst.add(upsertDoc);
                 insert = true;
             }
             // Track modifications per object and collect upsert ids

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemUpsertAndExtractionTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemUpsertAndExtractionTest.java
@@ -136,6 +136,56 @@ public class InMemUpsertAndExtractionTest {
                 .isFalse();
     }
 
+    @Test
+    public void explicitEqOperatorSeedsValue() throws Exception {
+        // {$and:[{_id:"x"},{state:{$eq:"active"}}]} — the explicit $eq form must seed like a scalar
+        Map<String, Object> filter = and(
+                eq("_id", "x"),
+                operator("state", "$eq", "active"));
+
+        upsert(filter, set("name", "n"));
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).isEqualTo("x");
+        assertThat(stored.get("state"))
+                .as("an explicit {$eq: value} predicate must seed the value")
+                .isEqualTo("active");
+    }
+
+    @Test
+    public void eqNullDoesNotSeedField() throws Exception {
+        // {$and:[{_id:"x"},{deletedAt:{$eq:null}}]} — DELIBERATE divergence from MongoDB:
+        // the real server seeds a literal null; the in-memory driver leaves the field unset.
+        Map<String, Object> filter = and(
+                eq("_id", "x"),
+                operator("deletedAt", "$eq", null));
+
+        upsert(filter, set("name", "n"));
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).isEqualTo("x");
+        assertThat(stored.containsKey("deletedAt"))
+                .as("{$eq:null} must not seed the field (documented divergence from MongoDB)")
+                .isFalse();
+    }
+
+    @Test
+    public void orBranchesDoNotSeedUpsert() throws Exception {
+        // {$and:[{_id:"x"},{$or:[{role:"admin"}]}]} — $or is not seeded (documented divergence:
+        // MongoDB would collapse a single-branch $or and seed role:"admin").
+        Map<String, Object> filter = and(
+                eq("_id", "x"),
+                Doc.of("$or", List.of(eq("role", "admin"))));
+
+        upsert(filter, set("name", "n"));
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).isEqualTo("x");
+        assertThat(stored.containsKey("role"))
+                .as("$or branches must not seed a value (documented divergence)")
+                .isFalse();
+    }
+
     // --- helpers -------------------------------------------------------------
 
     /** {field: value} — an equality predicate. */

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemUpsertAndExtractionTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemUpsertAndExtractionTest.java
@@ -1,0 +1,185 @@
+package de.caluga.test.morphium.driver;
+
+import de.caluga.morphium.driver.Doc;
+import de.caluga.morphium.driver.commands.ClearCollectionCommand;
+import de.caluga.morphium.driver.commands.DeleteMongoCommand;
+import de.caluga.morphium.driver.commands.FindCommand;
+import de.caluga.morphium.driver.commands.UpdateMongoCommand;
+import de.caluga.morphium.driver.inmem.InMemoryDriver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the InMemoryDriver upsert bug: equality predicates nested inside an
+ * {@code $and} filter must seed the upserted document (mirroring MongoDB), so that a fixed
+ * {@code _id} is used instead of a freshly generated one.
+ *
+ * <p>Concrete trigger: the quarkus-morphium migration lock acquires its lock via
+ * {@code findAndModify({$and:[{_id:"migration_lock"},{expires_at:{$lte:now}}]}, upsert:true)}
+ * and later deletes by {@code _id="migration_lock"}. Before the fix the upserted document got a
+ * generated ObjectId, so the delete never matched and the lock leaked.
+ */
+@Tag("inmemory")
+public class InMemUpsertAndExtractionTest {
+
+    private static final String DB = "upsert_and_db";
+    private static final String COLL = "locks";
+
+    private InMemoryDriver driver;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        driver = new InMemoryDriver();
+        driver.connect();
+        new ClearCollectionCommand(driver).setDb(DB).setColl(COLL).doClear();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        driver.close();
+    }
+
+    @Test
+    public void upsertSeedsIdFromAndFilter() throws Exception {
+        Date now = new Date();
+        // {$and:[{_id:"migration_lock"},{expires_at:{$lte:now}}]} — exactly what the lock acquire builds
+        Map<String, Object> filter = and(
+                eq("_id", "migration_lock"),
+                operator("expires_at", "$lte", now));
+        Map<String, Object> setOwner = set("owner", "owner-1");
+
+        Map<String, Object> result = upsert(filter, setOwner);
+
+        assertThat(result.get("upserted")).as("upsert should have inserted a document").isNotNull();
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id"))
+                .as("_id must be seeded from the $and equality predicate, not generated")
+                .isEqualTo("migration_lock");
+        assertThat(stored.get("owner")).isEqualTo("owner-1");
+    }
+
+    @Test
+    public void deleteByIdRemovesUpsertedLock() throws Exception {
+        Date now = new Date();
+        Map<String, Object> filter = and(
+                eq("_id", "migration_lock"),
+                operator("expires_at", "$lte", now));
+
+        upsert(filter, set("owner", "owner-1"));
+
+        // This is exactly the regression: releaseLock() deletes by _id="migration_lock".
+        // Before the fix the upserted doc had a generated id, so this delete matched nothing
+        // and the lock leaked.
+        deleteById("migration_lock");
+
+        assertThat(find(Doc.of()))
+                .as("delete by the fixed _id must remove the upserted lock")
+                .isEmpty();
+    }
+
+    @Test
+    public void upsertSeedsIdFromNestedAndFilter() throws Exception {
+        // {$and:[{$and:[{_id:"nested"}]}]} — recursion must still reach the equality field
+        Map<String, Object> filter = and(and(eq("_id", "nested")));
+
+        upsert(filter, set("owner", "owner-1"));
+
+        assertThat(onlyDocument().get("_id"))
+                .as("_id must be seeded through nested $and recursion")
+                .isEqualTo("nested");
+    }
+
+    @Test
+    public void operatorPredicatesDoNotSeedUpsert() throws Exception {
+        // _id is an equality predicate (seeded); counter has only a $gt predicate (not seeded).
+        Map<String, Object> filter = and(
+                eq("_id", "x"),
+                operator("counter", "$gt", 5));
+
+        upsert(filter, set("name", "n"));
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).isEqualTo("x");
+        assertThat(stored.get("name")).isEqualTo("n");
+        assertThat(stored.get("counter"))
+                .as("an operator predicate ($gt) must not seed a value")
+                .isNull();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void dottedEqualityPredicateSeedsNestedDocument() throws Exception {
+        // {$and:[{_id:"x"},{"a.b": 1}]} — MongoDB seeds the dotted path as a nested doc {a:{b:1}}
+        Map<String, Object> filter = and(
+                eq("_id", "x"),
+                eq("a.b", 1));
+
+        upsert(filter, set("name", "n"));
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).isEqualTo("x");
+        assertThat(stored.get("a"))
+                .as("dotted path a.b must be seeded as a nested document, not a literal key")
+                .isInstanceOf(Map.class);
+        assertThat(((Map<String, Object>) stored.get("a")).get("b")).isEqualTo(1);
+        assertThat(stored.containsKey("a.b"))
+                .as("the literal key \"a.b\" must not exist")
+                .isFalse();
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    /** {field: value} — an equality predicate. */
+    private Map<String, Object> eq(String field, Object value) {
+        return Doc.of(field, value);
+    }
+
+    /** {field: {op: value}} — an operator predicate such as {@code {$lte: now}}. */
+    private Map<String, Object> operator(String field, String op, Object value) {
+        return Doc.of(field, Doc.of(op, value));
+    }
+
+    /** {$and: [branch, branch, ...]}. */
+    @SafeVarargs
+    private Map<String, Object> and(Map<String, Object>... branches) {
+        return Doc.of("$and", List.of(branches));
+    }
+
+    /** {$set: {field: value}}. */
+    private Map<String, Object> set(String field, Object value) {
+        return Doc.of("$set", Doc.of(field, value));
+    }
+
+    private Map<String, Object> upsert(Map<String, Object> filter, Map<String, Object> update) throws Exception {
+        return new UpdateMongoCommand(driver)
+                .setDb(DB).setColl(COLL)
+                .addUpdate(Doc.of("q", filter, "u", update, "upsert", true))
+                .execute();
+    }
+
+    private List<Map<String, Object>> find(Map<String, Object> filter) throws Exception {
+        return new FindCommand(driver).setDb(DB).setColl(COLL).setFilter(filter).execute();
+    }
+
+    private void deleteById(Object id) throws Exception {
+        // limit 1: deleting by a unique _id matches at most one document
+        new DeleteMongoCommand(driver).setDb(DB).setColl(COLL)
+                .addDelete(Doc.of("_id", id), 1, null, null)
+                .execute();
+    }
+
+    private Map<String, Object> onlyDocument() throws Exception {
+        List<Map<String, Object>> all = find(Doc.of());
+        assertThat(all).hasSize(1);
+        return all.get(0);
+    }
+}


### PR DESCRIPTION
Hi Stephan,

a small but real correctness fix in the `InMemoryDriver`, found while debugging a
lock leak in the quarkus-morphium migration framework that only showed up against the
in-memory driver, not against real MongoDB.

## Problem
On upsert, the `InMemoryDriver` seeded the new document only from the **top-level
non-`$` keys** of the filter. As soon as the filter used `$and` — e.g.
`{$and:[{_id:"migration_lock"},{expires_at:{$lte:now}}]}` — the `_id` equality
predicate was nested inside `$and` and therefore **never** copied into the document.
The result was an upserted document with a **generated ObjectId** instead of
`_id="migration_lock"`. Real MongoDB seeds equality predicates from the filter
(including those nested in `$and`) into the inserted document.

Concretely this caused a lock leak: the migration runner acquires its lock via
`findAndModify({$and:[{_id:"migration_lock"},…]}, upsert:true)` and later releases it
with `delete({_id:"migration_lock"})`, which never matched because the id was
generated. Everything worked against real MongoDB; only the in-memory driver diverged.

## Fix
`collectUpsertEqualityFields()` walks the filter and seeds the document the way
MongoDB does:
- equality predicates — a scalar (`{field: value}`) or `{field: {$eq: value}}` — are
  seeded;
- equality fields nested inside `$and` are collected **recursively**;
- operator predicates (`$lte`, `$gt`, `$in`, …) and `$or`/`$nor` are **not** seeded;
- `{field: {$eq: null}}` leaves the field unset, so an upserted `_id` still gets a
  fresh id;
- **dotted field names** (e.g. `"a.b"`) are seeded as a nested document
  (`{a:{b:value}}`) via `setByPath`, consistent with the rest of the driver's path
  handling, so a later query on `a.b` matches.

The previous behaviour for plain top-level equality filters is unchanged.

## Tests
`InMemUpsertAndExtractionTest` covers: `$and` seeding, nested `$and`, delete-by-`_id`
after the upsert (closing the regression loop), operator-predicate skipping, and
dotted-path nesting.

The fix was additionally reviewed by GitHub Copilot; all comments (including exactly
the dotted-path case) have been addressed.

Cheers,
Heiko
