### PR TITLE
feat(aggregation): WARN when renamed project(Map) keys are referenced untranslated (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Aggregator: WARN when a renamed project(Map) key is referenced by its original spelling (#208)
+`project(Map)` translates its keys through the entity's field-name mapping. When a later stage references such a key by the name the user wrote, the reference points at a non-existent field and MongoDB silently returns `$sum: 0` / `$push: []`. Both aggregator implementations now log a WARN (once per reference) naming both spellings. `$$`-variables and `$literal` subtrees are ignored; dot-paths are matched by their first segment.
+
 #### PoppyDB: priority-based leader step-back after failover (#177)
 A PoppyDB leader now voluntarily hands leadership to a peer with higher election priority, mirroring MongoDB's priority takeover. Previously a failover to a lower-priority node was permanent — the preferred primary never returned, even after it recovered.
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
@@ -1,6 +1,7 @@
 package de.caluga.morphium.aggregation;
 
 import de.caluga.morphium.Collation;
+import de.caluga.morphium.aggregation.internal.UntranslatedRefWarner;
 import de.caluga.morphium.Morphium;
 import de.caluga.morphium.UtilsMap;
 import de.caluga.morphium.annotations.Entity;
@@ -41,6 +42,7 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     private boolean explain = false;
     private Collation collation;
     private final Logger log = LoggerFactory.getLogger(AggregatorImpl.class);
+    private final UntranslatedRefWarner refWarner = new UntranslatedRefWarner();
 
     public AggregatorImpl(Morphium morphium, Class<? extends T> type, Class<? extends R> resultType) {
         this.morphium = morphium;
@@ -114,6 +116,9 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
             String key = tf(e.getKey());
+            if (!key.equals(e.getKey())) {
+                refWarner.recordProjectKeyTranslation(e.getKey(), key);
+            }
             if (e.getValue() instanceof Expr) {
                 p.put(key, ((Expr) e.getValue()).toQueryObject());
             } else {
@@ -311,8 +316,10 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     }
 
     @Override
-    /** single entry point for pipeline stages: every stage helper routes through here. */
+    /** single entry point for pipeline stages: every stage helper routes through here,
+     * so the untranslated-reference check sees the stage as it will be sent to MongoDB. */
     public void addOperator(Map<String, Object> o) {
+        refWarner.warnUntranslatedRefs(o, log);
         params.add(o);
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/internal/UntranslatedRefWarner.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/internal/UntranslatedRefWarner.java
@@ -1,0 +1,74 @@
+package de.caluga.morphium.aggregation.internal;
+
+import de.caluga.morphium.aggregation.Expr;
+import org.slf4j.Logger;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Internal helper shared by AggregatorImpl and InMemAggregator: project(Map) translates
+ * its keys through the entity's field-name mapping. If a later stage references such a
+ * key by the name the user wrote, the reference points at a non-existent field and
+ * MongoDB silently returns 0 / [] (issue #208). This check makes that case visible with
+ * a WARN. Not intended as public API.
+ */
+public final class UntranslatedRefWarner {
+
+    private final Map<String, String> translatedProjectKeys = new LinkedHashMap<>();
+    private final Set<String> warnedRefs = new HashSet<>();
+
+    /** project(Map) reports every key it renamed here, so later stages referencing the
+     * original spelling can be warned about */
+    public void recordProjectKeyTranslation(String original, String translated) {
+        translatedProjectKeys.put(original, translated);
+    }
+
+    /**
+     * scans a pipeline stage for $-references to a project key that was silently
+     * renamed and logs a WARN for every distinct hit. $$-variables and $literal
+     * subtrees (data by definition) are ignored; dot-paths are matched by their
+     * first segment.
+     */
+    public void warnUntranslatedRefs(Object stage, Logger log) {
+        if (translatedProjectKeys.isEmpty()) {
+            return;
+        }
+        scan(stage, log);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void scan(Object value, Logger log) {
+        if (value instanceof Expr) {
+            // the InMemAggregator keeps Expr objects in its stages - scan their serialized form
+            scan(((Expr) value).toQueryObject(), log);
+            return;
+        }
+        if (value instanceof String) {
+            String s = (String) value;
+            if (s.startsWith("$") && !s.startsWith("$$")) {
+                String firstSegment = s.substring(1).split("\\.")[0];
+                String translated = translatedProjectKeys.get(firstSegment);
+                if (translated != null && warnedRefs.add(firstSegment)) {
+                    log.warn("Aggregation stage references '${}', but project(Map) translated that key to '{}'. "
+                             + "The reference will not resolve and silently yields 0 / []. "
+                             + "Reference '${}' instead.",
+                             firstSegment, translated, translated);
+                }
+            }
+        } else if (value instanceof Map) {
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) value).entrySet()) {
+                if (!"$literal".equals(e.getKey())) {
+                    scan(e.getValue(), log);
+                }
+            }
+        } else if (value instanceof List) {
+            for (Object v : (List<Object>) value) {
+                scan(v, log);
+            }
+        }
+    }
+}

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
@@ -2,6 +2,7 @@ package de.caluga.morphium.driver.inmem;
 
 import de.caluga.morphium.*;
 import de.caluga.morphium.aggregation.*;
+import de.caluga.morphium.aggregation.internal.UntranslatedRefWarner;
 import de.caluga.morphium.async.AsyncOperationCallback;
 import de.caluga.morphium.async.AsyncOperationType;
 import de.caluga.morphium.driver.Doc;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 @SuppressWarnings("CommentedOutCode")
 public class InMemAggregator<T, R> implements Aggregator<T, R> {
     private final Logger log = LoggerFactory.getLogger(InMemAggregator.class);
+    private final UntranslatedRefWarner refWarner = new UntranslatedRefWarner();
     private final List<Map<String, Object>> params = new ArrayList<>();
     private final List<Group<T, R>> groups = new ArrayList<>();
     private Class <? extends T > type;
@@ -117,7 +119,11 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         Map<String, Object> p = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
-            p.put(tf(e.getKey()), e.getValue());
+            String key = tf(e.getKey());
+            if (!key.equals(e.getKey())) {
+                refWarner.recordProjectKeyTranslation(e.getKey(), key);
+            }
+            p.put(key, e.getValue());
         }
 
         Map<String, Object> map = UtilsMap.of("$project", p);
@@ -295,8 +301,10 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     }
 
     @Override
-    /** single entry point for pipeline stages: every stage helper routes through here. */
+    /** single entry point for pipeline stages: every stage helper routes through here,
+     * so the untranslated-reference check sees the stage as it will be executed. */
     public void addOperator(Map<String, Object> o) {
+        refWarner.warnUntranslatedRefs(o, log);
         params.add(o);
     }
 

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
@@ -1,5 +1,8 @@
 package de.caluga.test.mongo.suite.inmem;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import de.caluga.morphium.aggregation.Aggregator;
 import de.caluga.morphium.aggregation.AggregatorImpl;
 import de.caluga.morphium.aggregation.Expr;
@@ -7,6 +10,7 @@ import de.caluga.morphium.annotations.Entity;
 import de.caluga.morphium.annotations.Id;
 import de.caluga.morphium.annotations.caching.NoCache;
 import de.caluga.morphium.driver.MorphiumId;
+import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -156,6 +160,90 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
             Map<String, Object> group = groupParams(agg);
             assertEquals("$item_count", opRef(group, "s1", "$stdDevSamp"),
                          impl + ": stdDevSamp must emit the $stdDevSamp operator");
+        }
+    }
+
+    private List<ILoggingEvent> runAndCaptureWarns(Aggregator<AggEntity, Map> agg, Runnable pipelineBuilder) {
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(agg.getClass());
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            pipelineBuilder.run();
+            return appender.list.stream()
+                   .filter(ev -> ev.getLevel() == Level.WARN)
+                   .collect(java.util.stream.Collectors.toList());
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    private ILoggingEvent runAndCaptureWarn(Aggregator<AggEntity, Map> agg, Runnable pipelineBuilder) {
+        List<ILoggingEvent> warns = runAndCaptureWarns(agg, pipelineBuilder);
+        return warns.isEmpty() ? null : warns.get(0);
+    }
+
+    @Test
+    public void warnsWhenTranslatedProjectKeyIsReferencedUntranslated() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$itemCount").end();
+            });
+            assertNotNull(warn, impl + ": referencing $itemCount after project translated the key to item_count should WARN");
+            assertTrue(warn.getFormattedMessage().contains("itemCount"),
+                       impl + ": warning should name the reference the user wrote");
+            assertTrue(warn.getFormattedMessage().contains("item_count"),
+                       impl + ": warning should name the translated key");
+        }
+    }
+
+    @Test
+    public void noWarnWhenTranslatedKeyIsReferencedCorrectly() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$item_count").end();
+            });
+            assertNull(warn, impl + ": referencing the translated name must not WARN");
+        }
+    }
+
+    @Test
+    public void warnsOutsideGroupStagesToo() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.addFields(Map.of("doubled", "$itemCount"));
+            });
+            assertNotNull(warn, impl + ": a non-group stage referencing the renamed key must WARN too");
+        }
+    }
+
+    @Test
+    public void warnIsEmittedOnlyOncePerReference() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            List<ILoggingEvent> warns = runAndCaptureWarns(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("a", "$itemCount").max("b", "$itemCount").end();
+            });
+            assertEquals(1, warns.size(), impl + ": the same untranslated reference must only be warned about once");
+        }
+    }
+
+    @Test
+    public void noWarnForLiteralContent() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.addFields(Map.of("label", Map.of("$literal", "$itemCount")));
+            });
+            assertNull(warn, impl + ": $literal content is data, not a reference - no WARN");
         }
     }
 


### PR DESCRIPTION
**PR C of 4** (stacked on PR B; retarget once B is merged).

Makes the silent-zero case from #208 visible: `project(Map)` translates its keys through the entity field-name mapping — a later stage referencing the name the user wrote gets `$sum: 0` / `$push: []` with no error. Both aggregator implementations now record renamed project keys (new internal `UntranslatedRefWarner`) and log a WARN naming both spellings when any subsequent stage references the original spelling. Thanks to PR B's single entry point this covers every stage, not just `$group`.

Details: deduplicated per reference, `$$`-variables and `$literal` subtrees ignored, dot-paths matched by first segment, `Expr` objects (kept in InMem stages) scanned via their serialized form.

Five new tests (positive, negative, non-group stage, dedup, `$literal`), each against both implementations: 38/38 green.

Part of #208 — the behavioral fix (opt-in uniform translation) follows in PR D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)