### PR TITLE
fix(aggregation): Group.stdDevSamp emitted stdDevSamp without $ prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The `InMemoryDriver` now honors `$setOnInsert` and the `upsert`/`new` flags in `
 
 ### Fixed
 
+#### Aggregator: `Group.stdDevSamp(String, Object)` emitted `stdDevSamp` without the `$` prefix
+The operator map was built as `{stdDevSamp: ...}` instead of `{$stdDevSamp: ...}`, so the String-based `stdDevSamp` accumulator never worked. (The `$stdDevPop` sibling was correct.)
+
 #### Driver: replicaset failover repaired — bounded timeouts, write retries, changestream recovery
 During a primary failure (crash, frozen VM, network partition) the driver effectively never recovered: writes failed or hung indefinitely, messaging never reconnected. Root causes and fixes:
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
@@ -137,7 +137,7 @@ public class Group<T, R> {
     }
 
     public Group<T, R> stdDevSamp(String name, Object value) {
-        operators.add(getMap(name, getMap("stdDevSamp", value)));
+        operators.add(getMap(name, getMap("$stdDevSamp", value)));
         return this;
     }
 

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
@@ -132,6 +132,33 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> groupParams(Aggregator<AggEntity, Map> agg) {
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey("$group"), "stage should be $group");
+        return (Map<String, Object>) stage.get("$group");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object opRef(Map<String, Object> group, String name, String op) {
+        assertTrue(group.containsKey(name), "group should contain output field " + name);
+        Map<String, Object> opMap = (Map<String, Object>) group.get(name);
+        assertTrue(opMap.containsKey(op), name + " should use operator " + op);
+        return opMap.get(op);
+    }
+
+    @Test
+    public void stdDevSampStringOverloadUsesDollarOperator() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group("$lastName").stdDevSamp("s1", "$item_count").end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$item_count", opRef(group, "s1", "$stdDevSamp"),
+                         impl + ": stdDevSamp must emit the $stdDevSamp operator");
+        }
+    }
+
     @Test
     public void lookupEnumTranslatesLocalAndForeignFieldNames() {
         for (Aggregator<AggEntity, Map> agg : bothImplementations()) {


### PR DESCRIPTION
**PR A of 4** (stacked series replacing #216 — A → B #? → C #? → D #?).

`Group.stdDevSamp(String, Object)` built its operator map as `{stdDevSamp: ...}` instead of `{$stdDevSamp: ...}` — the String-based accumulator never worked (`$stdDevPop` was correct). One-line fix plus a test running against both `AggregatorImpl` and `InMemAggregator`.

Standalone and cherry-pickable for a 6.2.x patch release. CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)