### PR TITLE
feat(aggregation): complete field-name translation coverage (#217)

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Aggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Aggregator.java
@@ -182,10 +182,13 @@ public interface Aggregator<T, R> {
     Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch);
 
     /** Adds a $graphLookup stage using a collection name and string fields.
+     * Note: connectFromField and connectToField are always passed through as raw Mongo
+     * field names — with only a collection name there is no entity type to translate
+     * against. Use the Class-based overloads to get field-name translation.
      * @param fromCollection the collection name to search
      * @param startWith expression for the starting value
-     * @param connectFromField the field to connect from
-     * @param connectToField the field to connect to
+     * @param connectFromField the field to connect from (raw Mongo field name, not translated)
+     * @param connectToField the field to connect to (raw Mongo field name, not translated)
      * @param as the output array field name
      * @param maxDepth maximum recursion depth
      * @param depthField field name to store depth

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Aggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Aggregator.java
@@ -246,9 +246,13 @@ public interface Aggregator<T, R> {
     Aggregator<T, R> lookup(Class fromType, Enum localField, Enum foreignField, String outputArray, List<Expr> pipeline, Map<String, Expr> let);
 
     /** Adds a $lookup stage using a collection name and string fields.
+     * Note: localField is translated using the search type's field-name mapping,
+     * but foreignField is always passed through as a raw Mongo field name — with only
+     * a collection name there is no entity type to translate against. Use the
+     * Class/Enum-based overload to get translation on both sides.
      * @param fromCollection the collection name to join
-     * @param localField the local field name
-     * @param foreignField the foreign field name
+     * @param localField the local field name (Java property name, will be translated)
+     * @param foreignField the foreign field name (raw Mongo field name, not translated)
      * @param outputArray the output array field name
      * @param pipeline optional sub-pipeline
      * @param let optional let variables
@@ -442,6 +446,20 @@ public interface Aggregator<T, R> {
      * @return the aggregator */
     @SuppressWarnings("unused")
     Aggregator<T,R> setCollectionName(String cn);
+
+    /** Overrides the config setting translateAggregationFieldNames for this aggregator.
+     * When enabled, $-field references in group stage helpers are translated from Java
+     * property names to Mongo field names (consistent with project(Map) key translation).
+     * Set before building stages.
+     * @param translate true/false to override, null to use the MorphiumConfig setting
+     * @return the aggregator */
+    Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate);
+
+    /** Returns the effective field-name-translation setting for this aggregator:
+     * the per-aggregator override if set, otherwise the value from MorphiumConfig
+     * (objectMappingSettings). Default false = legacy behavior.
+     * @return true if $-field references should be translated */
+    boolean isTranslateAggregationFieldNames();
 
     /** Adds a $group stage using a map as the id expression.
      * @param id the group id expression map

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
@@ -52,8 +52,12 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     private final Map<String, String> translatedProjectKeys = new LinkedHashMap<>();
 
     private String tf(String field) {
-        if (morphium.getARHelper().getField(type, field) == null) return field;
-        return morphium.getARHelper().getMongoFieldName(type, field);
+        return tf(type, field);
+    }
+
+    private String tf(Class<?> t, String field) {
+        if (morphium.getARHelper().getField(t, field) == null) return field;
+        return morphium.getARHelper().getMongoFieldName(t, field);
     }
 
     @Override
@@ -173,12 +177,14 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> addFields(Map<String, Object> m) {
         Map<String, Object> ret = new LinkedHashMap<>();
+        boolean translate = isTranslateAggregationFieldNames();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
+            String key = translate ? tf(e.getKey()) : e.getKey();
             if (e.getValue() instanceof Expr) {
-                ret.put(e.getKey(), ((Expr) e.getValue()).toQueryObject());
+                ret.put(key, ((Expr) e.getValue()).toQueryObject());
             } else {
-                ret.put(e.getKey(), e.getValue());
+                ret.put(key, translate ? RefTranslation.translateRefs(e.getValue(), this::tf) : e.getValue());
             }
         }
 
@@ -288,7 +294,14 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> sort(Map<String, Integer> sort) {
-        Map<String, Object> o = UtilsMap.of("$sort", sort);
+        Map<String, Integer> s = sort;
+        if (isTranslateAggregationFieldNames()) {
+            s = new LinkedHashMap<>();
+            for (Map.Entry<String, Integer> e : sort.entrySet()) {
+                s.put(tf(e.getKey()), e.getValue());
+            }
+        }
+        Map<String, Object> o = UtilsMap.of("$sort", s);
         params.add(o);
         return this;
     }
@@ -649,18 +662,19 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
         return graphLookup(morphium.getMapper().getCollectionName(type),
             startWith,
-            connectFromField.name(),
-            connectToField.name(),
+            tf(type, connectFromField.name()),
+            tf(type, connectToField.name()),
             as,
             maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
     public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        boolean translate = isTranslateAggregationFieldNames();
         return graphLookup(morphium.getMapper().getCollectionName(type),
             startWith,
-            connectFromField,
-            connectToField,
+            translate ? tf(type, connectFromField) : connectFromField,
+            translate ? tf(type, connectToField) : connectToField,
             as,
             maxDepth, depthField, restrictSearchWithMatch);
     }
@@ -954,7 +968,15 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> set(Map<String, Expr> param) {
-        Map<String, Object> o = UtilsMap.of("$set", Utils.getQueryObjectMap(param));
+        Map<String, Object> qo = Utils.getQueryObjectMap(param);
+        if (isTranslateAggregationFieldNames()) {
+            Map<String, Object> translated = new LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : qo.entrySet()) {
+                translated.put(tf(e.getKey()), e.getValue());
+            }
+            qo = translated;
+        }
+        Map<String, Object> o = UtilsMap.of("$set", qo);
         params.add(o);
         return this;
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
@@ -48,9 +48,24 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         setResultType(resultType);
     }
 
+    private Boolean translateAggregationFieldNames;
+    private final Map<String, String> translatedProjectKeys = new LinkedHashMap<>();
+
     private String tf(String field) {
         if (morphium.getARHelper().getField(type, field) == null) return field;
         return morphium.getARHelper().getMongoFieldName(type, field);
+    }
+
+    @Override
+    public Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate) {
+        translateAggregationFieldNames = translate;
+        return this;
+    }
+
+    @Override
+    public boolean isTranslateAggregationFieldNames() {
+        if (translateAggregationFieldNames != null) return translateAggregationFieldNames;
+        return morphium != null && morphium.getConfig().objectMappingSettings().isTranslateAggregationFieldNames();
     }
 
     @Override
@@ -114,6 +129,9 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
             String key = tf(e.getKey());
+            if (!key.equals(e.getKey())) {
+                translatedProjectKeys.put(e.getKey(), key);
+            }
             if (e.getValue() instanceof Expr) {
                 p.put(key, ((Expr) e.getValue()).toQueryObject());
             } else {
@@ -312,6 +330,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public void addOperator(Map<String, Object> o) {
+        UntranslatedRefWarner.warnOnUntranslatedRefs(translatedProjectKeys, o, log);
         params.add(o);
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
@@ -53,11 +53,33 @@ public class Group<T, R> {
         return ret;
     }
 
+    private String tf(String field) {
+        if (aggregator.getMorphium() == null) return field;
+        if (aggregator.getMorphium().getARHelper().getField(aggregator.getSearchType(), field) == null) return field;
+        return aggregator.getMorphium().getARHelper().getMongoFieldName(aggregator.getSearchType(), field);
+    }
+
+    private String ref(Enum<?> field) {
+        return "$" + tf(field.name());
+    }
+
     public Group<T, R> addToSet(String name, Object p) {
         Map<String, Object> o = getMap(name, getMap("$addToSet", p));
         operators.add(o);
         return this;
 
+    }
+
+    public Group<T, R> addToSet(String name, Enum<?> fieldRef) {
+        return addToSet(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> addToSet(Enum<?> name, Enum<?> fieldRef) {
+        return addToSet(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> addToSet(Enum<?> name, Object p) {
+        return addToSet(tf(name.name()), p);
     }
 
     public Group<T, R> addToSet(String name, Map<String, Object> param) {
@@ -77,10 +99,34 @@ public class Group<T, R> {
         return this;
     }
 
+    public Group<T, R> first(String name, Enum<?> fieldRef) {
+        return first(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> first(Enum<?> name, Enum<?> fieldRef) {
+        return first(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> first(Enum<?> name, Object p) {
+        return first(tf(name.name()), p);
+    }
+
     public Group<T, R> last(String name, Object p) {
         Map<String, Object> o = getMap(name, getMap("$last", p));
         operators.add(o);
         return this;
+    }
+
+    public Group<T, R> last(String name, Enum<?> fieldRef) {
+        return last(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> last(Enum<?> name, Enum<?> fieldRef) {
+        return last(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> last(Enum<?> name, Object p) {
+        return last(tf(name.name()), p);
     }
 
     public Group<T, R> max(String name, Object p) {
@@ -89,10 +135,34 @@ public class Group<T, R> {
         return this;
     }
 
+    public Group<T, R> max(String name, Enum<?> fieldRef) {
+        return max(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> max(Enum<?> name, Enum<?> fieldRef) {
+        return max(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> max(Enum<?> name, Object p) {
+        return max(tf(name.name()), p);
+    }
+
     public Group<T, R> min(String name, Object p) {
         Map<String, Object> o = getMap(name, getMap("$min", p));
         operators.add(o);
         return this;
+    }
+
+    public Group<T, R> min(String name, Enum<?> fieldRef) {
+        return min(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> min(Enum<?> name, Enum<?> fieldRef) {
+        return min(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> min(Enum<?> name, Object p) {
+        return min(tf(name.name()), p);
     }
 
     public Group<T, R> avg(String name, Object p) {
@@ -101,10 +171,34 @@ public class Group<T, R> {
         return this;
     }
 
+    public Group<T, R> avg(String name, Enum<?> fieldRef) {
+        return avg(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> avg(Enum<?> name, Enum<?> fieldRef) {
+        return avg(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> avg(Enum<?> name, Object p) {
+        return avg(tf(name.name()), p);
+    }
+
     public Group<T, R> push(String name, Object o) {
         Map<String, Object> jp = getMap(name, getMap("$push", o));
         operators.add(jp);
         return this;
+    }
+
+    public Group<T, R> push(String name, Enum<?> fieldRef) {
+        return push(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> push(Enum<?> name, Enum<?> fieldRef) {
+        return push(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> push(Enum<?> name, Object p) {
+        return push(tf(name.name()), p);
     }
     public Group<T, R> push(String name, String vn, String value) {
         Map<String, Object> o = getMap(name, getMap("$push", getMap(vn, value)));
@@ -131,14 +225,50 @@ public class Group<T, R> {
         return sum(name, (Object) p);
     }
 
+    public Group<T, R> sum(String name, Enum<?> fieldRef) {
+        return sum(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> sum(Enum<?> name, Enum<?> fieldRef) {
+        return sum(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> sum(Enum<?> name, Object p) {
+        return sum(tf(name.name()), p);
+    }
+
     public Group<T, R> stdDevPop(String name, Object value) {
         operators.add(getMap(name, getMap("$stdDevPop", value)));
         return this;
     }
 
+    public Group<T, R> stdDevPop(String name, Enum<?> fieldRef) {
+        return stdDevPop(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> stdDevPop(Enum<?> name, Enum<?> fieldRef) {
+        return stdDevPop(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> stdDevPop(Enum<?> name, Object p) {
+        return stdDevPop(tf(name.name()), p);
+    }
+
     public Group<T, R> stdDevSamp(String name, Object value) {
-        operators.add(getMap(name, getMap("stdDevSamp", value)));
+        operators.add(getMap(name, getMap("$stdDevSamp", value)));
         return this;
+    }
+
+    public Group<T, R> stdDevSamp(String name, Enum<?> fieldRef) {
+        return stdDevSamp(name, (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> stdDevSamp(Enum<?> name, Enum<?> fieldRef) {
+        return stdDevSamp(tf(name.name()), (Object) ref(fieldRef));
+    }
+
+    public Group<T, R> stdDevSamp(Enum<?> name, Object p) {
+        return stdDevSamp(tf(name.name()), p);
     }
 
     public Group<T, R> expr(String fld, Expr e) {
@@ -154,10 +284,45 @@ public class Group<T, R> {
         }
         Map<String, Object> params = new HashMap<>(id);
         operators.forEach(params::putAll);
+        if (aggregator.isTranslateAggregationFieldNames()) {
+            //noinspection unchecked
+            params = (Map<String, Object>) translateRefs(params);
+        }
         Map<String, Object> obj = getMap("$group", params);
         aggregator.addOperator(obj);
         ended = true;
         return aggregator;
+    }
+
+    /**
+     * translates $-field references (not $$-variables) from Java property names to Mongo
+     * field names, recursing into maps and lists. Only active when
+     * translateAggregationFieldNames is enabled.
+     */
+    @SuppressWarnings("unchecked")
+    private Object translateRefs(Object value) {
+        if (value instanceof String) {
+            String s = (String) value;
+            if (s.startsWith("$") && !s.startsWith("$$")) {
+                return "$" + tf(s.substring(1));
+            }
+            return s;
+        }
+        if (value instanceof Map) {
+            Map<String, Object> ret = new HashMap<>();
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) value).entrySet()) {
+                ret.put(e.getKey(), translateRefs(e.getValue()));
+            }
+            return ret;
+        }
+        if (value instanceof List) {
+            List<Object> ret = new ArrayList<>();
+            for (Object o : (List<Object>) value) {
+                ret.add(translateRefs(o));
+            }
+            return ret;
+        }
+        return value;
     }
 
     public List<Map<String, Object>> getOperators() {

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
@@ -286,43 +286,12 @@ public class Group<T, R> {
         operators.forEach(params::putAll);
         if (aggregator.isTranslateAggregationFieldNames()) {
             //noinspection unchecked
-            params = (Map<String, Object>) translateRefs(params);
+            params = (Map<String, Object>) RefTranslation.translateRefs(params, this::tf);
         }
         Map<String, Object> obj = getMap("$group", params);
         aggregator.addOperator(obj);
         ended = true;
         return aggregator;
-    }
-
-    /**
-     * translates $-field references (not $$-variables) from Java property names to Mongo
-     * field names, recursing into maps and lists. Only active when
-     * translateAggregationFieldNames is enabled.
-     */
-    @SuppressWarnings("unchecked")
-    private Object translateRefs(Object value) {
-        if (value instanceof String) {
-            String s = (String) value;
-            if (s.startsWith("$") && !s.startsWith("$$")) {
-                return "$" + tf(s.substring(1));
-            }
-            return s;
-        }
-        if (value instanceof Map) {
-            Map<String, Object> ret = new HashMap<>();
-            for (Map.Entry<String, Object> e : ((Map<String, Object>) value).entrySet()) {
-                ret.put(e.getKey(), translateRefs(e.getValue()));
-            }
-            return ret;
-        }
-        if (value instanceof List) {
-            List<Object> ret = new ArrayList<>();
-            for (Object o : (List<Object>) value) {
-                ret.add(translateRefs(o));
-            }
-            return ret;
-        }
-        return value;
     }
 
     public List<Map<String, Object>> getOperators() {

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/RefTranslation.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/RefTranslation.java
@@ -1,0 +1,46 @@
+package de.caluga.morphium.aggregation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+/**
+ * Internal helper for the opt-in translateAggregationFieldNames behavior: translates
+ * $-field references (not $$-variables) from Java property names to Mongo field names,
+ * recursing into maps and lists. Values that are no entity property pass through
+ * unchanged (the supplied translation function is expected to be identity for unknown
+ * names).
+ */
+public final class RefTranslation {
+
+    private RefTranslation() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Object translateRefs(Object value, UnaryOperator<String> tf) {
+        if (value instanceof String) {
+            String s = (String) value;
+            if (s.startsWith("$") && !s.startsWith("$$")) {
+                return "$" + tf.apply(s.substring(1));
+            }
+            return s;
+        }
+        if (value instanceof Map) {
+            Map<String, Object> ret = new HashMap<>();
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) value).entrySet()) {
+                ret.put(e.getKey(), translateRefs(e.getValue(), tf));
+            }
+            return ret;
+        }
+        if (value instanceof List) {
+            List<Object> ret = new ArrayList<>();
+            for (Object o : (List<Object>) value) {
+                ret.add(translateRefs(o, tf));
+            }
+            return ret;
+        }
+        return value;
+    }
+}

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/UntranslatedRefWarner.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/UntranslatedRefWarner.java
@@ -1,0 +1,58 @@
+package de.caluga.morphium.aggregation;
+
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Internal helper: project(Map) translates its keys through the entity's field-name
+ * mapping. If a later stage references such a key by the name the user wrote, the
+ * reference points at a non-existent field and MongoDB silently returns 0 / [] (see
+ * issue #208). This check makes that case visible with a WARN.
+ */
+public final class UntranslatedRefWarner {
+
+    private UntranslatedRefWarner() {
+    }
+
+    /**
+     * scans a pipeline stage for $-references to a project key that was translated and
+     * logs a WARN for every hit. $$-variables are ignored.
+     *
+     * @param translatedKeys original project key -&gt; translated Mongo field name
+     * @param stage          the stage (or part of it) to scan
+     * @param log            logger of the calling aggregator
+     */
+    public static void warnOnUntranslatedRefs(Map<String, String> translatedKeys, Object stage, Logger log) {
+        if (translatedKeys == null || translatedKeys.isEmpty()) {
+            return;
+        }
+        scan(translatedKeys, stage, log);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void scan(Map<String, String> translatedKeys, Object value, Logger log) {
+        if (value instanceof String) {
+            String s = (String) value;
+            if (s.startsWith("$") && !s.startsWith("$$")) {
+                String firstSegment = s.substring(1).split("\\.")[0];
+                String translated = translatedKeys.get(firstSegment);
+                if (translated != null) {
+                    log.warn("Aggregation stage references '${}', but project(Map) translated that key to '{}'. "
+                             + "The reference will not resolve and silently yields 0 / []. "
+                             + "Reference '${}' instead, or enable translateAggregationFieldNames.",
+                             firstSegment, translated, translated);
+                }
+            }
+        } else if (value instanceof Map) {
+            for (Object v : ((Map<String, Object>) value).values()) {
+                scan(translatedKeys, v, log);
+            }
+        } else if (value instanceof List) {
+            for (Object v : (List<Object>) value) {
+                scan(translatedKeys, v, log);
+            }
+        }
+    }
+}

--- a/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
@@ -10,6 +10,7 @@ public class ObjectMappingSettings extends Settings {
     private boolean objectSerializationEnabled = true;
     private boolean camelCaseConversionEnabled = true;
     private boolean warnOnNoEntitySerialization = false;
+    private boolean translateAggregationFieldNames = false;
     public boolean isCheckForNew() {
         return checkForNew;
     }
@@ -78,6 +79,32 @@ public class ObjectMappingSettings extends Settings {
     }
     public ObjectMappingSettings setWarnOnNoEntitySerialization(boolean warnOnNoEntitySerialization) {
         this.warnOnNoEntitySerialization = warnOnNoEntitySerialization;
+        return this;
+    }
+
+    /**
+     * if enabled, $-field references in aggregation stage helpers (e.g. Group.sum/push/avg)
+     * are translated from Java property names to Mongo field names, consistent with the
+     * translation of project(Map) keys. Default false = legacy behavior (references are
+     * passed through verbatim). Overridable per aggregator, see
+     * Aggregator.setTranslateAggregationFieldNames.
+     */
+    public boolean isTranslateAggregationFieldNames() {
+        return translateAggregationFieldNames;
+    }
+
+    public ObjectMappingSettings setTranslateAggregationFieldNames(boolean translateAggregationFieldNames) {
+        this.translateAggregationFieldNames = translateAggregationFieldNames;
+        return this;
+    }
+
+    public ObjectMappingSettings enableTranslateAggregationFieldNames() {
+        translateAggregationFieldNames = true;
+        return this;
+    }
+
+    public ObjectMappingSettings disableTranslateAggregationFieldNames() {
+        translateAggregationFieldNames = false;
         return this;
     }
 }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
@@ -38,9 +38,24 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         setResultType(resultType);
     }
 
+    private Boolean translateAggregationFieldNames;
+    private final Map<String, String> translatedProjectKeys = new LinkedHashMap<>();
+
     private String tf(String field) {
         if (morphium.getARHelper().getField(type, field) == null) return field;
         return morphium.getARHelper().getMongoFieldName(type, field);
+    }
+
+    @Override
+    public Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate) {
+        translateAggregationFieldNames = translate;
+        return this;
+    }
+
+    @Override
+    public boolean isTranslateAggregationFieldNames() {
+        if (translateAggregationFieldNames != null) return translateAggregationFieldNames;
+        return morphium != null && morphium.getConfig().objectMappingSettings().isTranslateAggregationFieldNames();
     }
 
     @Override
@@ -117,7 +132,11 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         Map<String, Object> p = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
-            p.put(tf(e.getKey()), e.getValue());
+            String key = tf(e.getKey());
+            if (!key.equals(e.getKey())) {
+                translatedProjectKeys.put(e.getKey(), key);
+            }
+            p.put(key, e.getValue());
         }
 
         Map<String, Object> map = UtilsMap.of("$project", p);
@@ -296,6 +315,7 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public void addOperator(Map<String, Object> o) {
+        UntranslatedRefWarner.warnOnUntranslatedRefs(translatedProjectKeys, o, log);
         params.add(o);
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
@@ -42,8 +42,12 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     private final Map<String, String> translatedProjectKeys = new LinkedHashMap<>();
 
     private String tf(String field) {
-        if (morphium.getARHelper().getField(type, field) == null) return field;
-        return morphium.getARHelper().getMongoFieldName(type, field);
+        return tf(type, field);
+    }
+
+    private String tf(Class<?> t, String field) {
+        if (morphium.getARHelper().getField(t, field) == null) return field;
+        return morphium.getARHelper().getMongoFieldName(t, field);
     }
 
     @Override
@@ -172,15 +176,19 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> addFields(Map<String, Object> m) {
         Map<String, Object> ret = new LinkedHashMap<>();
+        boolean translate = isTranslateAggregationFieldNames();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
             Object value = e.getValue();
             if (!(value instanceof Expr)) {
+                if (translate) {
+                    value = RefTranslation.translateRefs(value, this::tf);
+                }
                 // Convert raw aggregation expressions to Expr objects
                 value = Expr.parse(value);
             }
 
-            ret.put(e.getKey(), value);
+            ret.put(translate ? tf(e.getKey()) : e.getKey(), value);
         }
 
         Map<String, Object> o = UtilsMap.of("$addFields", ret);
@@ -273,7 +281,14 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> sort(Map<String, Integer> sort) {
-        Map<String, Object> o = UtilsMap.of("$sort", sort);
+        Map<String, Integer> s = sort;
+        if (isTranslateAggregationFieldNames()) {
+            s = new LinkedHashMap<>();
+            for (Map.Entry<String, Integer> e : sort.entrySet()) {
+                s.put(tf(e.getKey()), e.getValue());
+            }
+        }
+        Map<String, Object> o = UtilsMap.of("$sort", s);
         params.add(o);
         return this;
     }
@@ -541,12 +556,16 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type), startWith, connectFromField.name(), connectToField.name(), as, maxDepth, depthField, restrictSearchWithMatch);
+        return graphLookup(morphium.getMapper().getCollectionName(type), startWith, tf(type, connectFromField.name()), tf(type, connectToField.name()), as, maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
     public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type), startWith, connectFromField, connectToField, as, maxDepth, depthField, restrictSearchWithMatch);
+        boolean translate = isTranslateAggregationFieldNames();
+        return graphLookup(morphium.getMapper().getCollectionName(type), startWith,
+            translate ? tf(type, connectFromField) : connectFromField,
+            translate ? tf(type, connectToField) : connectToField,
+            as, maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
@@ -854,7 +873,15 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> set(Map<String, Expr> param) {
-        Map<String, Object> o = UtilsMap.of("$set", Utils.getQueryObjectMap(param));
+        Map<String, Object> qo = Utils.getQueryObjectMap(param);
+        if (isTranslateAggregationFieldNames()) {
+            Map<String, Object> translated = new LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : qo.entrySet()) {
+                translated.put(tf(e.getKey()), e.getValue());
+            }
+            qo = translated;
+        }
+        Map<String, Object> o = UtilsMap.of("$set", qo);
         params.add(o);
         return this;
     }

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
@@ -132,6 +132,219 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> groupParams(Aggregator<AggEntity, Map> agg) {
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey("$group"), "stage should be $group");
+        return (Map<String, Object>) stage.get("$group");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object opRef(Map<String, Object> group, String name, String op) {
+        assertTrue(group.containsKey(name), "group should contain output field " + name);
+        Map<String, Object> opMap = (Map<String, Object>) group.get(name);
+        assertTrue(opMap.containsKey(op), name + " should use operator " + op);
+        return opMap.get(op);
+    }
+
+    @Test
+    public void groupEnumRefTranslatesFieldReference() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group("$lastName")
+               .sum("s1", AggEntity.Fields.itemCount)
+               .avg("s2", AggEntity.Fields.itemCount)
+               .min("s3", AggEntity.Fields.itemCount)
+               .max("s4", AggEntity.Fields.itemCount)
+               .first("s5", AggEntity.Fields.itemCount)
+               .last("s6", AggEntity.Fields.itemCount)
+               .push("s7", AggEntity.Fields.itemCount)
+               .addToSet("s8", AggEntity.Fields.itemCount)
+               .stdDevPop("s9", AggEntity.Fields.itemCount)
+               .stdDevSamp("s10", AggEntity.Fields.itemCount)
+               .end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$item_count", opRef(group, "s1", "$sum"), impl + ": sum ref should be translated");
+            assertEquals("$item_count", opRef(group, "s2", "$avg"), impl + ": avg ref should be translated");
+            assertEquals("$item_count", opRef(group, "s3", "$min"), impl + ": min ref should be translated");
+            assertEquals("$item_count", opRef(group, "s4", "$max"), impl + ": max ref should be translated");
+            assertEquals("$item_count", opRef(group, "s5", "$first"), impl + ": first ref should be translated");
+            assertEquals("$item_count", opRef(group, "s6", "$last"), impl + ": last ref should be translated");
+            assertEquals("$item_count", opRef(group, "s7", "$push"), impl + ": push ref should be translated");
+            assertEquals("$item_count", opRef(group, "s8", "$addToSet"), impl + ": addToSet ref should be translated");
+            assertEquals("$item_count", opRef(group, "s9", "$stdDevPop"), impl + ": stdDevPop ref should be translated");
+            assertEquals("$item_count", opRef(group, "s10", "$stdDevSamp"), impl + ": stdDevSamp ref should be translated");
+        }
+    }
+
+    @Test
+    public void groupEnumOutputNameTranslates() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group("$lastName")
+               .sum(AggEntity.Fields.itemCount, AggEntity.Fields.itemCount)
+               .push(AggEntity.Fields.firstName, "$some_raw_ref")
+               .end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$item_count", opRef(group, "item_count", "$sum"),
+                         impl + ": enum output name and ref should both be translated");
+            assertFalse(group.containsKey("itemCount"), impl + ": untranslated itemCount should not appear");
+            assertEquals("$some_raw_ref", opRef(group, "first_name", "$push"),
+                         impl + ": enum output name translated, Object value passed verbatim");
+        }
+    }
+
+    @Test
+    public void stdDevSampStringOverloadUsesDollarOperator() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group("$lastName").stdDevSamp("s1", "$item_count").end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$item_count", opRef(group, "s1", "$stdDevSamp"),
+                         impl + ": stdDevSamp must emit the $stdDevSamp operator");
+        }
+    }
+
+    @Test
+    public void groupStringRefsStayVerbatimByDefault() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group(Map.of("ln", "$lastName")).sum("total", "$itemCount").end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$itemCount", opRef(group, "total", "$sum"),
+                         impl + ": legacy default must not translate group refs");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> id = (Map<String, Object>) group.get("_id");
+            assertEquals("$lastName", id.get("ln"), impl + ": legacy default must not translate group id refs");
+        }
+    }
+
+    @Test
+    public void translateFlagOnTranslatesGroupStringRefs() {
+        morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(true);
+        try {
+            for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+                String impl = agg.getClass().getSimpleName();
+                agg.group(Map.of("ln", "$lastName")).sum("total", "$itemCount").end();
+
+                Map<String, Object> group = groupParams(agg);
+                assertEquals("$item_count", opRef(group, "total", "$sum"),
+                             impl + ": flag on must translate group refs");
+                @SuppressWarnings("unchecked")
+                Map<String, Object> id = (Map<String, Object>) group.get("_id");
+                assertEquals("$last_name", id.get("ln"), impl + ": flag on must translate group id refs");
+            }
+        } finally {
+            morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(false);
+        }
+    }
+
+    @Test
+    public void perAggregatorOverrideBeatsConfig() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.group("x").sum("total", "$itemCount").end();
+            assertEquals("$item_count", opRef(groupParams(agg), "total", "$sum"),
+                         impl + ": aggregator override true must translate although config is off");
+        }
+
+        morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(true);
+        try {
+            for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+                String impl = agg.getClass().getSimpleName();
+                agg.setTranslateAggregationFieldNames(false);
+                agg.group("x").sum("total", "$itemCount").end();
+                assertEquals("$itemCount", opRef(groupParams(agg), "total", "$sum"),
+                             impl + ": aggregator override false must win over config on");
+            }
+        } finally {
+            morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(false);
+        }
+    }
+
+    private ch.qos.logback.classic.spi.ILoggingEvent runAndCaptureWarn(Aggregator<AggEntity, Map> agg, Runnable pipelineBuilder) {
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(agg.getClass());
+        ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new ch.qos.logback.core.read.ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            pipelineBuilder.run();
+            return appender.list.stream()
+                   .filter(ev -> ev.getLevel() == ch.qos.logback.classic.Level.WARN)
+                   .findFirst().orElse(null);
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    public void warnsWhenTranslatedProjectKeyIsReferencedUntranslated() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ch.qos.logback.classic.spi.ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$itemCount").end();
+            });
+            assertNotNull(warn, impl + ": referencing $itemCount after project translated the key to item_count should WARN");
+            assertTrue(warn.getFormattedMessage().contains("itemCount"),
+                       impl + ": warning should name the reference the user wrote");
+            assertTrue(warn.getFormattedMessage().contains("item_count"),
+                       impl + ": warning should name the translated key");
+        }
+    }
+
+    @Test
+    public void noWarnWhenTranslatedKeyIsReferencedCorrectly() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ch.qos.logback.classic.spi.ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$item_count").end();
+            });
+            assertNull(warn, impl + ": referencing the translated name must not WARN");
+        }
+    }
+
+    @Test
+    public void noWarnWhenTranslateFlagResolvesTheReference() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            ch.qos.logback.classic.spi.ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$itemCount").end();
+            });
+            assertNull(warn, impl + ": with the flag on the reference is translated and consistent — no WARN");
+        }
+    }
+
+    /** end-to-end repro of issue #208: with the flag on, the project/group pipeline from
+     * the issue returns real sums instead of silent zeros */
+    @Test
+    public void issue208PipelineReturnsCorrectSumsWithFlagOn() {
+        for (int i = 1; i <= 3; i++) {
+            AggEntity e = new AggEntity();
+            e.lastName = "smith";
+            e.itemCount = i;
+            morphium.store(e);
+        }
+
+        Aggregator<AggEntity, Map> agg = morphium.createAggregator(AggEntity.class, Map.class);
+        agg.setTranslateAggregationFieldNames(true);
+        agg.project(Map.of("lastName", "$last_name", "itemCount", "$item_count"));
+        agg.group("$lastName").sum("total", "$itemCount").end();
+
+        List<Map<String, Object>> result = agg.aggregateMap();
+        assertEquals(1, result.size(), "one group expected");
+        assertEquals(6, ((Number) result.get(0).get("total")).intValue(),
+                     "sum must be 3+2+1=6, not the silent 0 from issue #208");
+    }
+
     @Test
     public void lookupEnumTranslatesLocalAndForeignFieldNames() {
         for (Aggregator<AggEntity, Map> agg : bothImplementations()) {

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
@@ -345,6 +345,111 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
                      "sum must be 3+2+1=6, not the silent 0 from issue #208");
     }
 
+    /** InMemAggregator wraps raw addFields values in Expr — normalize for comparison */
+    private Object unwrapExpr(Object value) {
+        return value instanceof Expr ? ((Expr) value).toQueryObject() : value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> stagePart(Aggregator<AggEntity, Map> agg, String stageName) {
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey(stageName), "stage should be " + stageName);
+        return (Map<String, Object>) stage.get(stageName);
+    }
+
+    @Test
+    public void graphLookupEnumTranslatesConnectFields() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.graphLookup(LookupEntity.class, Expr.field("owner_name"),
+                            LookupEntity.Fields.ownerName, LookupEntity.Fields.ownerName,
+                            "joined", null, null, null);
+
+            Map<String, Object> gl = stagePart(agg, "$graphLookup");
+            assertEquals("owner_name", gl.get("connectFromField"),
+                         impl + ": enum connectFromField should be translated using the from type");
+            assertEquals("owner_name", gl.get("connectToField"),
+                         impl + ": enum connectToField should be translated using the from type");
+        }
+    }
+
+    @Test
+    public void graphLookupClassStringConnectFieldsTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.graphLookup(LookupEntity.class, Expr.field("owner_name"),
+                            "ownerName", "ownerName", "joined", null, null, null);
+
+            Map<String, Object> gl = stagePart(agg, "$graphLookup");
+            assertEquals("owner_name", gl.get("connectFromField"),
+                         impl + ": flag on must translate String connectFromField against the from type");
+            assertEquals("owner_name", gl.get("connectToField"),
+                         impl + ": flag on must translate String connectToField against the from type");
+        }
+    }
+
+    @Test
+    public void addFieldsAndSortStayVerbatimByDefault() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.addFields(Map.of("itemCount", "$firstName"));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            assertTrue(af.containsKey("itemCount"), impl + ": legacy default must not translate addFields keys");
+            assertEquals("$firstName", unwrapExpr(af.get("itemCount")),
+                         impl + ": legacy default must not translate addFields refs");
+        }
+
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.sort(Map.of("itemCount", 1));
+            assertTrue(stagePart(agg, "$sort").containsKey("itemCount"),
+                       impl + ": legacy default must not translate sort(Map) keys");
+        }
+    }
+
+    @Test
+    public void addFieldsKeysAndRefsTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.addFields(Map.of("itemCount", "$firstName"));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            assertTrue(af.containsKey("item_count"), impl + ": flag on must translate addFields keys");
+            assertFalse(af.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
+            assertEquals("$first_name", unwrapExpr(af.get("item_count")),
+                         impl + ": flag on must translate $-refs in addFields values");
+        }
+    }
+
+    @Test
+    public void setMapKeysTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.set(Map.of("itemCount", Expr.field("first_name")));
+
+            Map<String, Object> set = stagePart(agg, "$set");
+            assertTrue(set.containsKey("item_count"), impl + ": flag on must translate set(Map) keys");
+            assertFalse(set.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
+        }
+    }
+
+    @Test
+    public void sortMapKeysTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.sort(Map.of("itemCount", 1));
+
+            Map<String, Object> sort = stagePart(agg, "$sort");
+            assertTrue(sort.containsKey("item_count"), impl + ": flag on must translate sort(Map) keys");
+            assertFalse(sort.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
+        }
+    }
+
     @Test
     public void lookupEnumTranslatesLocalAndForeignFieldNames() {
         for (Aggregator<AggEntity, Map> agg : bothImplementations()) {


### PR DESCRIPTION
## Summary

Implements #217 — completes the opt-in `translateAggregationFieldNames` story from #216 across the remaining aggregation stage helpers, and fixes a `graphLookup` enum-overload bug.

> **Stacked PR**: based on `feature/208-aggregator-field-translation` (#216) because it builds on the flag and helper infrastructure introduced there. Retarget to `develop` once #216 is merged.

### Changes

- **`graphLookup` enum overload bugfix (always translates)**: `graphLookup(Class, Expr, Enum, Enum, ...)` passed `connectFromField.name()` / `connectToField.name()` through raw — same bug family as the `lookup` enum overload fixed in 6.2.5 (#198). Now translates against the *from* type (connect fields refer to documents of the from collection), independent of the flag, per the "enum always means translate" convention.
- **Flag-gated translation for the String paths** (default off = exactly legacy behavior):
  - `addFields(Map)`: keys and `$`-string refs in values (recursing into maps/lists, `$$`-variables untouched)
  - `set(Map<String, Expr>)`: keys (Expr values untouched, per the #208 scope decision)
  - `sort(Map<String, Integer>)`: keys
  - `graphLookup(Class, Expr, String, String, ...)`: connect fields, translated against the given from type
- **`RefTranslation`**: the recursive `$`-ref translation is extracted from `Group` into a shared helper used by `Group`, `AggregatorImpl` and `InMemAggregator`.
- **Javadoc**: `graphLookup(String fromCollection, ...)` documents that connect fields are raw Mongo field names (no entity type to translate against) — same wording as the `lookup(String ...)` note from #216.

### Tests

`AggregatorFieldNameTranslationTest` extended from 16 to 22 tests, each running against both `AggregatorImpl` and `InMemAggregator`: enum graphLookup translation, flag-on translation for addFields/set/sort/graphLookup, and a pinning test that the legacy default stays verbatim. Existing call sites verified: `GraphLookupTest` and `InMemAggregationTests` use String overloads with raw Mongo names — unaffected.

```
Tests run: 48, Failures: 0, Errors: 0, Skipped: 0
(AggregatorFieldNameTranslationTest 22, InMemAggregationTests 23, InMemAggregatorSmokeTest 3)
```

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)