### PR TITLE
feat(inmem): support $setOnInsert and upsert/newFlag in findAndModify

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -6039,11 +6039,15 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
      * <ul>
      *   <li>If no document matches and {@code upsert} is false, returns {@code null} and writes nothing.</li>
      *   <li>If no document matches and {@code upsert} is true, inserts a document (seeded from the
-     *       query equality predicates plus {@code $set}/{@code $setOnInsert}) and returns it
-     *       (the inserted document is always the "new" one).</li>
+     *       query equality predicates plus {@code $set}/{@code $setOnInsert}). An insert has no
+     *       pre-image, so {@code newFlag} selects between the inserted document ({@code true}) and
+     *       {@code null} ({@code false}) — matching MongoDB.</li>
      *   <li>If a document matches, it is updated; {@code newFlag} selects whether the returned
      *       document is the post-update ({@code true}) or pre-update ({@code false}) state.</li>
      * </ul>
+     *
+     * <p>The returned document is always a {@link #deepClone(Map) deepClone}; callers may mutate it
+     * without corrupting the in-memory store.
      */
     public Map<String, Object> findAndOneAndUpdate(String db, String col, Map<String, Object> query,
             Map<String, Object> update, Map<String, Object> sort, Map<String, Object> collation,
@@ -6068,22 +6072,21 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
             var updateResult = updateInternal(db, col, query, null, update, false, upsert, collation, null,
                                               pendingNotifications);
 
-            // Determine which document to return.
-            Object resultId = matchedId;
-            if (matchedId == null && updateResult.get("upsertedIds") instanceof List<?> ids && !ids.isEmpty()) {
-                resultId = ids.get(0); // freshly inserted document
-            }
+            // Determine which document to return. Every branch returns a deepClone (or null) so a
+            // caller mutating the result cannot corrupt the stored map.
             if (matchedId == null) {
-                // Insert case: the new document is always returned regardless of newFlag.
-                result = resultId == null ? null
-                    : find(db, col, Doc.of("_id", resultId), null, null, collation, 0, 1, true)
-                        .stream().findFirst().orElse(null);
+                // Insert case: no pre-image exists. newFlag=false returns null (MongoDB semantics);
+                // newFlag=true returns the freshly inserted document.
+                Object insertedId = null;
+                if (updateResult.get("upsertedIds") instanceof List<?> ids && !ids.isEmpty()) {
+                    insertedId = ids.get(0);
+                }
+                result = (newFlag && insertedId != null) ? findByIdClone(db, col, insertedId, collation) : null;
             } else if (newFlag) {
                 // Return the post-update state.
-                result = find(db, col, Doc.of("_id", matchedId), null, null, collation, 0, 1, true)
-                    .stream().findFirst().orElse(null);
+                result = findByIdClone(db, col, matchedId, collation);
             } else {
-                // Return the pre-update state.
+                // Return the pre-update snapshot (already a deepClone).
                 result = before;
             }
         } finally {
@@ -6095,6 +6098,17 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
                            notification.updatedFields, notification.removedFields, notification.beforeDocument);
         }
         return result;
+    }
+
+    /**
+     * Looks up a document by {@code _id} and returns a {@link #deepClone(Map) deepClone} of it, or
+     * {@code null} if absent. Used by {@link #findAndOneAndUpdate} so the returned document is never
+     * a live reference into the store. Must be called while holding the collection write lock.
+     */
+    private Map<String, Object> findByIdClone(String db, String col, Object id, Map<String, Object> collation)
+    throws MorphiumDriverException {
+        return find(db, col, Doc.of("_id", id), null, null, collation, 0, 1, true)
+            .stream().findFirst().map(this::deepClone).orElse(null);
     }
 
     public Map<String, Object> findAndOneAndReplace(String db, String col, Map<String, Object> query,

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -1686,7 +1686,7 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
             addResult(ret, prepareResult(valueDoc));
         } else {
             var res = findAndOneAndUpdate(cmd.getDb(), cmd.getColl(), cmd.getQuery(), cmd.getUpdate(), cmd.getSort(),
-                                          cmd.getCollation());
+                                          cmd.getCollation(), cmd.isUpsert(), cmd.isNewFlag());
             addResult(ret, prepareResult(Doc.of("value", res)));
         }
 
@@ -6030,6 +6030,25 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
     public Map<String, Object> findAndOneAndUpdate(String db, String col, Map<String, Object> query,
             Map<String, Object> update, Map<String, Object> sort, Map<String, Object> collation)
     throws MorphiumDriverException {
+        return findAndOneAndUpdate(db, col, query, update, sort, collation, false, false);
+    }
+
+    /**
+     * In-memory implementation of {@code findAndModify} for the update case, honouring
+     * {@code upsert} and {@code newFlag} (MongoDB's {@code new}):
+     * <ul>
+     *   <li>If no document matches and {@code upsert} is false, returns {@code null} and writes nothing.</li>
+     *   <li>If no document matches and {@code upsert} is true, inserts a document (seeded from the
+     *       query equality predicates plus {@code $set}/{@code $setOnInsert}) and returns it
+     *       (the inserted document is always the "new" one).</li>
+     *   <li>If a document matches, it is updated; {@code newFlag} selects whether the returned
+     *       document is the post-update ({@code true}) or pre-update ({@code false}) state.</li>
+     * </ul>
+     */
+    public Map<String, Object> findAndOneAndUpdate(String db, String col, Map<String, Object> query,
+            Map<String, Object> update, Map<String, Object> sort, Map<String, Object> collation,
+            boolean upsert, boolean newFlag)
+    throws MorphiumDriverException {
         // NOTE: In MongoDB, findAndModify is atomic. We implement this by holding the
         // write lock for both find and update.
         java.util.concurrent.locks.ReadWriteLock lock = getCollectionLock(db, col);
@@ -6039,12 +6058,34 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
         try {
             // Use internal flag to skip lock acquisition in find() and update()
             List<Map<String, Object>> ret = find(db, col, query, sort, null, collation, 0, 1, true);
-            if (ret.isEmpty()) {
+            if (ret.isEmpty() && !upsert) {
                 return null;
             }
-            // Call update with internal=true via the internal updateInternal method
-            updateInternal(db, col, query, null, update, false, false, collation, null, pendingNotifications);
-            result = ret.get(0);
+            // Pre-update snapshot for an existing document (used when newFlag == false)
+            Map<String, Object> before = ret.isEmpty() ? null : deepClone(ret.get(0));
+            Object matchedId = ret.isEmpty() ? null : ret.get(0).get("_id");
+
+            var updateResult = updateInternal(db, col, query, null, update, false, upsert, collation, null,
+                                              pendingNotifications);
+
+            // Determine which document to return.
+            Object resultId = matchedId;
+            if (matchedId == null && updateResult.get("upsertedIds") instanceof List<?> ids && !ids.isEmpty()) {
+                resultId = ids.get(0); // freshly inserted document
+            }
+            if (matchedId == null) {
+                // Insert case: the new document is always returned regardless of newFlag.
+                result = resultId == null ? null
+                    : find(db, col, Doc.of("_id", resultId), null, null, collation, 0, 1, true)
+                        .stream().findFirst().orElse(null);
+            } else if (newFlag) {
+                // Return the post-update state.
+                result = find(db, col, Doc.of("_id", matchedId), null, null, collation, 0, 1, true)
+                    .stream().findFirst().orElse(null);
+            } else {
+                // Return the pre-update state.
+                result = before;
+            }
         } finally {
             lock.writeLock().unlock();
         }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -4275,6 +4275,71 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
         return (Map<String, Object>) map;
     }
 
+    /**
+     * Applies the field assignments of a {@code $set}-style update operator to {@code obj}.
+     * Shared by {@code $set} and {@code $setOnInsert} so both behave identically with respect
+     * to value evaluation and dotted-path navigation. Path-creation errors are appended to
+     * {@code writeErrors}.
+     */
+    @SuppressWarnings("unchecked")
+    private void applySetFields(Map<String, Object> obj, Map<String, Object> cmd,
+                                List<Map<String, Object>> writeErrors) {
+        // Process all entries, including null values (unlike $unset which removes fields)
+        for (Map.Entry<String, Object> entry : cmd.entrySet()) {
+            var v = entry.getValue();
+
+            if (v instanceof Map) {
+                try {
+                    v = Expr.parse(v).evaluate(obj);
+                } catch (Exception e) {
+                    // swallow
+                }
+            }
+
+            if (entry.getKey().contains(".")) {
+                String[] path = entry.getKey().split("\\.");
+                var current = obj;
+                boolean pathError = false;
+
+                // Navigate to parent, creating intermediate documents as needed
+                for (int i = 0; i < path.length - 1; i++) {
+                    String p = path[i];
+                    Object existing = current.get(p);
+                    if (existing != null) {
+                        if (existing instanceof Map) {
+                            current = (Map) existing;
+                        } else {
+                            // Type mismatch - cannot create field in non-document
+                            String errorMsg = String.format(
+                                                              "Cannot create field '%s' in element {%s: %s}",
+                                                              path[i + 1], p, existing);
+                            log.error(errorMsg);
+                            writeErrors.add(Doc.of(
+                                                            "index", 0,
+                                                            "code", 28,
+                                                            "errmsg", errorMsg
+                                            ));
+                            pathError = true;
+                            break;
+                        }
+                    } else {
+                        // Create intermediate document
+                        Map<String, Object> newDoc = Doc.of();
+                        current.put(p, newDoc);
+                        current = newDoc;
+                    }
+                }
+
+                if (!pathError) {
+                    // Set the final field
+                    current.put(path[path.length - 1], v);
+                }
+            } else {
+                obj.put(entry.getKey(), v);
+            }
+        }
+    }
+
     @SuppressWarnings({"ConstantConditions", "unchecked"})
     private Map<String, Object> updateInternal(String db, String collection, Map<String, Object> query,
             Map<String, Object> sort, Map<String, Object> op, boolean multiple, boolean upsert,
@@ -4342,86 +4407,19 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
                         case "$set":
 
                             // $set:{"field":"value", "other_field": 123}
-                            for (Map.Entry<String, Object> entry : cmd.entrySet()) {
-                                // Process all entries, including null values (unlike $unset which removes
-                                // fields)
-                                var v = entry.getValue();
+                            applySetFields(obj, cmd, writeErrors);
 
-                                if (v instanceof Map) {
-                                    try {
-                                        v = Expr.parse(v).evaluate(obj);
-                                    } catch (Exception e) {
-                                        // swallow
-                                    }
-                                }
+                            break;
 
-                                if (entry.getKey().contains(".")) {
-                                    String[] path = entry.getKey().split("\\.");
-                                    var current = obj;
-                                    Map lastEl = null;
-                                    boolean pathError = false;
+                        case "$setOnInsert":
 
-                                    // Navigate to parent, creating intermediate documents as needed
-                                    for (int i = 0; i < path.length - 1; i++) {
-                                        String p = path[i];
-                                        Object existing = current.get(p);
-                                        if (existing != null) {
-                                            if (existing instanceof Map) {
-                                                lastEl = current;
-                                                current = (Map) existing;
-                                            } else {
-                                                // Type mismatch - cannot create field in non-document
-                                                String errorMsg = String.format(
-                                                                                  "Cannot create field '%s' in element {%s: %s}",
-                                                                                  path[i + 1], p, existing);
-                                                log.error(errorMsg);
-                                                writeErrors.add(Doc.of(
-                                                                                "index", 0,
-                                                                                "code", 28,
-                                                                                "errmsg", errorMsg
-                                                                ));
-                                                pathError = true;
-                                                break;
-                                            }
-                                        } else {
-                                            // Create intermediate document
-                                            Map<String, Object> newDoc = Doc.of();
-                                            current.put(p, newDoc);
-                                            lastEl = current;
-                                            current = newDoc;
-                                        }
-                                    }
-
-                                    if (!pathError) {
-                                        // Set the final field
-                                        current.put(path[path.length - 1], v);
-                                    }
-                                } else {
-                                    obj.put(entry.getKey(), v);
-                                }
-                                // } else {
-                                // if (entry.getKey().contains(".")) {
-                                // String[] path = entry.getKey().split("\\.");
-                                // var current = obj;
-                                // Map lastEl = null;
-
-                                // for (String p : path) {
-                                // lastEl = current;
-
-                                // if (current.get(p) != null) {
-                                // current = (Map) current.get(p);
-                                // } else {
-                                // break;
-                                // }
-                                // }
-
-                                // if (lastEl != null) {
-                                // lastEl.remove(path[path.length - 1]);
-                                // }
-                                // } else {
-                                // obj.remove(entry.getKey());
-                                // }
-                                // }
+                            // $setOnInsert applies its fields ONLY when the upsert results in an
+                            // insert. On a pure update (the document already existed) it is a no-op,
+                            // matching MongoDB semantics. This lets callers seed insert-only fields
+                            // such as a String _id, an initial @Version value or a creationSource
+                            // without overwriting them on subsequent updates.
+                            if (insert) {
+                                applySetFields(obj, cmd, writeErrors);
                             }
 
                             break;

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemSetOnInsertTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemSetOnInsertTest.java
@@ -1,0 +1,121 @@
+package de.caluga.test.morphium.driver;
+
+import de.caluga.morphium.driver.Doc;
+import de.caluga.morphium.driver.commands.ClearCollectionCommand;
+import de.caluga.morphium.driver.commands.FindCommand;
+import de.caluga.morphium.driver.commands.UpdateMongoCommand;
+import de.caluga.morphium.driver.inmem.InMemoryDriver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@code $setOnInsert} support in the {@link InMemoryDriver}.
+ *
+ * <p>{@code $setOnInsert} must apply its fields only when an upsert results in an INSERT and be a
+ * no-op on a pure update. This lets callers seed insert-only fields — a String {@code _id}, an
+ * initial {@code @Version} value, an immutable {@code creationSource} — without overwriting them on
+ * subsequent updates. It is the building block for an atomic upsert-on-natural-key that replaces a
+ * non-atomic find-then-save (check-then-act) pattern.
+ */
+@Tag("inmemory")
+public class InMemSetOnInsertTest {
+
+    private static final String DB = "set_on_insert_db";
+    private static final String COLL = "campaigns";
+
+    private InMemoryDriver driver;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        driver = new InMemoryDriver();
+        driver.connect();
+        new ClearCollectionCommand(driver).setDb(DB).setColl(COLL).doClear();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        driver.close();
+    }
+
+    @Test
+    public void setOnInsertAppliesFieldsOnInsert() throws Exception {
+        Map<String, Object> filter = Doc.of("campaignNumber", "A0001");
+        Map<String, Object> update = Doc.of(
+                "$set", Doc.of("publicationDate", "2026-06-01"),
+                "$setOnInsert", Doc.of("_id", "fixed-id-1", "version", 1L, "creationSource", "AUTOMATIC"));
+
+        Map<String, Object> result = upsert(filter, update);
+
+        assertThat(result.get("upserted")).as("first upsert must insert").isNotNull();
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).as("_id must be seeded by $setOnInsert, not generated").isEqualTo("fixed-id-1");
+        assertThat(stored.get("version")).isEqualTo(1L);
+        assertThat(stored.get("creationSource")).isEqualTo("AUTOMATIC");
+        assertThat(stored.get("campaignNumber")).as("query equality predicate is still seeded").isEqualTo("A0001");
+        assertThat(stored.get("publicationDate")).as("$set is also applied on insert").isEqualTo("2026-06-01");
+    }
+
+    @Test
+    public void setOnInsertIsIgnoredOnUpdate() throws Exception {
+        Map<String, Object> filter = Doc.of("campaignNumber", "A0002");
+
+        // 1) insert with creationSource=MANUAL
+        upsert(filter, Doc.of(
+                "$set", Doc.of("publicationDate", "2026-06-01"),
+                "$setOnInsert", Doc.of("_id", "fixed-id-2", "version", 1L, "creationSource", "MANUAL")));
+
+        // 2) second upsert hits the existing document — $setOnInsert MUST NOT overwrite creationSource,
+        //    while $set MUST update publicationDate.
+        upsert(filter, Doc.of(
+                "$set", Doc.of("publicationDate", "2026-07-15"),
+                "$setOnInsert", Doc.of("_id", "should-be-ignored", "version", 99L, "creationSource", "AUTOMATIC")));
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).as("_id must not change on update").isEqualTo("fixed-id-2");
+        assertThat(stored.get("version")).as("version must not be touched by $setOnInsert on update").isEqualTo(1L);
+        assertThat(stored.get("creationSource"))
+                .as("creationSource is insert-only — must survive a later update")
+                .isEqualTo("MANUAL");
+        assertThat(stored.get("publicationDate")).as("$set must still apply on update").isEqualTo("2026-07-15");
+    }
+
+    @Test
+    public void setOnInsertWithoutSetStillUpdatesNothingExtraOnUpdate() throws Exception {
+        Map<String, Object> filter = Doc.of("campaignNumber", "A0003");
+
+        upsert(filter, Doc.of("$setOnInsert", Doc.of("_id", "fixed-id-3", "creationSource", "AUTOMATIC")));
+        upsert(filter, Doc.of("$setOnInsert", Doc.of("_id", "x", "creationSource", "MANUAL")));
+
+        assertThat(find(Doc.of())).as("must remain a single document").hasSize(1);
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).isEqualTo("fixed-id-3");
+        assertThat(stored.get("creationSource")).isEqualTo("AUTOMATIC");
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private Map<String, Object> upsert(Map<String, Object> filter, Map<String, Object> update) throws Exception {
+        return new UpdateMongoCommand(driver)
+                .setDb(DB).setColl(COLL)
+                .addUpdate(Doc.of("q", filter, "u", update, "upsert", true))
+                .execute();
+    }
+
+    private List<Map<String, Object>> find(Map<String, Object> filter) throws Exception {
+        return new FindCommand(driver).setDb(DB).setColl(COLL).setFilter(filter).execute();
+    }
+
+    private Map<String, Object> onlyDocument() throws Exception {
+        List<Map<String, Object>> all = find(Doc.of());
+        assertThat(all).hasSize(1);
+        return all.get(0);
+    }
+}

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemSetOnInsertTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemSetOnInsertTest.java
@@ -2,6 +2,7 @@ package de.caluga.test.morphium.driver;
 
 import de.caluga.morphium.driver.Doc;
 import de.caluga.morphium.driver.commands.ClearCollectionCommand;
+import de.caluga.morphium.driver.commands.FindAndModifyMongoCommand;
 import de.caluga.morphium.driver.commands.FindCommand;
 import de.caluga.morphium.driver.commands.UpdateMongoCommand;
 import de.caluga.morphium.driver.inmem.InMemoryDriver;
@@ -100,7 +101,64 @@ public class InMemSetOnInsertTest {
         assertThat(stored.get("creationSource")).isEqualTo("AUTOMATIC");
     }
 
+    @Test
+    public void findAndModifyUpsertInsertsAndSeedsSetOnInsert() throws Exception {
+        Map<String, Object> filter = Doc.of("campaignNumber", "F0001");
+        Map<String, Object> update = Doc.of(
+                "$set", Doc.of("publicationDate", "2026-06-01"),
+                "$setOnInsert", Doc.of("_id", "famid-1", "version", 1L, "creationSource", "AUTOMATIC"),
+                "$inc", Doc.of("version", 1L));
+
+        // newFlag=true must return the inserted document
+        Map<String, Object> returned = findAndModify(filter, update, true, true);
+
+        assertThat(returned).as("findAndModify upsert must return the inserted document").isNotNull();
+        assertThat(returned.get("_id")).isEqualTo("famid-1");
+        assertThat(returned.get("creationSource")).isEqualTo("AUTOMATIC");
+        assertThat(returned.get("publicationDate")).isEqualTo("2026-06-01");
+
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).isEqualTo("famid-1");
+    }
+
+    @Test
+    public void findAndModifyUpsertMergesIntoExistingAndReturnsNew() throws Exception {
+        Map<String, Object> filter = Doc.of("campaignNumber", "F0002");
+
+        findAndModify(filter, Doc.of(
+                "$set", Doc.of("publicationDate", "2026-06-01"),
+                "$setOnInsert", Doc.of("_id", "famid-2", "creationSource", "AUTOMATIC")), true, true);
+
+        // second call merges (description) — creationSource must survive, newFlag returns post-state
+        Map<String, Object> returned = findAndModify(filter, Doc.of(
+                "$set", Doc.of("campaignDescription", "merged"),
+                "$setOnInsert", Doc.of("_id", "ignored", "creationSource", "MANUAL")), true, true);
+
+        assertThat(returned.get("_id")).isEqualTo("famid-2");
+        assertThat(returned.get("creationSource")).isEqualTo("AUTOMATIC");
+        assertThat(returned.get("campaignDescription")).isEqualTo("merged");
+        assertThat(returned.get("publicationDate")).isEqualTo("2026-06-01");
+        assertThat(find(Doc.of())).hasSize(1);
+    }
+
+    @Test
+    public void findAndModifyWithoutUpsertReturnsNullWhenAbsent() throws Exception {
+        Map<String, Object> returned = findAndModify(Doc.of("campaignNumber", "missing"),
+                Doc.of("$set", Doc.of("x", 1)), false, true);
+        assertThat(returned).isNull();
+        assertThat(find(Doc.of())).isEmpty();
+    }
+
     // --- helpers -------------------------------------------------------------
+
+    private Map<String, Object> findAndModify(Map<String, Object> filter, Map<String, Object> update,
+                                              boolean upsert, boolean newFlag) throws Exception {
+        return new FindAndModifyMongoCommand(driver)
+                .setDb(DB).setColl(COLL)
+                .setQuery(filter).setUpdate(update)
+                .setUpsert(upsert).setNewFlag(newFlag)
+                .execute();
+    }
 
     private Map<String, Object> upsert(Map<String, Object> filter, Map<String, Object> update) throws Exception {
         return new UpdateMongoCommand(driver)

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemSetOnInsertTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemSetOnInsertTest.java
@@ -104,9 +104,11 @@ public class InMemSetOnInsertTest {
     @Test
     public void findAndModifyUpsertInsertsAndSeedsSetOnInsert() throws Exception {
         Map<String, Object> filter = Doc.of("campaignNumber", "F0001");
+        // version is incremented via $inc only (1 on insert) — $setOnInsert must NOT also target it,
+        // mirroring the application upsert; real mongod rejects a field appearing in both operators.
         Map<String, Object> update = Doc.of(
                 "$set", Doc.of("publicationDate", "2026-06-01"),
-                "$setOnInsert", Doc.of("_id", "famid-1", "version", 1L, "creationSource", "AUTOMATIC"),
+                "$setOnInsert", Doc.of("_id", "famid-1", "creationSource", "AUTOMATIC"),
                 "$inc", Doc.of("version", 1L));
 
         // newFlag=true must return the inserted document
@@ -116,9 +118,50 @@ public class InMemSetOnInsertTest {
         assertThat(returned.get("_id")).isEqualTo("famid-1");
         assertThat(returned.get("creationSource")).isEqualTo("AUTOMATIC");
         assertThat(returned.get("publicationDate")).isEqualTo("2026-06-01");
+        assertThat(returned.get("version")).as("$inc seeds version=1 on insert").isEqualTo(1L);
 
         Map<String, Object> stored = onlyDocument();
         assertThat(stored.get("_id")).isEqualTo("famid-1");
+    }
+
+    @Test
+    public void findAndModifyUpsertInsertWithNewFalseReturnsNull() throws Exception {
+        // An insert has no pre-image: with new:false (the default) MongoDB returns null.
+        Map<String, Object> filter = Doc.of("campaignNumber", "F0004");
+        Map<String, Object> returned = findAndModify(filter, Doc.of(
+                "$setOnInsert", Doc.of("_id", "famid-4", "creationSource", "AUTOMATIC")), true, false);
+
+        assertThat(returned).as("upsert-insert with new:false must return null").isNull();
+        // but the document was still inserted
+        Map<String, Object> stored = onlyDocument();
+        assertThat(stored.get("_id")).isEqualTo("famid-4");
+        assertThat(stored.get("creationSource")).isEqualTo("AUTOMATIC");
+    }
+
+    @Test
+    public void findAndModifyUpdateWithNewFalseReturnsPreImage() throws Exception {
+        Map<String, Object> filter = Doc.of("campaignNumber", "F0005");
+        findAndModify(filter, Doc.of("$set", Doc.of("status", "before")), true, true);
+
+        // new:false must return the document as it was BEFORE this update
+        Map<String, Object> returned = findAndModify(filter,
+                Doc.of("$set", Doc.of("status", "after")), false, false);
+
+        assertThat(returned.get("status")).as("new:false returns the pre-image").isEqualTo("before");
+        assertThat(onlyDocument().get("status")).as("store holds the post-update value").isEqualTo("after");
+    }
+
+    @Test
+    public void findAndModifyReturnedDocumentIsNotLiveReference() throws Exception {
+        // Mutating the returned document must not corrupt the stored map (all branches deepClone).
+        Map<String, Object> filter = Doc.of("campaignNumber", "F0006");
+        Map<String, Object> returned = findAndModify(filter, Doc.of(
+                "$setOnInsert", Doc.of("_id", "famid-6", "creationSource", "AUTOMATIC")), true, true);
+
+        returned.put("creationSource", "TAMPERED");
+        assertThat(onlyDocument().get("creationSource"))
+                .as("mutating the returned doc must not leak into the store")
+                .isEqualTo("AUTOMATIC");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds two related capabilities to `InMemoryDriver`, both needed so an atomic
`findOneAndUpdate(upsert=true)` can replace non-atomic find-then-save
(check-then-act) patterns in application code:

1. **`$setOnInsert` update operator** — was previously rejected with
   `RuntimeException("unknown operand")`. Now applies its fields only when the
   upsert results in an insert and is a no-op on a pure update, matching MongoDB.
   This lets callers seed insert-only fields (a String `_id`, an initial
   `@Version` value, an immutable `creationSource`) without overwriting them on
   subsequent updates. The field-assignment logic is shared with `$set` via a new
   `applySetFields()` helper.

2. **`upsert` and `newFlag` in `findAndModify`** — `findAndOneAndUpdate()`
   ignored both flags: on an empty match it returned `null` and inserted nothing,
   and it always returned the pre-update document. Now:
   - `upsert`: inserts a seeded document when nothing matches (combined with
     `$setOnInsert` above, insert-only fields are seeded correctly);
   - `newFlag`: returns the post-update document when `true`, pre-update when
     `false`; the inserted document is always returned on the upsert-insert path.

   The pre-existing 6-arg `findAndOneAndUpdate` overload is kept for backward
   compatibility.

## Why

Without these, `findOneAndUpdate(upsert=true)` is unusable in tests backed by the
in-memory driver, which forces application code to keep non-atomic
find-then-save patterns that can race (two concurrent ingest paths both creating
the same document, colliding on a unique index).

## Tests

New `InMemSetOnInsertTest` (6 tests) covers `$setOnInsert` on insert vs. update
and the `findAndModify` upsert/newFlag paths. Existing
`InMemUpsertAndExtractionTest`, `InMemUpdateResultTest`, `InMemUniqueIndexTest`
remain green.
