### PR TITLE
feat(aggregation): consistent field-name translation for aggregation stages (#208, #217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Aggregator: opt-in consistent field-name translation (#208, #217)
+`project(Map)` translates its keys through the entity's field-name mapping, but the other stage helpers passed keys and `$`-references through verbatim. A projected key colliding with an entity property was silently renamed, and a later `$group` stage referencing the name the user wrote got `$sum: 0` / `$push: []` with no error.
+
+New opt-in setting `translateAggregationFieldNames` (`ObjectMappingSettings`, overridable per aggregator via `Aggregator.setTranslateAggregationFieldNames`): when enabled, Java property names are translated uniformly — group operator `$`-references and id values, `addFields`/`set` keys and values, `sort(Map)` keys, `graphLookup` connect fields, and `$`-references inside `Expr` values. Dot-paths translate their first segment; `$$`-variables are never touched. **Default off = exactly the previous behavior.** The effective config value is snapshotted when the aggregator is created; the per-aggregator override wins at any time.
+
+Additionally, both aggregator implementations now log a WARN (once per reference) when a later stage references a `project(Map)` key by the spelling that was silently renamed — making the silent-zero case visible.
+
+New helpers `Aggregator.ref(Enum)` / `Aggregator.name(Enum)` translate enum field references explicitly (`F.itemCount` → `"$item_count"` / `"item_count"`), independent of the flag: `group.sum(agg.name(F.itemCount), agg.ref(F.itemCount))`. All new `Aggregator` interface methods are default methods — third-party implementations keep compiling.
+
+Known limitation: translation operates on the serialized pipeline, where `Expr.string("$...")` is indistinguishable from a field reference. `$literal` subtrees are never touched — wrap string values that look like field references in `$literal` when the flag is on.
+
 #### PoppyDB: priority-based leader step-back after failover (#177)
 A PoppyDB leader now voluntarily hands leadership to a peer with higher election priority, mirroring MongoDB's priority takeover. Previously a failover to a lower-priority node was permanent — the preferred primary never returned, even after it recovered.
 
@@ -18,6 +29,11 @@ Enabled by default. Configurable via `ElectionConfig.priorityTakeoverEnabled` / 
 
 #### InMemoryDriver: `$setOnInsert` and upsert/`new` support in `findAndModify` (#203)
 The `InMemoryDriver` now honors `$setOnInsert` and the `upsert`/`new` flags in `findAndModify`, matching MongoDB behavior. Includes a regression test for upsert via `$and`-nested `_id` filters (#202, #204).
+
+### Changed
+
+#### Aggregator: `graphLookup` enum overload now translates connect fields (#217)
+`graphLookup(Class, Expr, Enum, Enum, ...)` passed `connectFromField.name()` / `connectToField.name()` through untranslated — same defect family as the `lookup` enum overload fixed in 6.2.5 (#198). The enum overload now always translates both connect fields against the given from type, independent of the `translateAggregationFieldNames` flag. Code that relied on the raw enum name reaching the pipeline must use the String overload instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The `InMemoryDriver` now honors `$setOnInsert` and the `upsert`/`new` flags in `
 
 ### Fixed
 
+#### Aggregator: `Group.stdDevSamp(String, Object)` emitted `stdDevSamp` without the `$` prefix
+The operator map was built as `{stdDevSamp: ...}` instead of `{$stdDevSamp: ...}`, so the String-based `stdDevSamp` accumulator never worked. (The `$stdDevPop` sibling was correct.)
+
 #### Driver: replicaset failover repaired — bounded timeouts, write retries, changestream recovery
 During a primary failure (crash, frozen VM, network partition) the driver effectively never recovered: writes failed or hung indefinitely, messaging never reconnected. Root causes and fixes:
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Aggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Aggregator.java
@@ -182,10 +182,15 @@ public interface Aggregator<T, R> {
     Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch);
 
     /** Adds a $graphLookup stage using a collection name and string fields.
+     * Note: connectFromField and connectToField are always passed through as raw Mongo
+     * field names — with only a collection name there is no entity type to translate
+     * against. Use the Class-based overloads to get field-name translation. startWith
+     * however is evaluated against the input documents (the search type), so with
+     * translateAggregationFieldNames enabled its $-references ARE translated.
      * @param fromCollection the collection name to search
-     * @param startWith expression for the starting value
-     * @param connectFromField the field to connect from
-     * @param connectToField the field to connect to
+     * @param startWith expression for the starting value (translated against the search type when the flag is on)
+     * @param connectFromField the field to connect from (raw Mongo field name, not translated)
+     * @param connectToField the field to connect to (raw Mongo field name, not translated)
      * @param as the output array field name
      * @param maxDepth maximum recursion depth
      * @param depthField field name to store depth
@@ -246,9 +251,13 @@ public interface Aggregator<T, R> {
     Aggregator<T, R> lookup(Class fromType, Enum localField, Enum foreignField, String outputArray, List<Expr> pipeline, Map<String, Expr> let);
 
     /** Adds a $lookup stage using a collection name and string fields.
+     * Note: localField is translated using the search type's field-name mapping,
+     * but foreignField is always passed through as a raw Mongo field name — with only
+     * a collection name there is no entity type to translate against. Use the
+     * Class/Enum-based overload to get translation on both sides.
      * @param fromCollection the collection name to join
-     * @param localField the local field name
-     * @param foreignField the foreign field name
+     * @param localField the local field name (Java property name, will be translated)
+     * @param foreignField the foreign field name (raw Mongo field name, not translated)
      * @param outputArray the output array field name
      * @param pipeline optional sub-pipeline
      * @param let optional let variables
@@ -442,6 +451,45 @@ public interface Aggregator<T, R> {
      * @return the aggregator */
     @SuppressWarnings("unused")
     Aggregator<T,R> setCollectionName(String cn);
+
+    /** Overrides the config setting translateAggregationFieldNames for this aggregator.
+     * When enabled, stage keys and $-field references in stage helpers are translated
+     * from Java property names to Mongo field names (consistent with project(Map) key
+     * translation). Set before building stages.
+     * Default implementation is a no-op so that third-party Aggregator implementations
+     * keep compiling; Morphium's own implementations override it.
+     * @param translate true/false to override, null to use the MorphiumConfig setting
+     * @return the aggregator */
+    default Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate) {
+        return this;
+    }
+
+    /** Returns the effective field-name-translation setting for this aggregator:
+     * the per-aggregator override if set, otherwise the value from MorphiumConfig
+     * (objectMappingSettings). Default false = legacy behavior.
+     * @return true if $-field references should be translated */
+    default boolean isTranslateAggregationFieldNames() {
+        return false;
+    }
+
+    /** Translates an enum field reference of the search type to its Mongo field name.
+     * Example: {@code MyEntity.Fields.itemCount} becomes {@code "item_count"}. Use as
+     * output field name in stage helpers: {@code group.sum(agg.name(F.itemCount), ...)}.
+     * @param field enum naming a Java property of the search type
+     * @return the translated Mongo field name */
+    default String name(Enum<?> field) {
+        return de.caluga.morphium.aggregation.internal.FieldNameTranslation.translate(getMorphium(), getSearchType(), field.name());
+    }
+
+    /** Translates an enum field reference of the search type to a $-prefixed Mongo
+     * field reference. Example: {@code MyEntity.Fields.itemCount} becomes
+     * {@code "$item_count"}. Use as value in stage helpers:
+     * {@code group.sum("total", agg.ref(F.itemCount))}.
+     * @param field enum naming a Java property of the search type
+     * @return the translated $-prefixed field reference */
+    default String ref(Enum<?> field) {
+        return "$" + name(field);
+    }
 
     /** Adds a $group stage using a map as the id expression.
      * @param id the group id expression map

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
@@ -1,6 +1,7 @@
 package de.caluga.morphium.aggregation;
 
 import de.caluga.morphium.Collation;
+import de.caluga.morphium.aggregation.internal.FieldNameTranslation;
 import de.caluga.morphium.Morphium;
 import de.caluga.morphium.UtilsMap;
 import de.caluga.morphium.annotations.Entity;
@@ -41,16 +42,28 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     private boolean explain = false;
     private Collation collation;
     private final Logger log = LoggerFactory.getLogger(AggregatorImpl.class);
+    private final FieldNameTranslation fieldNames;
 
     public AggregatorImpl(Morphium morphium, Class<? extends T> type, Class<? extends R> resultType) {
         this.morphium = morphium;
         setSearchType(type);
         setResultType(resultType);
+        fieldNames = new FieldNameTranslation(morphium, type);
     }
 
     private String tf(String field) {
-        if (morphium.getARHelper().getField(type, field) == null) return field;
-        return morphium.getARHelper().getMongoFieldName(type, field);
+        return fieldNames.tf(field);
+    }
+
+    @Override
+    public Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate) {
+        fieldNames.setOverride(translate);
+        return this;
+    }
+
+    @Override
+    public boolean isTranslateAggregationFieldNames() {
+        return fieldNames.isEnabled();
     }
 
     @Override
@@ -114,6 +127,9 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
             String key = tf(e.getKey());
+            if (!key.equals(e.getKey())) {
+                fieldNames.recordProjectKeyTranslation(e.getKey(), key);
+            }
             if (e.getValue() instanceof Expr) {
                 p.put(key, ((Expr) e.getValue()).toQueryObject());
             } else {
@@ -122,7 +138,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         }
 
         Map<String, Object> map = UtilsMap.of("$project", p);
-        params.add(map);
+        addOperator(map);
         return this;
     }
 
@@ -155,17 +171,16 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> addFields(Map<String, Object> m) {
         Map<String, Object> ret = new LinkedHashMap<>();
+        boolean translate = isTranslateAggregationFieldNames();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
-            if (e.getValue() instanceof Expr) {
-                ret.put(e.getKey(), ((Expr) e.getValue()).toQueryObject());
-            } else {
-                ret.put(e.getKey(), e.getValue());
-            }
+            String key = translate ? tf(e.getKey()) : e.getKey();
+            Object value = e.getValue() instanceof Expr ? ((Expr) e.getValue()).toQueryObject() : e.getValue();
+            ret.put(key, translate ? fieldNames.translateRefs(value) : value);
         }
 
         Map<String, Object> o = UtilsMap.of("$addFields", ret);
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
@@ -191,34 +206,34 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         if (collectionName == null)
             collectionName = q.getCollectionName();
 
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     @Override
     public Aggregator<T, R> matchSubQuery(Query<?> q) {
         Map<String, Object> o = UtilsMap.of("$match", q.toQueryObject());
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     @Override
     public Aggregator<T, R> match(Expr q) {
-        params.add(UtilsMap.of("$match", UtilsMap.of("$expr", q.toQueryObject())));
+        addOperator(UtilsMap.of("$match", UtilsMap.of("$expr", q.toQueryObject())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> limit(int num) {
         Map<String, Object> o = UtilsMap.of("$limit", num);
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     @Override
     public Aggregator<T, R> skip(int num) {
         Map<String, Object> o = UtilsMap.of("$skip", num);
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
@@ -226,14 +241,14 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> unwind(Expr listField) {
         Map<String, Object> o = UtilsMap.of("$unwind", listField);
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     @Override
     public Aggregator<T, R> unwind(String listField) {
         Map<String, Object> o = UtilsMap.of("$unwind", tf(listField));
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
@@ -270,8 +285,9 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> sort(Map<String, Integer> sort) {
-        Map<String, Object> o = UtilsMap.of("$sort", sort);
-        params.add(o);
+        Map<String, Integer> s = isTranslateAggregationFieldNames() ? fieldNames.translateKeys(sort) : sort;
+        Map<String, Object> o = UtilsMap.of("$sort", s);
+        addOperator(o);
         return this;
     }
 
@@ -310,8 +326,12 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         return gr;
     }
 
+    /** single entry point for pipeline stages: every stage helper routes through here.
+     * Invariant: any flag-based translation must happen BEFORE this call, so the
+     * untranslated-reference check only sees the stage as it will be sent to MongoDB. */
     @Override
     public void addOperator(Map<String, Object> o) {
+        fieldNames.warnUntranslatedRefs(o, log);
         params.add(o);
     }
 
@@ -481,7 +501,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> count(String fld) {
-        params.add(UtilsMap.of("$count", fld));
+        addOperator(UtilsMap.of("$count", fld));
         return this;
     }
 
@@ -524,7 +544,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             "default", preset.toQueryObject(),
             "output", Utils.getQueryObjectMap(output))
             );
-        params.add(m);
+        addOperator(m);
         return this;
     }
 
@@ -549,7 +569,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         if (granularity != null)
             bucketAuto.put("granularity", granularity.getValue());
 
-        params.add(map);
+        addOperator(map);
         return this;
     }
 
@@ -580,7 +600,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             m.put("queryExecStats", new HashMap<>());
         }
 
-        params.add(UtilsMap.of("$collStats", m));
+        addOperator(UtilsMap.of("$collStats", m));
         return this;
     }
 
@@ -588,7 +608,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     //{ $currentOp: { allUsers: <boolean>, idleConnections: <boolean>, idleCursors: <boolean>, idleSessions: <boolean>, localOps: <boolean> } }
     @Override
     public Aggregator<T, R> currentOp(boolean allUsers, boolean idleConnections, boolean idleCursors, boolean idleSessions, boolean localOps) {
-        params.add(UtilsMap.of("$currentOp", UtilsMap.of("allUsers", allUsers, "idleConnections", idleConnections, "idleCursors", idleCursors,
+        addOperator(UtilsMap.of("$currentOp", UtilsMap.of("allUsers", allUsers, "idleConnections", idleConnections, "idleCursors", idleCursors,
             "idleSessions", idleSessions,
             "localOps", localOps)
             ));
@@ -598,7 +618,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> facetExpr(Map<String, Expr> facets) {
         Map<String, Object> map = Utils.getQueryObjectMap(facets);
-        params.add(UtilsMap.of("$facet", map));
+        addOperator(UtilsMap.of("$facet", map));
         return this;
     }
 
@@ -610,7 +630,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             map.put(e.getKey(), e.getValue().getPipeline());
         }
 
-        params.add(UtilsMap.of("$facet", map));
+        addOperator(UtilsMap.of("$facet", map));
         return this;
     }
 
@@ -622,26 +642,27 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             map.put(e.getKey().name(), ((ObjectMapperImpl) morphium.getMapper()).marshallIfNecessary(e.getValue()));
         }
 
-        params.add(UtilsMap.of("$geoNear", map));
+        addOperator(UtilsMap.of("$geoNear", map));
         return this;
     }
 
     @Override
-    public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type),
+    public Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        return graphLookup(morphium.getMapper().getCollectionName(fromType),
             startWith,
-            connectFromField.name(),
-            connectToField.name(),
+            fieldNames.tf(fromType, connectFromField.name()),
+            fieldNames.tf(fromType, connectToField.name()),
             as,
             maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
-    public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type),
+    public Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        boolean translate = isTranslateAggregationFieldNames();
+        return graphLookup(morphium.getMapper().getCollectionName(fromType),
             startWith,
-            connectFromField,
-            connectToField,
+            translate ? fieldNames.tf(fromType, connectFromField) : connectFromField,
+            translate ? fieldNames.tf(fromType, connectToField) : connectToField,
             as,
             maxDepth, depthField, restrictSearchWithMatch);
     }
@@ -649,12 +670,13 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> graphLookup(String fromCollection, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField,
         Query restrictSearchWithMatch) {
+        Object startWithQo = isTranslateAggregationFieldNames()
+            ? fieldNames.translateRefs(startWith.toQueryObject()) : startWith.toQueryObject();
         Map<String, Object> add = UtilsMap.of("from", (Object) fromCollection,
-            "startWith", startWith.toQueryObject(),
+            "startWith", startWithQo,
             "connectFromField", connectFromField,
             "connectToField", connectToField,
             "as", as);
-        params.add(UtilsMap.of("$graphLookup", add));
 
         if (maxDepth != null)
             add.put("maxDepth", maxDepth);
@@ -665,24 +687,25 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         if (restrictSearchWithMatch != null)
             add.put("restrictSearchWithMatch", restrictSearchWithMatch.toQueryObject());
 
+        addOperator(UtilsMap.of("$graphLookup", add));
         return this;
     }
 
     @Override
     public Aggregator<T, R> indexStats() {
-        params.add(UtilsMap.of("$indexStats", new HashMap<>()));
+        addOperator(UtilsMap.of("$indexStats", new HashMap<>()));
         return this;
     }
 
     @Override
     public Aggregator<T, R> listLocalSessionsAllUsers() {
-        params.add(UtilsMap.of("$listLocalSessions", UtilsMap.of("allUsers", true)));
+        addOperator(UtilsMap.of("$listLocalSessions", UtilsMap.of("allUsers", true)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> listLocalSessions() {
-        params.add(UtilsMap.of("$listLocalSessions", new HashMap<>()));
+        addOperator(UtilsMap.of("$listLocalSessions", new HashMap<>()));
         return this;
     }
 
@@ -700,19 +723,19 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             usersList.add(UtilsMap.of(users.get(i), dbs.get(j)));
         }
 
-        params.add(UtilsMap.of("$listLocalSessions", UtilsMap.of("users", usersList)));
+        addOperator(UtilsMap.of("$listLocalSessions", UtilsMap.of("users", usersList)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> listSessionsAllUsers() {
-        params.add(UtilsMap.of("$listSessions", UtilsMap.of("allUsers", true)));
+        addOperator(UtilsMap.of("$listSessions", UtilsMap.of("allUsers", true)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> listSessions() {
-        params.add(UtilsMap.of("$listSessions", new HashMap<>()));
+        addOperator(UtilsMap.of("$listSessions", new HashMap<>()));
         return this;
     }
 
@@ -730,7 +753,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             usersList.add(UtilsMap.of(users.get(i), dbs.get(j)));
         }
 
-        params.add(UtilsMap.of("$listSessions", UtilsMap.of("users", usersList)));
+        addOperator(UtilsMap.of("$listSessions", UtilsMap.of("users", usersList)));
         return this;
     }
 
@@ -788,7 +811,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             m.put("let", map);
         }
 
-        params.add(UtilsMap.of("$lookup", m));
+        addOperator(UtilsMap.of("$lookup", m));
         return this;
     }
 
@@ -868,26 +891,26 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             doc.put("whenMatched", pipeline);
         }
 
-        params.add(UtilsMap.of("$merge", doc));
+        addOperator(UtilsMap.of("$merge", doc));
         return this;
     }
 
     @Override
     public Aggregator<T, R> out(String collectionName) {
-        params.add(UtilsMap.of("$out", UtilsMap.of("coll", collectionName)));
+        addOperator(UtilsMap.of("$out", UtilsMap.of("coll", collectionName)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> out(String db, String collectionName) {
-        params.add(UtilsMap.of("$out", UtilsMap.of("coll", collectionName, "db", db)
+        addOperator(UtilsMap.of("$out", UtilsMap.of("coll", collectionName, "db", db)
             ));
         return this;
     }
 
     @Override
     public Aggregator<T, R> planCacheStats(Map<String, Object> param) {
-        params.add(UtilsMap.of("$planCacheStats", new HashMap<>()));
+        addOperator(UtilsMap.of("$planCacheStats", new HashMap<>()));
         return this;
     }
 
@@ -902,25 +925,25 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> redact(Expr redact) {
-        params.add(UtilsMap.of("$redact", redact.toQueryObject()));
+        addOperator(UtilsMap.of("$redact", redact.toQueryObject()));
         return this;
     }
 
     @Override
     public Aggregator<T, R> replaceRoot(Expr newRoot) {
-        params.add(UtilsMap.of("$replaceRoot", UtilsMap.of("newRoot", newRoot.toQueryObject())));
+        addOperator(UtilsMap.of("$replaceRoot", UtilsMap.of("newRoot", newRoot.toQueryObject())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> replaceWith(Expr newDoc) {
-        params.add(UtilsMap.of("$replaceWith", newDoc.toQueryObject()));
+        addOperator(UtilsMap.of("$replaceWith", newDoc.toQueryObject()));
         return this;
     }
 
     @Override
     public Aggregator<T, R> sample(int sampleSize) {
-        params.add(UtilsMap.of("$sample", UtilsMap.of("size", sampleSize)));
+        addOperator(UtilsMap.of("$sample", UtilsMap.of("size", sampleSize)));
         return this;
     }
 
@@ -935,8 +958,13 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> set(Map<String, Expr> param) {
-        Map<String, Object> o = UtilsMap.of("$set", Utils.getQueryObjectMap(param));
-        params.add(o);
+        Map<String, Object> qo = Utils.getQueryObjectMap(param);
+        if (isTranslateAggregationFieldNames()) {
+            qo = fieldNames.translateKeys(qo);
+            qo.replaceAll((k, v) -> fieldNames.translateRefs(v));
+        }
+        Map<String, Object> o = UtilsMap.of("$set", qo);
+        addOperator(o);
         return this;
     }
 
@@ -952,19 +980,19 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> sortByCount(Expr sortby) {
-        params.add(UtilsMap.of("$sortByCount", sortby.toQueryObject()));
+        addOperator(UtilsMap.of("$sortByCount", sortby.toQueryObject()));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unionWith(String collection) {
-        params.add(UtilsMap.of("$unionWith", collection));
+        addOperator(UtilsMap.of("$unionWith", collection));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unionWith(Aggregator agg) {
-        params.add(UtilsMap.of("$unionWith", UtilsMap.of("coll", (Object) collectionName,
+        addOperator(UtilsMap.of("$unionWith", UtilsMap.of("coll", (Object) collectionName,
             "pipeline", agg.getPipeline())
             ));
         return this;
@@ -972,20 +1000,20 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> unset(List<String> field) {
-        params.add(UtilsMap.of("$unset", field.stream().map(this::tf).collect(Collectors.toList())));
+        addOperator(UtilsMap.of("$unset", field.stream().map(this::tf).collect(Collectors.toList())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unset(String... param) {
-        params.add(UtilsMap.of("$unset", Arrays.stream(param).map(this::tf).collect(Collectors.toList())));
+        addOperator(UtilsMap.of("$unset", Arrays.stream(param).map(this::tf).collect(Collectors.toList())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unset(@SuppressWarnings("rawtypes") Enum... field) {
         List<String> lst = Arrays.stream(field).map(e -> tf(e.name())).collect(Collectors.toList());
-        params.add(UtilsMap.of("$unset", lst));
+        addOperator(UtilsMap.of("$unset", lst));
         return this;
     }
 
@@ -999,7 +1027,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
             stageName = "$" + stageName;
         }
 
-        params.add(UtilsMap.of(stageName, param));
+        addOperator(UtilsMap.of(stageName, param));
         return this;
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
@@ -1,5 +1,6 @@
 package de.caluga.morphium.aggregation;
 
+import de.caluga.morphium.aggregation.internal.FieldNameTranslation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,10 @@ public class Group<T, R> {
         Map<String, Object> ret = new HashMap<>();
         ret.put(key, value);
         return ret;
+    }
+
+    private String tf(String field) {
+        return FieldNameTranslation.translate(aggregator.getMorphium(), aggregator.getSearchType(), field);
     }
 
     public Group<T, R> addToSet(String name, Object p) {
@@ -106,6 +111,7 @@ public class Group<T, R> {
         operators.add(jp);
         return this;
     }
+
     public Group<T, R> push(String name, String vn, String value) {
         Map<String, Object> o = getMap(name, getMap("$push", getMap(vn, value)));
         operators.add(o);
@@ -154,6 +160,10 @@ public class Group<T, R> {
         }
         Map<String, Object> params = new HashMap<>(id);
         operators.forEach(params::putAll);
+        if (aggregator.isTranslateAggregationFieldNames()) {
+            //noinspection unchecked
+            params = (Map<String, Object>) FieldNameTranslation.translateRefs(params, this::tf);
+        }
         Map<String, Object> obj = getMap("$group", params);
         aggregator.addOperator(obj);
         ended = true;

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
@@ -137,7 +137,7 @@ public class Group<T, R> {
     }
 
     public Group<T, R> stdDevSamp(String name, Object value) {
-        operators.add(getMap(name, getMap("stdDevSamp", value)));
+        operators.add(getMap(name, getMap("$stdDevSamp", value)));
         return this;
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/internal/FieldNameTranslation.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/internal/FieldNameTranslation.java
@@ -1,0 +1,177 @@
+package de.caluga.morphium.aggregation.internal;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.aggregation.Expr;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/**
+ * Internal helper shared by AggregatorImpl and InMemAggregator: implements the opt-in
+ * translateAggregationFieldNames behavior and the untranslated-reference warning
+ * (issue #208/#217). Not intended as public API.
+ *
+ * <p>The effective flag value is snapshotted from MorphiumConfig when the aggregator is
+ * created, so a pipeline is always built consistently even if the config changes
+ * mid-build; the per-aggregator override still takes precedence at any time.</p>
+ */
+public final class FieldNameTranslation {
+
+    private final Morphium morphium;
+    private final Class<?> searchType;
+    private final boolean configEnabled;
+    private Boolean override;
+    private final Map<String, String> translatedProjectKeys = new LinkedHashMap<>();
+    private final Set<String> warnedRefs = new HashSet<>();
+
+    public FieldNameTranslation(Morphium morphium, Class<?> searchType) {
+        this.morphium = morphium;
+        this.searchType = searchType;
+        this.configEnabled = morphium != null
+            && morphium.getConfig().objectMappingSettings().isTranslateAggregationFieldNames();
+    }
+
+    public void setOverride(Boolean override) {
+        this.override = override;
+    }
+
+    public boolean isEnabled() {
+        return override != null ? override : configEnabled;
+    }
+
+    /** the single implementation of Java-property-name to Mongo-field-name translation;
+     * null-safe: without a Morphium instance or type, and for names that are no entity
+     * property, the name passes through unchanged */
+    public static String translate(Morphium morphium, Class<?> type, String field) {
+        if (morphium == null || type == null) return field;
+        if (morphium.getARHelper().getField(type, field) == null) return field;
+        return morphium.getARHelper().getMongoFieldName(type, field);
+    }
+
+    /** translates a Java property name of the search type to its Mongo field name;
+     * names that are no property pass through unchanged */
+    public String tf(String field) {
+        return tf(searchType, field);
+    }
+
+    /** same as {@link #tf(String)}, but against an explicitly given entity type
+     * (e.g. the from type of a lookup/graphLookup) */
+    public String tf(Class<?> type, String field) {
+        return translate(morphium, type, field);
+    }
+
+    /** returns a copy of the map with all keys translated, preserving order */
+    public <V> Map<String, V> translateKeys(Map<String, V> m) {
+        Map<String, V> ret = new LinkedHashMap<>();
+        for (Map.Entry<String, V> e : m.entrySet()) {
+            ret.put(tf(e.getKey()), e.getValue());
+        }
+        return ret;
+    }
+
+    /** translates $-refs against the search type, see {@link #translateRefs(Object, UnaryOperator)} */
+    public Object translateRefs(Object value) {
+        return translateRefs(value, this::tf);
+    }
+
+    /**
+     * translates $-field references (not $$-variables) from Java property names to Mongo
+     * field names, recursing into maps and lists. Dot-paths translate their first
+     * segment ($itemCount.sub becomes $item_count.sub); deeper segments cannot be
+     * resolved without embedded-type information and pass through unchanged.
+     * $literal subtrees are data by definition and are never touched. Note that this
+     * operates on the serialized pipeline: Expr.string("$...") is indistinguishable
+     * from a field reference here and is therefore not supported with the flag on
+     * (wrap in $literal instead).
+     */
+    @SuppressWarnings("unchecked")
+    public static Object translateRefs(Object value, UnaryOperator<String> tf) {
+        if (value instanceof String) {
+            String s = (String) value;
+            if (s.startsWith("$") && !s.startsWith("$$")) {
+                String path = s.substring(1);
+                int dot = path.indexOf('.');
+                if (dot < 0) {
+                    return "$" + tf.apply(path);
+                }
+                return "$" + tf.apply(path.substring(0, dot)) + path.substring(dot);
+            }
+            return s;
+        }
+        if (value instanceof Map) {
+            Map<String, Object> ret = new LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) value).entrySet()) {
+                if ("$literal".equals(e.getKey())) {
+                    ret.put(e.getKey(), e.getValue());
+                } else {
+                    ret.put(e.getKey(), translateRefs(e.getValue(), tf));
+                }
+            }
+            return ret;
+        }
+        if (value instanceof List) {
+            List<Object> ret = new ArrayList<>();
+            for (Object o : (List<Object>) value) {
+                ret.add(translateRefs(o, tf));
+            }
+            return ret;
+        }
+        return value;
+    }
+
+    /** project(Map) reports every key it renamed here, so later stages referencing the
+     * original spelling can be warned about */
+    public void recordProjectKeyTranslation(String original, String translated) {
+        translatedProjectKeys.put(original, translated);
+    }
+
+    /**
+     * scans a pipeline stage for $-references to a project key that was silently
+     * renamed and logs a WARN for every distinct hit (issue #208: such references
+     * yield 0 / [] without any error). $$-variables are ignored.
+     */
+    public void warnUntranslatedRefs(Object stage, Logger log) {
+        if (translatedProjectKeys.isEmpty()) {
+            return;
+        }
+        scan(stage, log);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void scan(Object value, Logger log) {
+        if (value instanceof Expr) {
+            // the InMemAggregator keeps Expr objects in its stages - scan their serialized form
+            scan(((Expr) value).toQueryObject(), log);
+            return;
+        }
+        if (value instanceof String) {
+            String s = (String) value;
+            if (s.startsWith("$") && !s.startsWith("$$")) {
+                String firstSegment = s.substring(1).split("\\.")[0];
+                String translated = translatedProjectKeys.get(firstSegment);
+                if (translated != null && warnedRefs.add(firstSegment)) {
+                    log.warn("Aggregation stage references '${}', but project(Map) translated that key to '{}'. "
+                             + "The reference will not resolve and silently yields 0 / []. "
+                             + "Reference '${}' instead, or enable translateAggregationFieldNames.",
+                             firstSegment, translated, translated);
+                }
+            }
+        } else if (value instanceof Map) {
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) value).entrySet()) {
+                if (!"$literal".equals(e.getKey())) {
+                    scan(e.getValue(), log);
+                }
+            }
+        } else if (value instanceof List) {
+            for (Object v : (List<Object>) value) {
+                scan(v, log);
+            }
+        }
+    }
+}

--- a/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
@@ -10,6 +10,7 @@ public class ObjectMappingSettings extends Settings {
     private boolean objectSerializationEnabled = true;
     private boolean camelCaseConversionEnabled = true;
     private boolean warnOnNoEntitySerialization = false;
+    private boolean translateAggregationFieldNames = false;
     public boolean isCheckForNew() {
         return checkForNew;
     }
@@ -78,6 +79,32 @@ public class ObjectMappingSettings extends Settings {
     }
     public ObjectMappingSettings setWarnOnNoEntitySerialization(boolean warnOnNoEntitySerialization) {
         this.warnOnNoEntitySerialization = warnOnNoEntitySerialization;
+        return this;
+    }
+
+    /**
+     * if enabled, $-field references in aggregation stage helpers (e.g. Group.sum/push/avg)
+     * are translated from Java property names to Mongo field names, consistent with the
+     * translation of project(Map) keys. Default false = legacy behavior (references are
+     * passed through verbatim). Overridable per aggregator, see
+     * Aggregator.setTranslateAggregationFieldNames.
+     */
+    public boolean isTranslateAggregationFieldNames() {
+        return translateAggregationFieldNames;
+    }
+
+    public ObjectMappingSettings setTranslateAggregationFieldNames(boolean translateAggregationFieldNames) {
+        this.translateAggregationFieldNames = translateAggregationFieldNames;
+        return this;
+    }
+
+    public ObjectMappingSettings enableTranslateAggregationFieldNames() {
+        translateAggregationFieldNames = true;
+        return this;
+    }
+
+    public ObjectMappingSettings disableTranslateAggregationFieldNames() {
+        translateAggregationFieldNames = false;
         return this;
     }
 }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
@@ -2,6 +2,7 @@ package de.caluga.morphium.driver.inmem;
 
 import de.caluga.morphium.*;
 import de.caluga.morphium.aggregation.*;
+import de.caluga.morphium.aggregation.internal.FieldNameTranslation;
 import de.caluga.morphium.async.AsyncOperationCallback;
 import de.caluga.morphium.async.AsyncOperationType;
 import de.caluga.morphium.driver.Doc;
@@ -31,16 +32,28 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     private boolean useDisk = false;
     private boolean explain = false;
     private Collation collation;
+    private final FieldNameTranslation fieldNames;
 
     public InMemAggregator(Morphium morphium, Class <? extends T > type, Class <? extends R > resultType) {
         this.morphium = morphium;
         setSearchType(type);
         setResultType(resultType);
+        fieldNames = new FieldNameTranslation(morphium, type);
     }
 
     private String tf(String field) {
-        if (morphium.getARHelper().getField(type, field) == null) return field;
-        return morphium.getARHelper().getMongoFieldName(type, field);
+        return fieldNames.tf(field);
+    }
+
+    @Override
+    public Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate) {
+        fieldNames.setOverride(translate);
+        return this;
+    }
+
+    @Override
+    public boolean isTranslateAggregationFieldNames() {
+        return fieldNames.isEnabled();
     }
 
     @Override
@@ -117,11 +130,15 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         Map<String, Object> p = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
-            p.put(tf(e.getKey()), e.getValue());
+            String key = tf(e.getKey());
+            if (!key.equals(e.getKey())) {
+                fieldNames.recordProjectKeyTranslation(e.getKey(), key);
+            }
+            p.put(key, e.getValue());
         }
 
         Map<String, Object> map = UtilsMap.of("$project", p);
-        params.add(map);
+        addOperator(map);
         return this;
     }
 
@@ -146,26 +163,34 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     //    @Override
     //    public Aggregator<T, R> project(Map<String, Object> m) {
     //        Map<String, Object> o = UtilsMap.of("$project", m);
-    //        params.add(o);
+    //        addOperator(o);
     //        return this;
     //    }
 
     @Override
     public Aggregator<T, R> addFields(Map<String, Object> m) {
         Map<String, Object> ret = new LinkedHashMap<>();
+        boolean translate = isTranslateAggregationFieldNames();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
             Object value = e.getValue();
-            if (!(value instanceof Expr)) {
+            if (value instanceof Expr) {
+                if (translate) {
+                    value = Expr.parse(fieldNames.translateRefs(((Expr) value).toQueryObject()));
+                }
+            } else {
+                if (translate) {
+                    value = fieldNames.translateRefs(value);
+                }
                 // Convert raw aggregation expressions to Expr objects
                 value = Expr.parse(value);
             }
 
-            ret.put(e.getKey(), value);
+            ret.put(translate ? tf(e.getKey()) : e.getKey(), value);
         }
 
         Map<String, Object> o = UtilsMap.of("$addFields", ret);
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
@@ -177,47 +202,47 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             collectionName = q.getCollectionName();
         }
 
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     @Override
     public Aggregator<T, R> matchSubQuery(Query<?> q) {
         Map<String, Object> o = UtilsMap.of("$match", q.toQueryObject());
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     @Override
     public Aggregator<T, R> match(Expr q) {
-        params.add(UtilsMap.of("$match", UtilsMap.of("$expr", q)));
+        addOperator(UtilsMap.of("$match", UtilsMap.of("$expr", q)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> limit(int num) {
         Map<String, Object> o = UtilsMap.of("$limit", num);
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     @Override
     public Aggregator<T, R> skip(int num) {
         Map<String, Object> o = UtilsMap.of("$skip", num);
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     @Override
     public Aggregator<T, R> unwind(String listField) {
         Map<String, Object> o = UtilsMap.of("$unwind", tf(listField));
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
     public Aggregator<T, R> unwind(Expr field) {
         Map<String, Object> o = UtilsMap.of("$unwind", field);
-        params.add(o);
+        addOperator(o);
         return this;
     }
 
@@ -254,8 +279,9 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> sort(Map<String, Integer> sort) {
-        Map<String, Object> o = UtilsMap.of("$sort", sort);
-        params.add(o);
+        Map<String, Integer> s = isTranslateAggregationFieldNames() ? fieldNames.translateKeys(sort) : sort;
+        Map<String, Object> o = UtilsMap.of("$sort", s);
+        addOperator(o);
         return this;
     }
 
@@ -294,8 +320,12 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         return gr;
     }
 
+    /** single entry point for pipeline stages: every stage helper routes through here.
+     * Invariant: any flag-based translation must happen BEFORE this call, so the
+     * untranslated-reference check only sees the stage as it will be executed. */
     @Override
     public void addOperator(Map<String, Object> o) {
+        fieldNames.warnUntranslatedRefs(o, log);
         params.add(o);
     }
 
@@ -379,7 +409,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> count(String fld) {
-        params.add(UtilsMap.of("$count", fld));
+        addOperator(UtilsMap.of("$count", fld));
         return this;
     }
 
@@ -417,7 +447,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
         List<Object> bn = new ArrayList<>(boundaries);
         Map<String, Object> m = UtilsMap.of("$bucket", UtilsMap.of("groupBy", (Object) groupBy, "boundaries", bn, "default", preset, "output", Utils.getQueryObjectMap(output)));
-        params.add(m);
+        addOperator(m);
         return this;
     }
 
@@ -445,7 +475,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             bucketAuto.put("granularity", granularity.getValue());
         }
 
-        params.add(map);
+        addOperator(map);
         return this;
     }
 
@@ -477,21 +507,21 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             m.put("queryExecStats", new HashMap<>());
         }
 
-        params.add(UtilsMap.of("$collStats", m));
+        addOperator(UtilsMap.of("$collStats", m));
         return this;
     }
 
     //{ $currentOp: { allUsers: <boolean>, idleConnections: <boolean>, idleCursors: <boolean>, idleSessions: <boolean>, localOps: <boolean> } }
     @Override
     public Aggregator<T, R> currentOp(boolean allUsers, boolean idleConnections, boolean idleCursors, boolean idleSessions, boolean localOps) {
-        params.add(UtilsMap.of("$currentOp", UtilsMap.of("allUsers", allUsers, "idleConnections", idleConnections, "idleCursors", idleCursors, "idleSessions", idleSessions, "localOps", localOps)));
+        addOperator(UtilsMap.of("$currentOp", UtilsMap.of("allUsers", allUsers, "idleConnections", idleConnections, "idleCursors", idleCursors, "idleSessions", idleSessions, "localOps", localOps)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> facetExpr(Map<String, Expr> facets) {
         Map<String, Object> map = Utils.getQueryObjectMap(facets);
-        params.add(UtilsMap.of("$facet", map));
+        addOperator(UtilsMap.of("$facet", map));
         return this;
     }
 
@@ -503,7 +533,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             map.put(e.getKey(), e.getValue().getPipeline());
         }
 
-        params.add(UtilsMap.of("$facet", map));
+        addOperator(UtilsMap.of("$facet", map));
         return this;
     }
 
@@ -515,25 +545,30 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             map.put(e.getKey().name(), ((ObjectMapperImpl) morphium.getMapper()).marshallIfNecessary(e.getValue()));
         }
 
-        params.add(UtilsMap.of("$geoNear", map));
+        addOperator(UtilsMap.of("$geoNear", map));
         return this;
     }
 
     @Override
-    public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type), startWith, connectFromField.name(), connectToField.name(), as, maxDepth, depthField, restrictSearchWithMatch);
+    public Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        return graphLookup(morphium.getMapper().getCollectionName(fromType), startWith, fieldNames.tf(fromType, connectFromField.name()), fieldNames.tf(fromType, connectToField.name()), as, maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
-    public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type), startWith, connectFromField, connectToField, as, maxDepth, depthField, restrictSearchWithMatch);
+    public Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        boolean translate = isTranslateAggregationFieldNames();
+        return graphLookup(morphium.getMapper().getCollectionName(fromType), startWith,
+            translate ? fieldNames.tf(fromType, connectFromField) : connectFromField,
+            translate ? fieldNames.tf(fromType, connectToField) : connectToField,
+            as, maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
     public Aggregator<T, R> graphLookup(String fromCollection, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField,
                                         Query restrictSearchWithMatch) {
-        Map<String, Object> add = UtilsMap.of("from", (Object) fromCollection, "startWith", startWith, "connectFromField", connectFromField, "connectToField", connectToField, "as", as);
-        params.add(UtilsMap.of("$graphLookup", add));
+        Expr startWithExpr = isTranslateAggregationFieldNames()
+            ? Expr.parse(fieldNames.translateRefs(startWith.toQueryObject())) : startWith;
+        Map<String, Object> add = UtilsMap.of("from", (Object) fromCollection, "startWith", startWithExpr, "connectFromField", connectFromField, "connectToField", connectToField, "as", as);
 
         if (maxDepth != null) {
             add.put("maxDepth", maxDepth);
@@ -547,24 +582,25 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             add.put("restrictSearchWithMatch", restrictSearchWithMatch);
         }
 
+        addOperator(UtilsMap.of("$graphLookup", add));
         return this;
     }
 
     @Override
     public Aggregator<T, R> indexStats() {
-        params.add(UtilsMap.of("$indexStats", new HashMap<>()));
+        addOperator(UtilsMap.of("$indexStats", new HashMap<>()));
         return this;
     }
 
     @Override
     public Aggregator<T, R> listLocalSessionsAllUsers() {
-        params.add(UtilsMap.of("$listLocalSessions", UtilsMap.of("allUsers", true)));
+        addOperator(UtilsMap.of("$listLocalSessions", UtilsMap.of("allUsers", true)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> listLocalSessions() {
-        params.add(UtilsMap.of("$listLocalSessions", new HashMap<>()));
+        addOperator(UtilsMap.of("$listLocalSessions", new HashMap<>()));
         return this;
     }
 
@@ -582,19 +618,19 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             usersList.add(UtilsMap.of(users.get(i), dbs.get(j)));
         }
 
-        params.add(UtilsMap.of("$listLocalSessions", UtilsMap.of("users", usersList)));
+        addOperator(UtilsMap.of("$listLocalSessions", UtilsMap.of("users", usersList)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> listSessionsAllUsers() {
-        params.add(UtilsMap.of("$listSessions", UtilsMap.of("allUsers", true)));
+        addOperator(UtilsMap.of("$listSessions", UtilsMap.of("allUsers", true)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> listSessions() {
-        params.add(UtilsMap.of("$listSessions", new HashMap<>()));
+        addOperator(UtilsMap.of("$listSessions", new HashMap<>()));
         return this;
     }
 
@@ -612,7 +648,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             usersList.add(UtilsMap.of(users.get(i), dbs.get(j)));
         }
 
-        params.add(UtilsMap.of("$listSessions", UtilsMap.of("users", usersList)));
+        addOperator(UtilsMap.of("$listSessions", UtilsMap.of("users", usersList)));
         return this;
     }
 
@@ -666,7 +702,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             m.put("let", map);
         }
 
-        params.add(UtilsMap.of("$lookup", m));
+        addOperator(UtilsMap.of("$lookup", m));
         return this;
     }
 
@@ -755,13 +791,13 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             doc.put("whenMatched", pipeline);
         }
 
-        params.add(UtilsMap.of("$merge", doc));
+        addOperator(UtilsMap.of("$merge", doc));
         return this;
     }
 
     @Override
     public Aggregator<T, R> out(String collectionName) {
-        params.add(UtilsMap.of("$out", UtilsMap.of("coll", collectionName)));
+        addOperator(UtilsMap.of("$out", UtilsMap.of("coll", collectionName)));
         return this;
     }
 
@@ -772,13 +808,13 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> out(String db, String collectionName) {
-        params.add(UtilsMap.of("$out", UtilsMap.of("coll", collectionName, "db", db)));
+        addOperator(UtilsMap.of("$out", UtilsMap.of("coll", collectionName, "db", db)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> planCacheStats(Map<String, Object> param) {
-        params.add(UtilsMap.of("$planCacheStats", new HashMap<>()));
+        addOperator(UtilsMap.of("$planCacheStats", new HashMap<>()));
         return this;
     }
 
@@ -801,25 +837,25 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> redact(Expr redact) {
-        params.add(UtilsMap.of("$redact", redact));
+        addOperator(UtilsMap.of("$redact", redact));
         return this;
     }
 
     @Override
     public Aggregator<T, R> replaceRoot(Expr newRoot) {
-        params.add(UtilsMap.of("$replaceRoot", UtilsMap.of("newRoot", newRoot)));
+        addOperator(UtilsMap.of("$replaceRoot", UtilsMap.of("newRoot", newRoot)));
         return this;
     }
 
     @Override
     public Aggregator<T, R> replaceWith(Expr newDoc) {
-        params.add(UtilsMap.of("$replaceWith", newDoc));
+        addOperator(UtilsMap.of("$replaceWith", newDoc));
         return this;
     }
 
     @Override
     public Aggregator<T, R> sample(int sampleSize) {
-        params.add(UtilsMap.of("$sample", UtilsMap.of("size", sampleSize)));
+        addOperator(UtilsMap.of("$sample", UtilsMap.of("size", sampleSize)));
         return this;
     }
 
@@ -834,8 +870,13 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> set(Map<String, Expr> param) {
-        Map<String, Object> o = UtilsMap.of("$set", Utils.getQueryObjectMap(param));
-        params.add(o);
+        Map<String, Object> qo = Utils.getQueryObjectMap(param);
+        if (isTranslateAggregationFieldNames()) {
+            qo = fieldNames.translateKeys(qo);
+            qo.replaceAll((k, v) -> fieldNames.translateRefs(v));
+        }
+        Map<String, Object> o = UtilsMap.of("$set", qo);
+        addOperator(o);
         return this;
     }
 
@@ -852,38 +893,38 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> sortByCount(Expr sortby) {
-        params.add(UtilsMap.of("$sortByCount", sortby));
+        addOperator(UtilsMap.of("$sortByCount", sortby));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unionWith(String collection) {
-        params.add(UtilsMap.of("$unionWith", collection));
+        addOperator(UtilsMap.of("$unionWith", collection));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unionWith(Aggregator agg) {
-        params.add(UtilsMap.of("$unionWith", UtilsMap.of("coll", (Object) collectionName, "pipeline", agg.getPipeline())));
+        addOperator(UtilsMap.of("$unionWith", UtilsMap.of("coll", (Object) collectionName, "pipeline", agg.getPipeline())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unset(List<String> field) {
-        params.add(UtilsMap.of("$unset", field.stream().map(this::tf).collect(Collectors.toList())));
+        addOperator(UtilsMap.of("$unset", field.stream().map(this::tf).collect(Collectors.toList())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unset(String... param) {
-        params.add(UtilsMap.of("$unset", Arrays.stream(param).map(this::tf).collect(Collectors.toList())));
+        addOperator(UtilsMap.of("$unset", Arrays.stream(param).map(this::tf).collect(Collectors.toList())));
         return this;
     }
 
     @Override
     public Aggregator<T, R> unset(Enum... field) {
         List<String> lst = Arrays.stream(field).map(e -> tf(e.name())).collect(Collectors.toList());
-        params.add(UtilsMap.of("$unset", lst));
+        addOperator(UtilsMap.of("$unset", lst));
         return this;
     }
 
@@ -897,7 +938,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
             stageName = "$" + stageName;
         }
 
-        params.add(UtilsMap.of(stageName, param));
+        addOperator(UtilsMap.of(stageName, param));
         return this;
     }
 

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
@@ -132,6 +132,33 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> groupParams(Aggregator<AggEntity, Map> agg) {
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey("$group"), "stage should be $group");
+        return (Map<String, Object>) stage.get("$group");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object opRef(Map<String, Object> group, String name, String op) {
+        assertTrue(group.containsKey(name), "group should contain output field " + name);
+        Map<String, Object> opMap = (Map<String, Object>) group.get(name);
+        assertTrue(opMap.containsKey(op), name + " should use operator " + op);
+        return opMap.get(op);
+    }
+
+    @Test
+    public void stdDevSampStringOverloadUsesDollarOperator() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group("$lastName").stdDevSamp("s1", "$item_count").end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$item_count", opRef(group, "s1", "$stdDevSamp"),
+                         impl + ": stdDevSamp must emit the $stdDevSamp operator");
+        }
+    }
+
     @Test
     public void lookupEnumTranslatesLocalAndForeignFieldNames() {
         for (Aggregator<AggEntity, Map> agg : bothImplementations()) {

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
@@ -1,8 +1,12 @@
 package de.caluga.test.mongo.suite.inmem;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import de.caluga.morphium.aggregation.Aggregator;
 import de.caluga.morphium.aggregation.AggregatorImpl;
 import de.caluga.morphium.aggregation.Expr;
+import org.slf4j.LoggerFactory;
 import de.caluga.morphium.annotations.Entity;
 import de.caluga.morphium.annotations.Id;
 import de.caluga.morphium.annotations.caching.NoCache;
@@ -148,6 +152,41 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
     }
 
     @Test
+    public void refAndNameTranslateEnumFieldReferences() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            assertEquals("item_count", agg.name(AggEntity.Fields.itemCount),
+                         impl + ": name() should translate to the Mongo field name");
+            assertEquals("$item_count", agg.ref(AggEntity.Fields.itemCount),
+                         impl + ": ref() should translate and $-prefix");
+
+            agg.group("$lastName")
+               .sum(agg.name(AggEntity.Fields.itemCount), agg.ref(AggEntity.Fields.itemCount))
+               .push("raw", "$some_raw_ref")
+               .end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$item_count", opRef(group, "item_count", "$sum"),
+                         impl + ": name()/ref() should produce translated output name and reference");
+            assertFalse(group.containsKey("itemCount"), impl + ": untranslated itemCount should not appear");
+            assertEquals("$some_raw_ref", opRef(group, "raw", "$push"),
+                         impl + ": plain string values stay verbatim");
+        }
+    }
+
+    /** regression for the overload trap: an enum passed as VALUE must stay a value —
+     * there are deliberately no (String, Enum) overloads on Group */
+    @Test
+    public void enumValuesAreNotCapturedAsFieldReferences() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group("$lastName").push("status", AggEntity.Fields.firstName).end();
+            assertEquals(AggEntity.Fields.firstName, opRef(groupParams(agg), "status", "$push"),
+                         impl + ": an enum value must be passed through, not turned into a $-ref");
+        }
+    }
+
+    @Test
     public void stdDevSampStringOverloadUsesDollarOperator() {
         for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
             String impl = agg.getClass().getSimpleName();
@@ -156,6 +195,356 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
             Map<String, Object> group = groupParams(agg);
             assertEquals("$item_count", opRef(group, "s1", "$stdDevSamp"),
                          impl + ": stdDevSamp must emit the $stdDevSamp operator");
+        }
+    }
+
+    @Test
+    public void groupStringRefsStayVerbatimByDefault() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group(Map.of("ln", "$lastName")).sum("total", "$itemCount").end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$itemCount", opRef(group, "total", "$sum"),
+                         impl + ": legacy default must not translate group refs");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> id = (Map<String, Object>) group.get("_id");
+            assertEquals("$lastName", id.get("ln"), impl + ": legacy default must not translate group id refs");
+        }
+    }
+
+    @Test
+    public void translateFlagOnTranslatesGroupStringRefs() {
+        morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(true);
+        try {
+            for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+                String impl = agg.getClass().getSimpleName();
+                agg.group(Map.of("ln", "$lastName")).sum("total", "$itemCount").end();
+
+                Map<String, Object> group = groupParams(agg);
+                assertEquals("$item_count", opRef(group, "total", "$sum"),
+                             impl + ": flag on must translate group refs");
+                @SuppressWarnings("unchecked")
+                Map<String, Object> id = (Map<String, Object>) group.get("_id");
+                assertEquals("$last_name", id.get("ln"), impl + ": flag on must translate group id refs");
+            }
+        } finally {
+            morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(false);
+        }
+    }
+
+    @Test
+    public void perAggregatorOverrideBeatsConfig() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.group("x").sum("total", "$itemCount").end();
+            assertEquals("$item_count", opRef(groupParams(agg), "total", "$sum"),
+                         impl + ": aggregator override true must translate although config is off");
+        }
+
+        morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(true);
+        try {
+            for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+                String impl = agg.getClass().getSimpleName();
+                agg.setTranslateAggregationFieldNames(false);
+                agg.group("x").sum("total", "$itemCount").end();
+                assertEquals("$itemCount", opRef(groupParams(agg), "total", "$sum"),
+                             impl + ": aggregator override false must win over config on");
+            }
+        } finally {
+            morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(false);
+        }
+    }
+
+    private List<ILoggingEvent> runAndCaptureWarns(Aggregator<AggEntity, Map> agg, Runnable pipelineBuilder) {
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(agg.getClass());
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            pipelineBuilder.run();
+            return appender.list.stream()
+                   .filter(ev -> ev.getLevel() == Level.WARN)
+                   .collect(java.util.stream.Collectors.toList());
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    private ILoggingEvent runAndCaptureWarn(Aggregator<AggEntity, Map> agg, Runnable pipelineBuilder) {
+        List<ILoggingEvent> warns = runAndCaptureWarns(agg, pipelineBuilder);
+        return warns.isEmpty() ? null : warns.get(0);
+    }
+
+    @Test
+    public void warnsWhenTranslatedProjectKeyIsReferencedUntranslated() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$itemCount").end();
+            });
+            assertNotNull(warn, impl + ": referencing $itemCount after project translated the key to item_count should WARN");
+            assertTrue(warn.getFormattedMessage().contains("itemCount"),
+                       impl + ": warning should name the reference the user wrote");
+            assertTrue(warn.getFormattedMessage().contains("item_count"),
+                       impl + ": warning should name the translated key");
+        }
+    }
+
+    @Test
+    public void warnsOutsideGroupStagesToo() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.addFields(Map.of("doubled", "$itemCount"));
+            });
+            assertNotNull(warn, impl + ": a non-group stage referencing the renamed key must WARN too");
+        }
+    }
+
+    @Test
+    public void warnIsEmittedOnlyOncePerReference() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            List<ILoggingEvent> warns = runAndCaptureWarns(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("a", "$itemCount").max("b", "$itemCount").end();
+            });
+            assertEquals(1, warns.size(), impl + ": the same untranslated reference must only be warned about once");
+        }
+    }
+
+    @Test
+    public void literalValuesStayUntouchedWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.addFields(Map.of("x", Map.of("$literal", "$firstName")));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> literal = (Map<String, Object>) unwrapExpr(af.get("x"));
+            assertEquals("$firstName", literal.get("$literal"),
+                         impl + ": $literal content is data, not a field reference - must never be translated");
+        }
+    }
+
+    @Test
+    public void setMapValueRefsTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.set(Map.of("copy", Expr.field("firstName")));
+
+            Map<String, Object> set = stagePart(agg, "$set");
+            assertEquals("$first_name", unwrapExpr(set.get("copy")),
+                         impl + ": flag on must translate refs in set(Map) values");
+        }
+    }
+
+    @Test
+    public void graphLookupStartWithTranslatesWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.graphLookup(LookupEntity.class, Expr.field("itemCount"),
+                            "owner_name", "owner_name", "joined", null, null, null);
+
+            Map<String, Object> gl = stagePart(agg, "$graphLookup");
+            assertEquals("$item_count", unwrapExpr(gl.get("startWith")),
+                         impl + ": startWith is evaluated on input docs and must translate against the search type");
+        }
+    }
+
+    @Test
+    public void noWarnWhenTranslatedKeyIsReferencedCorrectly() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$item_count").end();
+            });
+            assertNull(warn, impl + ": referencing the translated name must not WARN");
+        }
+    }
+
+    @Test
+    public void noWarnWhenTranslateFlagResolvesTheReference() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$itemCount").end();
+            });
+            assertNull(warn, impl + ": with the flag on the reference is translated and consistent — no WARN");
+        }
+    }
+
+    @Test
+    public void dotPathRefsTranslateFirstSegmentWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.group("$lastName").push("all", "$itemCount.sub").end();
+            assertEquals("$item_count.sub", opRef(groupParams(agg), "all", "$push"),
+                         impl + ": dot-path refs must translate their first segment");
+        }
+    }
+
+    @Test
+    public void dollarDollarVariablesStayUntouchedWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.group("$lastName").push("all", "$$ROOT").end();
+            assertEquals("$$ROOT", opRef(groupParams(agg), "all", "$push"),
+                         impl + ": $$-variables must never be translated");
+        }
+    }
+
+    @Test
+    public void addFieldsExprValueTranslatesWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.addFields(Map.of("computed", Expr.field("firstName")));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            assertEquals("$first_name", unwrapExpr(af.get("computed")),
+                         impl + ": flag on must translate refs inside Expr values too");
+        }
+    }
+
+    /** end-to-end repro of issue #208: with the flag on, the project/group pipeline from
+     * the issue returns real sums instead of silent zeros */
+    @Test
+    public void issue208PipelineReturnsCorrectSumsWithFlagOn() {
+        for (int i = 1; i <= 3; i++) {
+            AggEntity e = new AggEntity();
+            e.lastName = "smith";
+            e.itemCount = i;
+            morphium.store(e);
+        }
+
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.project(Map.of("lastName", "$last_name", "itemCount", "$item_count"));
+            agg.group("$lastName").sum("total", "$itemCount").end();
+
+            List<Map<String, Object>> result = agg.aggregateMap();
+            assertEquals(1, result.size(), impl + ": one group expected");
+            assertEquals(6, ((Number) result.get(0).get("total")).intValue(),
+                         impl + ": sum must be 3+2+1=6, not the silent 0 from issue #208");
+        }
+    }
+
+    /** InMemAggregator wraps raw addFields values in Expr — normalize for comparison */
+    private Object unwrapExpr(Object value) {
+        return value instanceof Expr ? ((Expr) value).toQueryObject() : value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> stagePart(Aggregator<AggEntity, Map> agg, String stageName) {
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey(stageName), "stage should be " + stageName);
+        return (Map<String, Object>) stage.get(stageName);
+    }
+
+    @Test
+    public void graphLookupEnumTranslatesConnectFields() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.graphLookup(LookupEntity.class, Expr.field("owner_name"),
+                            LookupEntity.Fields.ownerName, LookupEntity.Fields.ownerName,
+                            "joined", null, null, null);
+
+            Map<String, Object> gl = stagePart(agg, "$graphLookup");
+            assertEquals("owner_name", gl.get("connectFromField"),
+                         impl + ": enum connectFromField should be translated using the from type");
+            assertEquals("owner_name", gl.get("connectToField"),
+                         impl + ": enum connectToField should be translated using the from type");
+        }
+    }
+
+    @Test
+    public void graphLookupClassStringConnectFieldsTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.graphLookup(LookupEntity.class, Expr.field("owner_name"),
+                            "ownerName", "ownerName", "joined", null, null, null);
+
+            Map<String, Object> gl = stagePart(agg, "$graphLookup");
+            assertEquals("owner_name", gl.get("connectFromField"),
+                         impl + ": flag on must translate String connectFromField against the from type");
+            assertEquals("owner_name", gl.get("connectToField"),
+                         impl + ": flag on must translate String connectToField against the from type");
+        }
+    }
+
+    @Test
+    public void addFieldsAndSortStayVerbatimByDefault() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.addFields(Map.of("itemCount", "$firstName"));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            assertTrue(af.containsKey("itemCount"), impl + ": legacy default must not translate addFields keys");
+            assertEquals("$firstName", unwrapExpr(af.get("itemCount")),
+                         impl + ": legacy default must not translate addFields refs");
+        }
+
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.sort(Map.of("itemCount", 1));
+            assertTrue(stagePart(agg, "$sort").containsKey("itemCount"),
+                       impl + ": legacy default must not translate sort(Map) keys");
+        }
+    }
+
+    @Test
+    public void addFieldsKeysAndRefsTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.addFields(Map.of("itemCount", "$firstName"));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            assertTrue(af.containsKey("item_count"), impl + ": flag on must translate addFields keys");
+            assertFalse(af.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
+            assertEquals("$first_name", unwrapExpr(af.get("item_count")),
+                         impl + ": flag on must translate $-refs in addFields values");
+        }
+    }
+
+    @Test
+    public void setMapKeysTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.set(Map.of("itemCount", Expr.field("first_name")));
+
+            Map<String, Object> set = stagePart(agg, "$set");
+            assertTrue(set.containsKey("item_count"), impl + ": flag on must translate set(Map) keys");
+            assertFalse(set.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
+        }
+    }
+
+    @Test
+    public void sortMapKeysTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.sort(Map.of("itemCount", 1));
+
+            Map<String, Object> sort = stagePart(agg, "$sort");
+            assertTrue(sort.containsKey("item_count"), impl + ": flag on must translate sort(Map) keys");
+            assertFalse(sort.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
         }
     }
 


### PR DESCRIPTION
## Summary

Implements the 6.3 part of #208 plus the coverage completion from #217, **reworked after code review** (supersedes #220, which is folded in here). Two commits: the standalone `stdDevSamp` bugfix, then the feature.

### The problem
`project(Map)` translates its keys through the entity field-name mapping, but the other stage helpers passed keys and `$`-references through verbatim. A projected key colliding with an entity property was silently renamed — later stages referencing the name the user wrote got `$sum: 0` / `$push: []` with no error.

### Changes

- **Opt-in setting `translateAggregationFieldNames`** (`ObjectMappingSettings`, per-aggregator override via `Aggregator.setTranslateAggregationFieldNames`). When on, translation applies **uniformly**: group operator `$`-refs and id values, `addFields`/`set` keys *and values*, `sort(Map)` keys, `graphLookup` connect fields and `startWith`, and `$`-refs **inside `Expr` values** (one mental model: the flag translates Java names, raw string or Expr alike). Dot-paths translate their first segment; `$$`-variables are never touched. **Default off = exactly legacy behavior.** The config value is snapshotted at aggregator creation, so a pipeline is always built consistently; the override wins at any time.
- **WARN on the silent-zero case**, deduplicated per reference, emitted by both implementations when a later stage references a renamed `project(Map)` key by its original spelling.
- **`Aggregator.ref(Enum)` / `Aggregator.name(Enum)`**: explicit enum translation helpers (`F.itemCount` → `"$item_count"` / `"item_count"`), always translating, independent of the flag. **Deliberately no `Group` overloads**: `(String, Enum)` overloads would silently capture enums passed as *values* (`push("status", MyStatus.ACTIVE)` → `"$active"`) and make `sum("x", null)` ambiguous. A regression test pins that enum values stay values.
- **`graphLookup` enum overload bugfix**: translated connect fields against the from type (same family as the 6.2.5 `lookup` fix, #198). ⚠️ Behavior change outside the flag — called out in CHANGELOG under *Changed*.
- **`Group.stdDevSamp(String, Object)` bugfix** (own commit): emitted `stdDevSamp` without the `$` prefix — the accumulator never worked via the String path.
- **All new `Aggregator` interface methods are `default` methods** — third-party implementations keep compiling (binary + source compatible).
- **Shared implementation**: `FieldNameTranslation` encapsulates flag resolution, translation, project-key recording and the warner; used by `AggregatorImpl`, `InMemAggregator` and `Group` — no more copy-paste drift between the implementations.
- Javadoc on `lookup(String ...)` / `graphLookup(String ...)`: with only a collection name there is no type to translate against — those field names are raw Mongo names.

### On project(Map) key translation (the root-cause question)
The underlying wart is that `project(Map)` translates its **keys** although they are output names — `Map.of("itemCount", "$item_count")` produces a field named `item_count`, not what was asked for. Changing that is a hard behavioral break for everyone relying on it since it shipped, which is exactly what 6.3 must not do. Position for 7.0 (tracked in #208): either deprecate key translation in `project(Map)` with a literal-projection replacement, or make the flag-on behavior the default so the pipeline is at least *consistently* translated. The WARN is a stopgap for the transition, not a permanent fixture.

### Tests

`AggregatorFieldNameTranslationTest`: 25 tests, each running against both `AggregatorImpl` and `InMemAggregator` — including dot-path refs, `$$`-variables, Expr values under the flag, the enum-value capture regression, WARN positive/negative cases, and an end-to-end repro of the issue scenario (sum = 6 instead of silent 0) through both implementations.

```
Tests run: 51, Failures: 0, Errors: 0, Skipped: 0
(AggregatorFieldNameTranslationTest 25, InMemAggregationTests 23, InMemAggregatorSmokeTest 3)
```

Closes #208
Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)