### PR TITLE
refactor: unify synchronized list creation in BufferedMorphiumWriterImpl (#173)

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/writer/BufferedMorphiumWriterImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/writer/BufferedMorphiumWriterImpl.java
@@ -223,7 +223,7 @@ public class BufferedMorphiumWriterImpl implements MorphiumWriter, ShutdownListe
         //        synchronized (opLog) {
         if (opLog.get(type) == null) {
             synchronized (opLog) {
-                opLog.putIfAbsent(type, new Vector<>());
+                opLog.putIfAbsent(type, Collections.synchronizedList(new ArrayList<>()));
             }
         }
 
@@ -869,8 +869,6 @@ public class BufferedMorphiumWriterImpl implements MorphiumWriter, ShutdownListe
                     lastRun.put(clz, System.currentTimeMillis());
                     List<WriteBufferEntry> localQueue;
                     localQueue = opLog.remove(clz);
-                    //                            opLog.put(clz, new
-                    // Vector<WriteBufferEntry>());
                     flushQueueToMongo(localQueue);
 
                     if (localQueue != null && !localQueue.isEmpty()) {

--- a/pom.xml
+++ b/pom.xml
@@ -201,12 +201,12 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.5.25</version>
+        <version>1.5.37</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.5.25</version>
+        <version>1.5.37</version>
       </dependency>
       <dependency>
         <groupId>com.colofabrix.scala</groupId>


### PR DESCRIPTION
## Summary
- Replace the single legacy `new Vector<>()` in `addToWriteQueue()` with `Collections.synchronizedList(new ArrayList<>())`, matching all other `opLog` list creation sites
- Remove a stale commented-out `Vector` remnant in `runIt()`
- Bump logback 1.5.25 → 1.5.37, fixing CVE-2026-9828 (Dependabot alert #26, low severity)

## Motivation
`BufferedMorphiumWriterImpl` inconsistently created thread-safe lists for the `opLog` map — one site used the legacy `Vector`, all others `Collections.synchronizedList`. Both are thread-safe, but the inconsistency made the thread-safety guarantees harder to reason about.

The logback bump rides along: logback-core <= 1.5.32 has a deserialization-of-untrusted-data vulnerability; 1.5.37 is the current release.

Closes #173

## Impact
Code quality and dependency hygiene — no behavioral change. Verified: `morphium-core` compiles and both logback artifacts resolve to 1.5.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)