### PR TITLE
feat(query): add findOneAndUpdate(update, upsert, returnNew) with client-side id seeding

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -6059,7 +6059,15 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
             Map<String, Object> before = ret.isEmpty() ? null : deepClone(ret.get(0));
             Object matchedId = ret.isEmpty() ? null : ret.get(0).get("_id");
 
-            var updateResult = updateInternal(db, col, query, null, update, false, upsert, collation, null,
+            // IMPORTANT: once `sort` has picked a specific document above, the update itself must
+            // be pinned to that document's _id. Re-running the original (unsorted, unlimited)
+            // `query` here would let updateInternal's own find(..., limit=1) pick an arbitrary
+            // match, silently ignoring the caller's sort() when several documents match. On the
+            // upsert-insert path (matchedId == null) the original query is still needed so
+            // collectUpsertEqualityFields() can seed the new document from its equality predicates.
+            Map<String, Object> updateQuery = matchedId != null ? Doc.of("_id", matchedId) : query;
+
+            var updateResult = updateInternal(db, col, updateQuery, null, update, false, upsert, collation, null,
                                               pendingNotifications);
 
             // Determine which document to return. Every branch returns a deepClone (or null) so a

--- a/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
@@ -45,6 +45,8 @@ import de.caluga.morphium.async.AsyncOperationType;
 import de.caluga.morphium.driver.Doc;
 import de.caluga.morphium.driver.MorphiumCursor;
 import de.caluga.morphium.driver.MorphiumDriverException;
+import de.caluga.morphium.driver.MorphiumId;
+import org.bson.types.ObjectId;
 import de.caluga.morphium.driver.commands.CountMongoCommand;
 import de.caluga.morphium.driver.commands.DistinctMongoCommand;
 import de.caluga.morphium.driver.commands.ExplainCommand;
@@ -493,6 +495,126 @@ public class Query<T> implements Cloneable {
         }
 
         return null;
+    }
+
+    /**
+     * Atomic find-and-update with optional upsert semantics.
+     *
+     * @param update    the update document (may contain $set, $setOnInsert, $inc, ...)
+     * @param upsert    if true, a new document is inserted when no document matches the query
+     * @param returnNew if true, the document AFTER applying the update is returned; if false,
+     *                  the document as it was BEFORE the update is returned (matches the
+     *                  behaviour of {@link #findOneAndUpdate(Map)})
+     */
+    @SuppressWarnings("ConstantConditions")
+    public T findOneAndUpdate(Map<String, Object> update, boolean upsert, boolean returnNew) {
+        // NOTE: unlike the legacy findOneAndUpdate(Map), this method NEVER serves from / writes to
+        // the read cache. findOneAndUpdate always has a write side-effect (and, with upsert=true,
+        // can insert a new document), so satisfying it from a stale read cache is never correct -
+        // the analogous cache-hit branch in the legacy findOneAndUpdate(Map) calls morphium.delete(...)
+        // on a cache hit, which for an upsert would DELETE the matched document instead of upserting
+        // it (silent data loss) - hence it is intentionally not replicated here.
+        morphium.inc(StatisticKeys.NO_CACHED_READS);
+
+        Map<String, Object> queryObject = toQueryObject();
+        Map<String, Object> effectiveUpdate = update;
+
+        if (upsert) {
+            effectiveUpdate = addGeneratedIdOnInsertIfNeeded(queryObject, update);
+        }
+
+        long start = System.currentTimeMillis();
+        Map<String, Object> ret = null;
+        MongoConnection con = null;
+        FindAndModifyMongoCommand settings = null;
+
+        try {
+            var wc = getMorphium().getWriteConcernForClass(getType());
+            con = morphium.getDriver().getPrimaryConnection(wc);
+            settings = new FindAndModifyMongoCommand(con).setDb(getDB()).setColl(getCollectionName()).setQuery(Doc.of(queryObject)).setUpdate(Doc.of(effectiveUpdate)).setUpsert(upsert).setNewFlag(returnNew);
+            if (wc != null) {
+                settings.setWriteConcern(wc.asMap());
+            }
+
+            if (collation != null) {
+                settings.setCollation(Doc.of(collation.toQueryObject()));
+            }
+
+            ret = settings.execute();
+            settings.releaseConnection();
+            settings = null;
+            con = null;
+        } catch (MorphiumDriverException e) {
+            log.error("Error", e);
+        } finally {
+            if (settings != null) {
+                settings.releaseConnection();
+            } else if (con != null) {
+                morphium.getDriver().releaseConnection(con);
+            }
+        }
+
+        if (ret == null) {
+            return null;
+        }
+
+        long dur = System.currentTimeMillis() - start;
+        // morphium.fireProfilingReadEvent(this, dur, ReadAccessType.GET);
+        T unmarshall = morphium.getMapper().deserialize(type, ret);
+
+        if (unmarshall != null) {
+            morphium.firePostLoadEvent(unmarshall);
+            updateLastAccess(unmarshall);
+        }
+
+        return unmarshall;
+    }
+
+    /**
+     * When performing an upsert-style findOneAndUpdate, MongoDB would otherwise assign a
+     * server-generated ObjectId to newly inserted documents. Morphium's store()-path always
+     * assigns a client-side id first (see MorphiumWriterImpl#setIdIfNull) so that String @Id
+     * fields end up with a MorphiumId-based UUID string rather than an ObjectId. This helper
+     * mirrors that behaviour for the upsert-insert case by adding a generated id via
+     * $setOnInsert - but ONLY if the caller has not already pinned down the id explicitly
+     * (via the query filter or via $set/$setOnInsert in the update document).
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> addGeneratedIdOnInsertIfNeeded(Map<String, Object> queryObject, Map<String, Object> update) {
+        if (queryObject.containsKey("_id")) {
+            return update;
+        }
+
+        Object setOnInsert = update.get("$setOnInsert");
+        if (setOnInsert instanceof Map && ((Map<String, Object>) setOnInsert).containsKey("_id")) {
+            return update;
+        }
+
+        Object set = update.get("$set");
+        if (set instanceof Map && ((Map<String, Object>) set).containsKey("_id")) {
+            return update;
+        }
+
+        Field idField = getARHelper().getIdField(type);
+        Object generatedId;
+
+        if (idField.getType().equals(MorphiumId.class)) {
+            generatedId = new MorphiumId();
+        } else if (idField.getType().equals(ObjectId.class)) {
+            generatedId = new ObjectId();
+        } else if (idField.getType().equals(String.class)) {
+            generatedId = new MorphiumId().toString();
+        } else if (idField.getType().isAssignableFrom(MorphiumId.class)) {
+            generatedId = new MorphiumId();
+        } else {
+            throw new IllegalArgumentException("Cannot generate ID of non-ID-Type");
+        }
+
+        Map<String, Object> newUpdate = new LinkedHashMap<>(update);
+        Map<String, Object> newSetOnInsert = setOnInsert instanceof Map ? new LinkedHashMap<>((Map<String, Object>) setOnInsert) : new LinkedHashMap<>();
+        newSetOnInsert.put("_id", generatedId);
+        newUpdate.put("$setOnInsert", newSetOnInsert);
+        return newUpdate;
     }
 
     public T findOneAndUpdateEnums(Map<Enum, Object> update) {

--- a/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
@@ -532,6 +532,9 @@ public class Query<T> implements Cloneable {
             var wc = getMorphium().getWriteConcernForClass(getType());
             con = morphium.getDriver().getPrimaryConnection(wc);
             settings = new FindAndModifyMongoCommand(con).setDb(getDB()).setColl(getCollectionName()).setQuery(Doc.of(queryObject)).setUpdate(Doc.of(effectiveUpdate)).setUpsert(upsert).setNewFlag(returnNew);
+            if (getSort() != null && !getSort().isEmpty()) {
+                settings.setSort(new Doc(getSort()));
+            }
             if (wc != null) {
                 settings.setWriteConcern(wc.asMap());
             }
@@ -545,13 +548,22 @@ public class Query<T> implements Cloneable {
             settings = null;
             con = null;
         } catch (MorphiumDriverException e) {
-            log.error("Error", e);
+            // MorphiumDriverException is already an unchecked exception (see
+            // MorphiumDriverExceptionTest) — let it propagate as-is so callers can catch it
+            // specifically, instead of masking it behind a generic RuntimeException. For an
+            // atomic write, the caller must be able to distinguish "no match" (null return,
+            // upsert=false) from "the write failed".
+            throw e;
         } finally {
             if (settings != null) {
                 settings.releaseConnection();
             } else if (con != null) {
                 morphium.getDriver().releaseConnection(con);
             }
+        }
+
+        if (morphium.getCache() != null) {
+            morphium.getCache().clearCacheIfNecessary(type);
         }
 
         if (ret == null) {

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/FindOneAndUpdateUpsertTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/FindOneAndUpdateUpsertTest.java
@@ -1,0 +1,187 @@
+package de.caluga.test.mongo.suite.inmem;
+
+import de.caluga.morphium.UtilsMap;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.annotations.Version;
+import de.caluga.morphium.query.Query;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for Query#findOneAndUpdate(Map, boolean, boolean) — atomic upsert support,
+ * running against the InMemoryDriver (supports $setOnInsert + upsert/newFlag as of PR #203).
+ */
+public class FindOneAndUpdateUpsertTest extends MorphiumInMemTestBase {
+
+    @Test
+    public void upsertInsertsNewDocumentWithGeneratedStringId() {
+        Query<UpsertTestEntity> q = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("X");
+
+        Map<String, Object> update = UtilsMap.of(
+                "$set", UtilsMap.of("naturalKey", "X", "payload", "p1"),
+                "$setOnInsert", UtilsMap.of("createdBy", "importer"),
+                "$inc", UtilsMap.of("version", 1L));
+
+        UpsertTestEntity ret = q.findOneAndUpdate(update, true, true);
+
+        assertNotNull(ret, "Upsert-insert must return the newly created document (returnNew=true)");
+        assertNotNull(ret.id, "id must be generated");
+        assertEquals("X", ret.naturalKey);
+        assertEquals("p1", ret.payload);
+        assertEquals("importer", ret.createdBy);
+        assertEquals(1L, ret.version);
+
+        // id must be a String-UUID (MorphiumId.toString()), NOT null, NOT an ObjectId-hex-only surprise type
+        assertEquals(24, ret.id.length(), "MorphiumId hex string is expected to be 24 chars");
+
+        assertEquals(1, morphium.createQueryFor(UpsertTestEntity.class).countAll());
+    }
+
+    @Test
+    public void upsertMergesExistingDocumentAndKeepsSetOnInsertFieldsUnchanged() {
+        Query<UpsertTestEntity> q1 = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("Y");
+
+        Map<String, Object> firstUpdate = UtilsMap.of(
+                "$set", UtilsMap.of("naturalKey", "Y", "payload", "initial"),
+                "$setOnInsert", UtilsMap.of("createdBy", "importer"),
+                "$inc", UtilsMap.of("version", 1L));
+
+        UpsertTestEntity created = q1.findOneAndUpdate(firstUpdate, true, true);
+        assertNotNull(created);
+        String originalId = created.id;
+
+        Query<UpsertTestEntity> q2 = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("Y");
+
+        Map<String, Object> secondUpdate = UtilsMap.of(
+                "$set", UtilsMap.of("naturalKey", "Y", "payload", "merged"),
+                "$setOnInsert", UtilsMap.of("createdBy", "shouldNotBeApplied"),
+                "$inc", UtilsMap.of("version", 1L));
+
+        UpsertTestEntity merged = q2.findOneAndUpdate(secondUpdate, true, true);
+
+        assertNotNull(merged);
+        assertEquals(originalId, merged.id, "_id must not change on merge");
+        assertEquals("merged", merged.payload, "$set fields must be overwritten");
+        assertEquals("importer", merged.createdBy, "$setOnInsert fields must stay untouched on existing doc");
+        assertEquals(2L, merged.version, "version must be incremented");
+
+        assertEquals(1, morphium.createQueryFor(UpsertTestEntity.class).countAll());
+    }
+
+    @Test
+    public void callerProvidedIdInSetOnInsertIsNotOverwritten() {
+        Query<UpsertTestEntity> q = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("Z");
+
+        Map<String, Object> update = UtilsMap.of(
+                "$set", UtilsMap.of("naturalKey", "Z", "payload", "p1"),
+                "$setOnInsert", UtilsMap.of("_id", "caller-defined-id"),
+                "$inc", UtilsMap.of("version", 1L));
+
+        UpsertTestEntity ret = q.findOneAndUpdate(update, true, true);
+
+        assertNotNull(ret);
+        assertEquals("caller-defined-id", ret.id, "caller-provided _id in $setOnInsert must be respected");
+    }
+
+    @Test
+    public void callerProvidedIdInQueryFilterIsNotOverwritten() {
+        Query<UpsertTestEntity> q = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("_id").eq("filter-defined-id");
+
+        Map<String, Object> update = UtilsMap.of(
+                "$set", UtilsMap.of("naturalKey", "W", "payload", "p1"),
+                "$inc", UtilsMap.of("version", 1L));
+
+        UpsertTestEntity ret = q.findOneAndUpdate(update, true, true);
+
+        assertNotNull(ret);
+        assertEquals("filter-defined-id", ret.id, "caller-provided _id in query filter must be respected");
+    }
+
+    @Test
+    public void plainFindOneAndUpdateWithoutUpsertBehavesAsBefore() {
+        // no document exists -> must return null, must NOT create a document (no upsert)
+        Query<UpsertTestEntity> q = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("does-not-exist");
+
+        Map<String, Object> update = UtilsMap.of("$set", UtilsMap.of("payload", "p1"));
+
+        UpsertTestEntity ret = q.findOneAndUpdate(update);
+        assertNull(ret, "Without upsert, no match must return null");
+        assertEquals(0, morphium.createQueryFor(UpsertTestEntity.class).countAll());
+
+        // now with an existing doc: returned document must be the OLD state (returnNew=false, matches previous default)
+        UpsertTestEntity existing = new UpsertTestEntity();
+        existing.id = "existing-1";
+        existing.naturalKey = "known";
+        existing.payload = "before";
+        morphium.store(existing);
+        waitForWrites();
+
+        Query<UpsertTestEntity> q2 = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("known");
+        Map<String, Object> update2 = UtilsMap.of("$set", UtilsMap.of("payload", "after"));
+        UpsertTestEntity retOld = q2.findOneAndUpdate(update2);
+
+        assertNotNull(retOld);
+        assertEquals("before", retOld.payload, "findOneAndUpdate(Map) must keep returning the document as it was BEFORE the update");
+
+        UpsertTestEntity reread = morphium.createQueryFor(UpsertTestEntity.class).f("naturalKey").eq("known").get();
+        assertEquals("after", reread.payload, "the update itself must still have been applied in the DB");
+    }
+
+    @Test
+    public void callerProvidedIdInSetIsNotOverwritten() {
+        Query<UpsertTestEntity> q = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("V");
+
+        Map<String, Object> update = UtilsMap.of(
+                "$set", UtilsMap.of("_id", "set-defined-id", "naturalKey", "V", "payload", "p1"),
+                "$inc", UtilsMap.of("version", 1L));
+
+        UpsertTestEntity ret = q.findOneAndUpdate(update, true, true);
+
+        assertNotNull(ret);
+        assertEquals("set-defined-id", ret.id, "caller-provided _id in $set must be respected, not overwritten by a generated id");
+    }
+
+    @Test
+    public void upsertInsertWithReturnNewFalseReturnsNullButStillCreatesDocument() {
+        Query<UpsertTestEntity> q = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("U");
+
+        Map<String, Object> update = UtilsMap.of(
+                "$set", UtilsMap.of("naturalKey", "U", "payload", "p1"),
+                "$inc", UtilsMap.of("version", 1L));
+
+        UpsertTestEntity ret = q.findOneAndUpdate(update, true, false);
+
+        assertNull(ret, "returnNew=false on an upsert-insert must return null (no document existed BEFORE the update)");
+
+        UpsertTestEntity stored = morphium.createQueryFor(UpsertTestEntity.class).f("naturalKey").eq("U").get();
+        assertNotNull(stored, "the document must have been created despite the null return value");
+        assertNotNull(stored.id, "id must have been generated");
+        assertEquals(24, stored.id.length(), "MorphiumId hex string is expected to be 24 chars");
+    }
+
+    @Entity(translateCamelCase = false)
+    public static class UpsertTestEntity {
+        @Id
+        public String id;
+        public String naturalKey;
+        public String payload;
+        public String createdBy;
+        @Version
+        public Long version;
+    }
+}

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/FindOneAndUpdateUpsertTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/FindOneAndUpdateUpsertTest.java
@@ -4,6 +4,7 @@ import de.caluga.morphium.UtilsMap;
 import de.caluga.morphium.annotations.Entity;
 import de.caluga.morphium.annotations.Id;
 import de.caluga.morphium.annotations.Version;
+import de.caluga.morphium.annotations.caching.Cache;
 import de.caluga.morphium.query.Query;
 import org.junit.jupiter.api.Test;
 
@@ -174,6 +175,65 @@ public class FindOneAndUpdateUpsertTest extends MorphiumInMemTestBase {
         assertEquals(24, stored.id.length(), "MorphiumId hex string is expected to be 24 chars");
     }
 
+    @Test
+    public void sortDeterminesWhichMatchingDocumentIsUpdated() {
+        // Three documents share the same group -> without a sort, MongoDB would update an
+        // arbitrary one. With sort("-priority") the highest-priority document must be updated.
+        for (int i = 1; i <= 3; i++) {
+            UpsertTestEntity e = new UpsertTestEntity();
+            e.id = "doc-" + i;
+            e.naturalKey = "group";
+            e.priority = i;
+            e.payload = "untouched";
+            morphium.store(e);
+        }
+        waitForWrites();
+
+        Query<UpsertTestEntity> q = morphium.createQueryFor(UpsertTestEntity.class)
+                .f("naturalKey").eq("group")
+                .sort("-priority");
+
+        Map<String, Object> update = UtilsMap.of("$set", UtilsMap.of("payload", "updated"));
+        UpsertTestEntity updated = q.findOneAndUpdate(update, false, true);
+
+        assertNotNull(updated);
+        assertEquals("doc-3", updated.id, "sort(\"-priority\") must select the highest-priority document");
+        assertEquals("updated", updated.payload);
+
+        // the other two must be untouched
+        assertEquals("untouched", morphium.createQueryFor(UpsertTestEntity.class).f("_id").eq("doc-1").get().payload);
+        assertEquals("untouched", morphium.createQueryFor(UpsertTestEntity.class).f("_id").eq("doc-2").get().payload);
+    }
+
+    @Test
+    public void upsertInvalidatesReadCacheForCachedEntity() {
+        CachedUpsertTestEntity existing = new CachedUpsertTestEntity();
+        existing.id = "cache-1";
+        existing.naturalKey = "cachedGroup";
+        existing.payload = "before";
+        morphium.store(existing);
+        waitForWrites();
+
+        // populate the read cache with the pre-upsert state
+        CachedUpsertTestEntity cachedRead = morphium.createQueryFor(CachedUpsertTestEntity.class)
+                .f("naturalKey").eq("cachedGroup").get();
+        assertNotNull(cachedRead);
+        assertEquals("before", cachedRead.payload);
+
+        Query<CachedUpsertTestEntity> q = morphium.createQueryFor(CachedUpsertTestEntity.class)
+                .f("naturalKey").eq("cachedGroup");
+        Map<String, Object> update = UtilsMap.of("$set", UtilsMap.of("payload", "after"));
+        CachedUpsertTestEntity updated = q.findOneAndUpdate(update, true, true);
+        assertNotNull(updated);
+        assertEquals("after", updated.payload);
+
+        // a fresh read for the same query must observe the update, not a stale cache entry
+        CachedUpsertTestEntity reread = morphium.createQueryFor(CachedUpsertTestEntity.class)
+                .f("naturalKey").eq("cachedGroup").get();
+        assertNotNull(reread);
+        assertEquals("after", reread.payload, "findOneAndUpdate must invalidate the read cache for @Cache entities");
+    }
+
     @Entity(translateCamelCase = false)
     public static class UpsertTestEntity {
         @Id
@@ -181,7 +241,17 @@ public class FindOneAndUpdateUpsertTest extends MorphiumInMemTestBase {
         public String naturalKey;
         public String payload;
         public String createdBy;
+        public int priority;
         @Version
         public Long version;
+    }
+
+    @Entity(translateCamelCase = false)
+    @Cache(readCache = true, clearOnWrite = true)
+    public static class CachedUpsertTestEntity {
+        @Id
+        public String id;
+        public String naturalKey;
+        public String payload;
     }
 }


### PR DESCRIPTION
## Summary

Adds an upsert-capable `findOneAndUpdate` overload to the abstracted `Query` API so consumers no longer need to reach into internal driver commands (`getPrimaryConnection` / `FindAndModifyMongoCommand`) to perform an atomic `findOneAndUpdate(upsert=true)`.

```java
public T findOneAndUpdate(Map<String, Object> update, boolean upsert, boolean returnNew)
```

## Motivation

Downstream consumers needed an atomic `findOneAndUpdate` with `upsert=true` and differentiated `$set` / `$setOnInsert` / `$inc` operators (e.g. insert-or-merge on a natural key). The only existing `findOneAndUpdate(Map)` sets neither `upsert` nor `newFlag`, forcing consumers to drop down to raw driver commands.

## Behaviour

- On an **upsert-insert**, a client-side id is seeded via `$setOnInsert._id` (mirroring `store()` / `setIdIfNull` semantics) so `@Id String` fields get a `MorphiumId`-based id instead of a server-generated `ObjectId` — **unless** the caller already pins `_id` via the query filter or `$set`/`$setOnInsert`.
- The new method never consults the read cache (a write side-effect must not be served from / delete against a stale cache — the legacy `findOneAndUpdate(Map)` cache-hit branch is intentionally not replicated).
- The existing `findOneAndUpdate(Map)` is left unchanged.

## Tests

`FindOneAndUpdateUpsertTest` (InMemoryDriver): upsert-insert generates a String id + `version=1`; upsert-merge applies `$set`, preserves `$setOnInsert`, increments version; caller-provided `_id` in query filter / `$set` / `$setOnInsert` is not overwritten; `returnNew=false` on insert returns null but still creates the document; regression for the plain no-upsert method. All green.