### PR TITLE
feat(aggregation): opt-in translateAggregationFieldNames (#208, #217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Aggregator: WARN when a renamed project(Map) key is referenced by its original spelling (#208)
 `project(Map)` translates its keys through the entity's field-name mapping. When a later stage references such a key by the name the user wrote, the reference points at a non-existent field and MongoDB silently returns `$sum: 0` / `$push: []`. Both aggregator implementations now log a WARN (once per reference) naming both spellings. `$$`-variables and `$literal` subtrees are ignored; dot-paths are matched by their first segment.
 
+#### Aggregator: opt-in consistent field-name translation (#208, #217)
+New opt-in setting `translateAggregationFieldNames` (`ObjectMappingSettings`, overridable per aggregator via `Aggregator.setTranslateAggregationFieldNames`): when enabled, Java property names are translated to Mongo field names. Covered stages: group operator `$`-references and id values, `project(Map)` and `addFields`/`set` keys *and values*, `sort(Map)` keys, `graphLookup` connect fields and `startWith` — including `$`-references inside `Expr` values there. **Not covered** (tracked in #221): stages taking a raw `Expr` — `match(Expr)`, `sortByCount`, `replaceRoot`/`replaceWith`, `redact`, `bucket`, `facetExpr`, `unwind(Expr)` — use Mongo field names or `Expr.field(Enum)` there. Dot-paths translate their first segment; `$$`-variables and `$literal` subtrees are never touched. **Default off = exactly the previous behavior.** The effective config value is snapshotted when the aggregator is created; the per-aggregator override wins at any time.
+
+New helpers `Aggregator.ref(Enum)` / `Aggregator.name(Enum)` translate enum field references explicitly (`F.itemCount` → `"$item_count"` / `"item_count"`), independent of the flag: `group.sum(agg.name(F.itemCount), agg.ref(F.itemCount))`. All new `Aggregator` interface methods are default methods — third-party implementations keep compiling.
+
+Known limitation: translation operates on the serialized pipeline, where `Expr.string("$...")` is indistinguishable from a field reference. Wrap string values that look like field references in `$literal` when the flag is on.
+
 #### PoppyDB: priority-based leader step-back after failover (#177)
 A PoppyDB leader now voluntarily hands leadership to a peer with higher election priority, mirroring MongoDB's priority takeover. Previously a failover to a lower-priority node was permanent — the preferred primary never returned, even after it recovered.
 
@@ -21,6 +28,11 @@ Enabled by default. Configurable via `ElectionConfig.priorityTakeoverEnabled` / 
 
 #### InMemoryDriver: `$setOnInsert` and upsert/`new` support in `findAndModify` (#203)
 The `InMemoryDriver` now honors `$setOnInsert` and the `upsert`/`new` flags in `findAndModify`, matching MongoDB behavior. Includes a regression test for upsert via `$and`-nested `_id` filters (#202, #204).
+
+### Changed
+
+#### Aggregator: `graphLookup` enum overload now translates connect fields (#217)
+`graphLookup(Class, Expr, Enum, Enum, ...)` passed `connectFromField.name()` / `connectToField.name()` through untranslated — same defect family as the `lookup` enum overload fixed in 6.2.5 (#198). The enum overload now always translates both connect fields against the given from type, independent of the `translateAggregationFieldNames` flag. Code that relied on the raw enum name reaching the pipeline must use the String overload instead.
 
 ### Fixed
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Aggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Aggregator.java
@@ -182,10 +182,15 @@ public interface Aggregator<T, R> {
     Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch);
 
     /** Adds a $graphLookup stage using a collection name and string fields.
+     * Note: connectFromField and connectToField are always passed through as raw Mongo
+     * field names — with only a collection name there is no entity type to translate
+     * against. Use the Class-based overloads to get field-name translation. startWith
+     * however is evaluated against the input documents (the search type), so with
+     * translateAggregationFieldNames enabled its $-references ARE translated.
      * @param fromCollection the collection name to search
-     * @param startWith expression for the starting value
-     * @param connectFromField the field to connect from
-     * @param connectToField the field to connect to
+     * @param startWith expression for the starting value (translated against the search type when the flag is on)
+     * @param connectFromField the field to connect from (raw Mongo field name, not translated)
+     * @param connectToField the field to connect to (raw Mongo field name, not translated)
      * @param as the output array field name
      * @param maxDepth maximum recursion depth
      * @param depthField field name to store depth
@@ -246,9 +251,13 @@ public interface Aggregator<T, R> {
     Aggregator<T, R> lookup(Class fromType, Enum localField, Enum foreignField, String outputArray, List<Expr> pipeline, Map<String, Expr> let);
 
     /** Adds a $lookup stage using a collection name and string fields.
+     * Note: localField is translated using the search type's field-name mapping,
+     * but foreignField is always passed through as a raw Mongo field name — with only
+     * a collection name there is no entity type to translate against. Use the
+     * Class/Enum-based overload to get translation on both sides.
      * @param fromCollection the collection name to join
-     * @param localField the local field name
-     * @param foreignField the foreign field name
+     * @param localField the local field name (Java property name, will be translated)
+     * @param foreignField the foreign field name (raw Mongo field name, not translated)
      * @param outputArray the output array field name
      * @param pipeline optional sub-pipeline
      * @param let optional let variables
@@ -442,6 +451,45 @@ public interface Aggregator<T, R> {
      * @return the aggregator */
     @SuppressWarnings("unused")
     Aggregator<T,R> setCollectionName(String cn);
+
+    /** Overrides the config setting translateAggregationFieldNames for this aggregator.
+     * When enabled, stage keys and $-field references in stage helpers are translated
+     * from Java property names to Mongo field names (consistent with project(Map) key
+     * translation). Set before building stages.
+     * Default implementation is a no-op so that third-party Aggregator implementations
+     * keep compiling; Morphium's own implementations override it.
+     * @param translate true/false to override, null to use the MorphiumConfig setting
+     * @return the aggregator */
+    default Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate) {
+        return this;
+    }
+
+    /** Returns the effective field-name-translation setting for this aggregator:
+     * the per-aggregator override if set, otherwise the value from MorphiumConfig
+     * (objectMappingSettings). Default false = legacy behavior.
+     * @return true if $-field references should be translated */
+    default boolean isTranslateAggregationFieldNames() {
+        return false;
+    }
+
+    /** Translates an enum field reference of the search type to its Mongo field name.
+     * Example: {@code MyEntity.Fields.itemCount} becomes {@code "item_count"}. Use as
+     * output field name in stage helpers: {@code group.sum(agg.name(F.itemCount), ...)}.
+     * @param field enum naming a Java property of the search type
+     * @return the translated Mongo field name */
+    default String name(Enum<?> field) {
+        return de.caluga.morphium.aggregation.internal.FieldNameTranslation.translate(getMorphium(), getSearchType(), field.name());
+    }
+
+    /** Translates an enum field reference of the search type to a $-prefixed Mongo
+     * field reference. Example: {@code MyEntity.Fields.itemCount} becomes
+     * {@code "$item_count"}. Use as value in stage helpers:
+     * {@code group.sum("total", agg.ref(F.itemCount))}.
+     * @param field enum naming a Java property of the search type
+     * @return the translated $-prefixed field reference */
+    default String ref(Enum<?> field) {
+        return "$" + name(field);
+    }
 
     /** Adds a $group stage using a map as the id expression.
      * @param id the group id expression map

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/AggregatorImpl.java
@@ -1,6 +1,7 @@
 package de.caluga.morphium.aggregation;
 
 import de.caluga.morphium.Collation;
+import de.caluga.morphium.aggregation.internal.FieldNameTranslation;
 import de.caluga.morphium.aggregation.internal.UntranslatedRefWarner;
 import de.caluga.morphium.Morphium;
 import de.caluga.morphium.UtilsMap;
@@ -43,16 +44,28 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     private Collation collation;
     private final Logger log = LoggerFactory.getLogger(AggregatorImpl.class);
     private final UntranslatedRefWarner refWarner = new UntranslatedRefWarner();
+    private final FieldNameTranslation fieldNames;
 
     public AggregatorImpl(Morphium morphium, Class<? extends T> type, Class<? extends R> resultType) {
         this.morphium = morphium;
         setSearchType(type);
         setResultType(resultType);
+        fieldNames = new FieldNameTranslation(morphium, type);
     }
 
     private String tf(String field) {
-        if (morphium.getARHelper().getField(type, field) == null) return field;
-        return morphium.getARHelper().getMongoFieldName(type, field);
+        return fieldNames.tf(field);
+    }
+
+    @Override
+    public Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate) {
+        fieldNames.setOverride(translate);
+        return this;
+    }
+
+    @Override
+    public boolean isTranslateAggregationFieldNames() {
+        return fieldNames.isEnabled();
     }
 
     @Override
@@ -113,17 +126,15 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> project(Map<String, Object> m) {
         Map<String, Object> p = new LinkedHashMap<>();
+        boolean translate = isTranslateAggregationFieldNames();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
             String key = tf(e.getKey());
             if (!key.equals(e.getKey())) {
                 refWarner.recordProjectKeyTranslation(e.getKey(), key);
             }
-            if (e.getValue() instanceof Expr) {
-                p.put(key, ((Expr) e.getValue()).toQueryObject());
-            } else {
-                p.put(key, e.getValue());
-            }
+            Object value = e.getValue() instanceof Expr ? ((Expr) e.getValue()).toQueryObject() : e.getValue();
+            p.put(key, translate ? fieldNames.translateRefs(value) : value);
         }
 
         Map<String, Object> map = UtilsMap.of("$project", p);
@@ -160,13 +171,12 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> addFields(Map<String, Object> m) {
         Map<String, Object> ret = new LinkedHashMap<>();
+        boolean translate = isTranslateAggregationFieldNames();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
-            if (e.getValue() instanceof Expr) {
-                ret.put(e.getKey(), ((Expr) e.getValue()).toQueryObject());
-            } else {
-                ret.put(e.getKey(), e.getValue());
-            }
+            String key = translate ? tf(e.getKey()) : e.getKey();
+            Object value = e.getValue() instanceof Expr ? ((Expr) e.getValue()).toQueryObject() : e.getValue();
+            ret.put(key, translate ? fieldNames.translateRefs(value) : value);
         }
 
         Map<String, Object> o = UtilsMap.of("$addFields", ret);
@@ -275,7 +285,8 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> sort(Map<String, Integer> sort) {
-        Map<String, Object> o = UtilsMap.of("$sort", sort);
+        Map<String, Integer> s = isTranslateAggregationFieldNames() ? fieldNames.translateKeys(sort) : sort;
+        Map<String, Object> o = UtilsMap.of("$sort", s);
         addOperator(o);
         return this;
     }
@@ -315,9 +326,10 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
         return gr;
     }
 
+    /** single entry point for pipeline stages: every stage helper routes through here.
+     * Invariant: any flag-based translation must happen BEFORE this call, so the
+     * untranslated-reference check only sees the stage as it will be sent to MongoDB. */
     @Override
-    /** single entry point for pipeline stages: every stage helper routes through here,
-     * so the untranslated-reference check sees the stage as it will be sent to MongoDB. */
     public void addOperator(Map<String, Object> o) {
         refWarner.warnUntranslatedRefs(o, log);
         params.add(o);
@@ -635,21 +647,22 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     }
 
     @Override
-    public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type),
+    public Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        return graphLookup(morphium.getMapper().getCollectionName(fromType),
             startWith,
-            connectFromField.name(),
-            connectToField.name(),
+            fieldNames.tf(fromType, connectFromField.name()),
+            fieldNames.tf(fromType, connectToField.name()),
             as,
             maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
-    public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type),
+    public Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        boolean translate = isTranslateAggregationFieldNames();
+        return graphLookup(morphium.getMapper().getCollectionName(fromType),
             startWith,
-            connectFromField,
-            connectToField,
+            translate ? fieldNames.tf(fromType, connectFromField) : connectFromField,
+            translate ? fieldNames.tf(fromType, connectToField) : connectToField,
             as,
             maxDepth, depthField, restrictSearchWithMatch);
     }
@@ -657,8 +670,10 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
     @Override
     public Aggregator<T, R> graphLookup(String fromCollection, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField,
         Query restrictSearchWithMatch) {
+        Object startWithQo = isTranslateAggregationFieldNames()
+            ? fieldNames.translateRefs(startWith.toQueryObject()) : startWith.toQueryObject();
         Map<String, Object> add = UtilsMap.of("from", (Object) fromCollection,
-            "startWith", startWith.toQueryObject(),
+            "startWith", startWithQo,
             "connectFromField", connectFromField,
             "connectToField", connectToField,
             "as", as);
@@ -943,7 +958,12 @@ public class AggregatorImpl<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> set(Map<String, Expr> param) {
-        Map<String, Object> o = UtilsMap.of("$set", Utils.getQueryObjectMap(param));
+        Map<String, Object> qo = Utils.getQueryObjectMap(param);
+        if (isTranslateAggregationFieldNames()) {
+            qo = fieldNames.translateKeys(qo);
+            qo.replaceAll((k, v) -> fieldNames.translateRefs(v));
+        }
+        Map<String, Object> o = UtilsMap.of("$set", qo);
         addOperator(o);
         return this;
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Group.java
@@ -1,5 +1,6 @@
 package de.caluga.morphium.aggregation;
 
+import de.caluga.morphium.aggregation.internal.FieldNameTranslation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,10 @@ public class Group<T, R> {
         Map<String, Object> ret = new HashMap<>();
         ret.put(key, value);
         return ret;
+    }
+
+    private String tf(String field) {
+        return FieldNameTranslation.translate(aggregator.getMorphium(), aggregator.getSearchType(), field);
     }
 
     public Group<T, R> addToSet(String name, Object p) {
@@ -106,6 +111,7 @@ public class Group<T, R> {
         operators.add(jp);
         return this;
     }
+
     public Group<T, R> push(String name, String vn, String value) {
         Map<String, Object> o = getMap(name, getMap("$push", getMap(vn, value)));
         operators.add(o);
@@ -154,6 +160,10 @@ public class Group<T, R> {
         }
         Map<String, Object> params = new HashMap<>(id);
         operators.forEach(params::putAll);
+        if (aggregator.isTranslateAggregationFieldNames()) {
+            //noinspection unchecked
+            params = (Map<String, Object>) FieldNameTranslation.translateRefs(params, this::tf);
+        }
         Map<String, Object> obj = getMap("$group", params);
         aggregator.addOperator(obj);
         ended = true;

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/internal/FieldNameTranslation.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/internal/FieldNameTranslation.java
@@ -1,0 +1,128 @@
+package de.caluga.morphium.aggregation.internal;
+
+import de.caluga.morphium.Morphium;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+/**
+ * Internal helper shared by AggregatorImpl and InMemAggregator: implements the opt-in
+ * translateAggregationFieldNames behavior (issue #208/#217); the
+ * untranslated-reference warning lives in UntranslatedRefWarner. Not intended as public API.
+ *
+ * <p>The effective flag value is snapshotted from MorphiumConfig when the aggregator is
+ * created, so a pipeline is always built consistently even if the config changes
+ * mid-build; the per-aggregator override still takes precedence at any time.</p>
+ */
+public final class FieldNameTranslation {
+
+    private static final Logger log = LoggerFactory.getLogger(FieldNameTranslation.class);
+
+    private final Morphium morphium;
+    private final Class<?> searchType;
+    private final boolean configEnabled;
+    private Boolean override;
+
+    public FieldNameTranslation(Morphium morphium, Class<?> searchType) {
+        this.morphium = morphium;
+        this.searchType = searchType;
+        this.configEnabled = morphium != null
+            && morphium.getConfig().objectMappingSettings().isTranslateAggregationFieldNames();
+    }
+
+    public void setOverride(Boolean override) {
+        this.override = override;
+    }
+
+    public boolean isEnabled() {
+        return override != null ? override : configEnabled;
+    }
+
+    /** the single implementation of Java-property-name to Mongo-field-name translation;
+     * null-safe: without a Morphium instance or type, and for names that are no entity
+     * property, the name passes through unchanged */
+    public static String translate(Morphium morphium, Class<?> type, String field) {
+        if (morphium == null || type == null) return field;
+        if (morphium.getARHelper().getField(type, field) == null) return field;
+        return morphium.getARHelper().getMongoFieldName(type, field);
+    }
+
+    /** translates a Java property name of the search type to its Mongo field name;
+     * names that are no property pass through unchanged */
+    public String tf(String field) {
+        return tf(searchType, field);
+    }
+
+    /** same as {@link #tf(String)}, but against an explicitly given entity type
+     * (e.g. the from type of a lookup/graphLookup) */
+    public String tf(Class<?> type, String field) {
+        return translate(morphium, type, field);
+    }
+
+    /** returns a copy of the map with all keys translated, preserving order */
+    public <V> Map<String, V> translateKeys(Map<String, V> m) {
+        Map<String, V> ret = new LinkedHashMap<>();
+        for (Map.Entry<String, V> e : m.entrySet()) {
+            String key = tf(e.getKey());
+            if (ret.put(key, e.getValue()) != null) {
+                log.warn("Field-name translation collapsed two keys onto '{}' - one entry was silently replaced", key);
+            }
+        }
+        return ret;
+    }
+
+    /** translates $-refs against the search type, see {@link #translateRefs(Object, UnaryOperator)} */
+    public Object translateRefs(Object value) {
+        return translateRefs(value, this::tf);
+    }
+
+    /**
+     * translates $-field references (not $$-variables) from Java property names to Mongo
+     * field names, recursing into maps and lists. Dot-paths translate their first
+     * segment ($itemCount.sub becomes $item_count.sub); deeper segments cannot be
+     * resolved without embedded-type information and pass through unchanged.
+     * $literal subtrees are data by definition and are never touched. Note that this
+     * operates on the serialized pipeline: Expr.string("$...") is indistinguishable
+     * from a field reference here and is therefore not supported with the flag on
+     * (wrap in $literal instead).
+     */
+    @SuppressWarnings("unchecked")
+    public static Object translateRefs(Object value, UnaryOperator<String> tf) {
+        if (value instanceof String) {
+            String s = (String) value;
+            if (s.startsWith("$") && !s.startsWith("$$")) {
+                String path = s.substring(1);
+                int dot = path.indexOf('.');
+                if (dot < 0) {
+                    return "$" + tf.apply(path);
+                }
+                return "$" + tf.apply(path.substring(0, dot)) + path.substring(dot);
+            }
+            return s;
+        }
+        if (value instanceof Map) {
+            Map<String, Object> ret = new LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) value).entrySet()) {
+                if ("$literal".equals(e.getKey())) {
+                    ret.put(e.getKey(), e.getValue());
+                } else {
+                    ret.put(e.getKey(), translateRefs(e.getValue(), tf));
+                }
+            }
+            return ret;
+        }
+        if (value instanceof List) {
+            List<Object> ret = new ArrayList<>();
+            for (Object o : (List<Object>) value) {
+                ret.add(translateRefs(o, tf));
+            }
+            return ret;
+        }
+        return value;
+    }
+}

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/internal/UntranslatedRefWarner.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/internal/UntranslatedRefWarner.java
@@ -55,7 +55,7 @@ public final class UntranslatedRefWarner {
                 if (translated != null && warnedRefs.add(firstSegment)) {
                     log.warn("Aggregation stage references '${}', but project(Map) translated that key to '{}'. "
                              + "The reference will not resolve and silently yields 0 / []. "
-                             + "Reference '${}' instead.",
+                             + "Reference '${}' instead, or enable translateAggregationFieldNames.",
                              firstSegment, translated, translated);
                 }
             }

--- a/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
@@ -10,6 +10,7 @@ public class ObjectMappingSettings extends Settings {
     private boolean objectSerializationEnabled = true;
     private boolean camelCaseConversionEnabled = true;
     private boolean warnOnNoEntitySerialization = false;
+    private boolean translateAggregationFieldNames = false;
     public boolean isCheckForNew() {
         return checkForNew;
     }
@@ -78,6 +79,35 @@ public class ObjectMappingSettings extends Settings {
     }
     public ObjectMappingSettings setWarnOnNoEntitySerialization(boolean warnOnNoEntitySerialization) {
         this.warnOnNoEntitySerialization = warnOnNoEntitySerialization;
+        return this;
+    }
+
+    /**
+     * if enabled, Java property names in aggregation stages are translated to Mongo
+     * field names. Covered: group operator $-references and id values, project(Map)
+     * and addFields/set keys and values, sort(Map) keys, graphLookup connect fields
+     * and startWith. NOT covered (see issue #221): stages taking a raw Expr, i.e.
+     * match(Expr), sortByCount, replaceRoot/replaceWith, redact, bucket, facetExpr,
+     * unwind(Expr) - use Mongo field names or Expr.field(Enum) there. Default false =
+     * legacy behavior (everything passed through verbatim). Overridable per
+     * aggregator, see Aggregator.setTranslateAggregationFieldNames.
+     */
+    public boolean isTranslateAggregationFieldNames() {
+        return translateAggregationFieldNames;
+    }
+
+    public ObjectMappingSettings setTranslateAggregationFieldNames(boolean translateAggregationFieldNames) {
+        this.translateAggregationFieldNames = translateAggregationFieldNames;
+        return this;
+    }
+
+    public ObjectMappingSettings enableTranslateAggregationFieldNames() {
+        translateAggregationFieldNames = true;
+        return this;
+    }
+
+    public ObjectMappingSettings disableTranslateAggregationFieldNames() {
+        translateAggregationFieldNames = false;
         return this;
     }
 }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
@@ -2,6 +2,7 @@ package de.caluga.morphium.driver.inmem;
 
 import de.caluga.morphium.*;
 import de.caluga.morphium.aggregation.*;
+import de.caluga.morphium.aggregation.internal.FieldNameTranslation;
 import de.caluga.morphium.aggregation.internal.UntranslatedRefWarner;
 import de.caluga.morphium.async.AsyncOperationCallback;
 import de.caluga.morphium.async.AsyncOperationType;
@@ -23,7 +24,6 @@ import java.util.stream.Collectors;
 @SuppressWarnings("CommentedOutCode")
 public class InMemAggregator<T, R> implements Aggregator<T, R> {
     private final Logger log = LoggerFactory.getLogger(InMemAggregator.class);
-    private final UntranslatedRefWarner refWarner = new UntranslatedRefWarner();
     private final List<Map<String, Object>> params = new ArrayList<>();
     private final List<Group<T, R>> groups = new ArrayList<>();
     private Class <? extends T > type;
@@ -33,16 +33,29 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     private boolean useDisk = false;
     private boolean explain = false;
     private Collation collation;
+    private final UntranslatedRefWarner refWarner = new UntranslatedRefWarner();
+    private final FieldNameTranslation fieldNames;
 
     public InMemAggregator(Morphium morphium, Class <? extends T > type, Class <? extends R > resultType) {
         this.morphium = morphium;
         setSearchType(type);
         setResultType(resultType);
+        fieldNames = new FieldNameTranslation(morphium, type);
     }
 
     private String tf(String field) {
-        if (morphium.getARHelper().getField(type, field) == null) return field;
-        return morphium.getARHelper().getMongoFieldName(type, field);
+        return fieldNames.tf(field);
+    }
+
+    @Override
+    public Aggregator<T, R> setTranslateAggregationFieldNames(Boolean translate) {
+        fieldNames.setOverride(translate);
+        return this;
+    }
+
+    @Override
+    public boolean isTranslateAggregationFieldNames() {
+        return fieldNames.isEnabled();
     }
 
     @Override
@@ -118,12 +131,22 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     public Aggregator<T, R> project(Map<String, Object> m) {
         Map<String, Object> p = new LinkedHashMap<>();
 
+        boolean translate = isTranslateAggregationFieldNames();
+
         for (Map.Entry<String, Object> e : m.entrySet()) {
             String key = tf(e.getKey());
             if (!key.equals(e.getKey())) {
                 refWarner.recordProjectKeyTranslation(e.getKey(), key);
             }
-            p.put(key, e.getValue());
+            Object value = e.getValue();
+            if (translate) {
+                if (value instanceof Expr) {
+                    value = Expr.parse(fieldNames.translateRefs(((Expr) value).toQueryObject()));
+                } else {
+                    value = fieldNames.translateRefs(value);
+                }
+            }
+            p.put(key, value);
         }
 
         Map<String, Object> map = UtilsMap.of("$project", p);
@@ -152,22 +175,30 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     //    @Override
     //    public Aggregator<T, R> project(Map<String, Object> m) {
     //        Map<String, Object> o = UtilsMap.of("$project", m);
-    //        params.add(o);
+    //        addOperator(o);
     //        return this;
     //    }
 
     @Override
     public Aggregator<T, R> addFields(Map<String, Object> m) {
         Map<String, Object> ret = new LinkedHashMap<>();
+        boolean translate = isTranslateAggregationFieldNames();
 
         for (Map.Entry<String, Object> e : m.entrySet()) {
             Object value = e.getValue();
-            if (!(value instanceof Expr)) {
+            if (value instanceof Expr) {
+                if (translate) {
+                    value = Expr.parse(fieldNames.translateRefs(((Expr) value).toQueryObject()));
+                }
+            } else {
+                if (translate) {
+                    value = fieldNames.translateRefs(value);
+                }
                 // Convert raw aggregation expressions to Expr objects
                 value = Expr.parse(value);
             }
 
-            ret.put(e.getKey(), value);
+            ret.put(translate ? tf(e.getKey()) : e.getKey(), value);
         }
 
         Map<String, Object> o = UtilsMap.of("$addFields", ret);
@@ -260,7 +291,8 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
 
     @Override
     public Aggregator<T, R> sort(Map<String, Integer> sort) {
-        Map<String, Object> o = UtilsMap.of("$sort", sort);
+        Map<String, Integer> s = isTranslateAggregationFieldNames() ? fieldNames.translateKeys(sort) : sort;
+        Map<String, Object> o = UtilsMap.of("$sort", s);
         addOperator(o);
         return this;
     }
@@ -300,9 +332,10 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         return gr;
     }
 
+    /** single entry point for pipeline stages: every stage helper routes through here.
+     * Invariant: any flag-based translation must happen BEFORE this call, so the
+     * untranslated-reference check only sees the stage as it will be executed. */
     @Override
-    /** single entry point for pipeline stages: every stage helper routes through here,
-     * so the untranslated-reference check sees the stage as it will be executed. */
     public void addOperator(Map<String, Object> o) {
         refWarner.warnUntranslatedRefs(o, log);
         params.add(o);
@@ -529,19 +562,25 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
     }
 
     @Override
-    public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type), startWith, connectFromField.name(), connectToField.name(), as, maxDepth, depthField, restrictSearchWithMatch);
+    public Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, Enum connectFromField, Enum connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        return graphLookup(morphium.getMapper().getCollectionName(fromType), startWith, fieldNames.tf(fromType, connectFromField.name()), fieldNames.tf(fromType, connectToField.name()), as, maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
-    public Aggregator<T, R> graphLookup(Class<?> type, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
-        return graphLookup(morphium.getMapper().getCollectionName(type), startWith, connectFromField, connectToField, as, maxDepth, depthField, restrictSearchWithMatch);
+    public Aggregator<T, R> graphLookup(Class<?> fromType, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField, Query restrictSearchWithMatch) {
+        boolean translate = isTranslateAggregationFieldNames();
+        return graphLookup(morphium.getMapper().getCollectionName(fromType), startWith,
+            translate ? fieldNames.tf(fromType, connectFromField) : connectFromField,
+            translate ? fieldNames.tf(fromType, connectToField) : connectToField,
+            as, maxDepth, depthField, restrictSearchWithMatch);
     }
 
     @Override
     public Aggregator<T, R> graphLookup(String fromCollection, Expr startWith, String connectFromField, String connectToField, String as, Integer maxDepth, String depthField,
                                         Query restrictSearchWithMatch) {
-        Map<String, Object> add = UtilsMap.of("from", (Object) fromCollection, "startWith", startWith, "connectFromField", connectFromField, "connectToField", connectToField, "as", as);
+        Expr startWithExpr = isTranslateAggregationFieldNames()
+            ? Expr.parse(fieldNames.translateRefs(startWith.toQueryObject())) : startWith;
+        Map<String, Object> add = UtilsMap.of("from", (Object) fromCollection, "startWith", startWithExpr, "connectFromField", connectFromField, "connectToField", connectToField, "as", as);
 
         if (maxDepth != null) {
             add.put("maxDepth", maxDepth);
@@ -843,7 +882,12 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
      */
     @Override
     public Aggregator<T, R> set(Map<String, Expr> param) {
-        Map<String, Object> o = UtilsMap.of("$set", Utils.getQueryObjectMap(param));
+        Map<String, Object> qo = Utils.getQueryObjectMap(param);
+        if (isTranslateAggregationFieldNames()) {
+            qo = fieldNames.translateKeys(qo);
+            qo.replaceAll((k, v) -> fieldNames.translateRefs(v));
+        }
+        Map<String, Object> o = UtilsMap.of("$set", qo);
         addOperator(o);
         return this;
     }

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/AggregatorFieldNameTranslationTest.java
@@ -6,11 +6,11 @@ import ch.qos.logback.core.read.ListAppender;
 import de.caluga.morphium.aggregation.Aggregator;
 import de.caluga.morphium.aggregation.AggregatorImpl;
 import de.caluga.morphium.aggregation.Expr;
+import org.slf4j.LoggerFactory;
 import de.caluga.morphium.annotations.Entity;
 import de.caluga.morphium.annotations.Id;
 import de.caluga.morphium.annotations.caching.NoCache;
 import de.caluga.morphium.driver.MorphiumId;
-import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -152,6 +152,41 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
     }
 
     @Test
+    public void refAndNameTranslateEnumFieldReferences() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            assertEquals("item_count", agg.name(AggEntity.Fields.itemCount),
+                         impl + ": name() should translate to the Mongo field name");
+            assertEquals("$item_count", agg.ref(AggEntity.Fields.itemCount),
+                         impl + ": ref() should translate and $-prefix");
+
+            agg.group("$lastName")
+               .sum(agg.name(AggEntity.Fields.itemCount), agg.ref(AggEntity.Fields.itemCount))
+               .push("raw", "$some_raw_ref")
+               .end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$item_count", opRef(group, "item_count", "$sum"),
+                         impl + ": name()/ref() should produce translated output name and reference");
+            assertFalse(group.containsKey("itemCount"), impl + ": untranslated itemCount should not appear");
+            assertEquals("$some_raw_ref", opRef(group, "raw", "$push"),
+                         impl + ": plain string values stay verbatim");
+        }
+    }
+
+    /** regression for the overload trap: an enum passed as VALUE must stay a value —
+     * there are deliberately no (String, Enum) overloads on Group */
+    @Test
+    public void enumValuesAreNotCapturedAsFieldReferences() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group("$lastName").push("status", AggEntity.Fields.firstName).end();
+            assertEquals(AggEntity.Fields.firstName, opRef(groupParams(agg), "status", "$push"),
+                         impl + ": an enum value must be passed through, not turned into a $-ref");
+        }
+    }
+
+    @Test
     public void stdDevSampStringOverloadUsesDollarOperator() {
         for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
             String impl = agg.getClass().getSimpleName();
@@ -160,6 +195,65 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
             Map<String, Object> group = groupParams(agg);
             assertEquals("$item_count", opRef(group, "s1", "$stdDevSamp"),
                          impl + ": stdDevSamp must emit the $stdDevSamp operator");
+        }
+    }
+
+    @Test
+    public void groupStringRefsStayVerbatimByDefault() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.group(Map.of("ln", "$lastName")).sum("total", "$itemCount").end();
+
+            Map<String, Object> group = groupParams(agg);
+            assertEquals("$itemCount", opRef(group, "total", "$sum"),
+                         impl + ": legacy default must not translate group refs");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> id = (Map<String, Object>) group.get("_id");
+            assertEquals("$lastName", id.get("ln"), impl + ": legacy default must not translate group id refs");
+        }
+    }
+
+    @Test
+    public void translateFlagOnTranslatesGroupStringRefs() {
+        morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(true);
+        try {
+            for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+                String impl = agg.getClass().getSimpleName();
+                agg.group(Map.of("ln", "$lastName")).sum("total", "$itemCount").end();
+
+                Map<String, Object> group = groupParams(agg);
+                assertEquals("$item_count", opRef(group, "total", "$sum"),
+                             impl + ": flag on must translate group refs");
+                @SuppressWarnings("unchecked")
+                Map<String, Object> id = (Map<String, Object>) group.get("_id");
+                assertEquals("$last_name", id.get("ln"), impl + ": flag on must translate group id refs");
+            }
+        } finally {
+            morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(false);
+        }
+    }
+
+    @Test
+    public void perAggregatorOverrideBeatsConfig() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.group("x").sum("total", "$itemCount").end();
+            assertEquals("$item_count", opRef(groupParams(agg), "total", "$sum"),
+                         impl + ": aggregator override true must translate although config is off");
+        }
+
+        morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(true);
+        try {
+            for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+                String impl = agg.getClass().getSimpleName();
+                agg.setTranslateAggregationFieldNames(false);
+                agg.group("x").sum("total", "$itemCount").end();
+                assertEquals("$itemCount", opRef(groupParams(agg), "total", "$sum"),
+                             impl + ": aggregator override false must win over config on");
+            }
+        } finally {
+            morphium.getConfig().objectMappingSettings().setTranslateAggregationFieldNames(false);
         }
     }
 
@@ -200,18 +294,6 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
     }
 
     @Test
-    public void noWarnWhenTranslatedKeyIsReferencedCorrectly() {
-        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
-            String impl = agg.getClass().getSimpleName();
-            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
-                agg.project(Map.of("itemCount", "$item_count"));
-                agg.group("$lastName").sum("total", "$item_count").end();
-            });
-            assertNull(warn, impl + ": referencing the translated name must not WARN");
-        }
-    }
-
-    @Test
     public void warnsOutsideGroupStagesToo() {
         for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
             String impl = agg.getClass().getSimpleName();
@@ -236,14 +318,267 @@ public class AggregatorFieldNameTranslationTest extends MorphiumInMemTestBase {
     }
 
     @Test
-    public void noWarnForLiteralContent() {
+    public void literalValuesStayUntouchedWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.addFields(Map.of("x", Map.of("$literal", "$firstName")));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> literal = (Map<String, Object>) unwrapExpr(af.get("x"));
+            assertEquals("$firstName", literal.get("$literal"),
+                         impl + ": $literal content is data, not a field reference - must never be translated");
+        }
+    }
+
+    @Test
+    public void setMapValueRefsTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.set(Map.of("copy", Expr.field("firstName")));
+
+            Map<String, Object> set = stagePart(agg, "$set");
+            assertEquals("$first_name", unwrapExpr(set.get("copy")),
+                         impl + ": flag on must translate refs in set(Map) values");
+        }
+    }
+
+    @Test
+    public void graphLookupStartWithTranslatesWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.graphLookup(LookupEntity.class, Expr.field("itemCount"),
+                            "owner_name", "owner_name", "joined", null, null, null);
+
+            Map<String, Object> gl = stagePart(agg, "$graphLookup");
+            assertEquals("$item_count", unwrapExpr(gl.get("startWith")),
+                         impl + ": startWith is evaluated on input docs and must translate against the search type");
+        }
+    }
+
+    @Test
+    public void noWarnWhenTranslatedKeyIsReferencedCorrectly() {
         for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
             String impl = agg.getClass().getSimpleName();
             ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
                 agg.project(Map.of("itemCount", "$item_count"));
-                agg.addFields(Map.of("label", Map.of("$literal", "$itemCount")));
+                agg.group("$lastName").sum("total", "$item_count").end();
             });
-            assertNull(warn, impl + ": $literal content is data, not a reference - no WARN");
+            assertNull(warn, impl + ": referencing the translated name must not WARN");
+        }
+    }
+
+    @Test
+    public void noWarnWhenTranslateFlagResolvesTheReference() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            ILoggingEvent warn = runAndCaptureWarn(agg, () -> {
+                agg.project(Map.of("itemCount", "$item_count"));
+                agg.group("$lastName").sum("total", "$itemCount").end();
+            });
+            assertNull(warn, impl + ": with the flag on the reference is translated and consistent — no WARN");
+        }
+    }
+
+    @Test
+    public void dotPathRefsTranslateFirstSegmentWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.group("$lastName").push("all", "$itemCount.sub").end();
+            assertEquals("$item_count.sub", opRef(groupParams(agg), "all", "$push"),
+                         impl + ": dot-path refs must translate their first segment");
+        }
+    }
+
+    @Test
+    public void dollarDollarVariablesStayUntouchedWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.group("$lastName").push("all", "$$ROOT").end();
+            assertEquals("$$ROOT", opRef(groupParams(agg), "all", "$push"),
+                         impl + ": $$-variables must never be translated");
+        }
+    }
+
+    @Test
+    public void addFieldsExprValueTranslatesWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.addFields(Map.of("computed", Expr.field("firstName")));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            assertEquals("$first_name", unwrapExpr(af.get("computed")),
+                         impl + ": flag on must translate refs inside Expr values too");
+        }
+    }
+
+    /** end-to-end repro of issue #208: with the flag on, the project/group pipeline from
+     * the issue returns real sums instead of silent zeros */
+    @Test
+    public void issue208PipelineReturnsCorrectSumsWithFlagOn() {
+        for (int i = 1; i <= 3; i++) {
+            AggEntity e = new AggEntity();
+            e.lastName = "smith";
+            e.itemCount = i;
+            morphium.store(e);
+        }
+
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.project(Map.of("lastName", "$lastName", "itemCount", "$itemCount"));
+            agg.group("$lastName").sum("total", "$itemCount").end();
+
+            List<Map<String, Object>> result = agg.aggregateMap();
+            assertEquals(1, result.size(), impl + ": one group expected");
+            assertEquals(6, ((Number) result.get(0).get("total")).intValue(),
+                         impl + ": sum must be 3+2+1=6, not the silent 0 from issue #208");
+        }
+    }
+
+    /** InMemAggregator wraps raw addFields values in Expr — normalize for comparison */
+    private Object unwrapExpr(Object value) {
+        return value instanceof Expr ? ((Expr) value).toQueryObject() : value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> stagePart(Aggregator<AggEntity, Map> agg, String stageName) {
+        Map<String, Object> stage = firstStage(agg);
+        assertTrue(stage.containsKey(stageName), "stage should be " + stageName);
+        return (Map<String, Object>) stage.get(stageName);
+    }
+
+    @Test
+    public void graphLookupEnumTranslatesConnectFields() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.graphLookup(LookupEntity.class, Expr.field("owner_name"),
+                            LookupEntity.Fields.ownerName, LookupEntity.Fields.ownerName,
+                            "joined", null, null, null);
+
+            Map<String, Object> gl = stagePart(agg, "$graphLookup");
+            assertEquals("owner_name", gl.get("connectFromField"),
+                         impl + ": enum connectFromField should be translated using the from type");
+            assertEquals("owner_name", gl.get("connectToField"),
+                         impl + ": enum connectToField should be translated using the from type");
+        }
+    }
+
+    @Test
+    public void graphLookupClassStringConnectFieldsTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.graphLookup(LookupEntity.class, Expr.field("owner_name"),
+                            "ownerName", "ownerName", "joined", null, null, null);
+
+            Map<String, Object> gl = stagePart(agg, "$graphLookup");
+            assertEquals("owner_name", gl.get("connectFromField"),
+                         impl + ": flag on must translate String connectFromField against the from type");
+            assertEquals("owner_name", gl.get("connectToField"),
+                         impl + ": flag on must translate String connectToField against the from type");
+        }
+    }
+
+    @Test
+    public void addFieldsAndSortStayVerbatimByDefault() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.addFields(Map.of("itemCount", "$firstName"));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            assertTrue(af.containsKey("itemCount"), impl + ": legacy default must not translate addFields keys");
+            assertEquals("$firstName", unwrapExpr(af.get("itemCount")),
+                         impl + ": legacy default must not translate addFields refs");
+        }
+
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.sort(Map.of("itemCount", 1));
+            assertTrue(stagePart(agg, "$sort").containsKey("itemCount"),
+                       impl + ": legacy default must not translate sort(Map) keys");
+        }
+    }
+
+    @Test
+    public void addFieldsKeysAndRefsTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.addFields(Map.of("itemCount", "$firstName"));
+
+            Map<String, Object> af = stagePart(agg, "$addFields");
+            assertTrue(af.containsKey("item_count"), impl + ": flag on must translate addFields keys");
+            assertFalse(af.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
+            assertEquals("$first_name", unwrapExpr(af.get("item_count")),
+                         impl + ": flag on must translate $-refs in addFields values");
+        }
+    }
+
+    @Test
+    public void setMapKeysTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.set(Map.of("itemCount", Expr.field("first_name")));
+
+            Map<String, Object> set = stagePart(agg, "$set");
+            assertTrue(set.containsKey("item_count"), impl + ": flag on must translate set(Map) keys");
+            assertFalse(set.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
+        }
+    }
+
+    @Test
+    public void sortMapKeysTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.sort(Map.of("itemCount", 1));
+
+            Map<String, Object> sort = stagePart(agg, "$sort");
+            assertTrue(sort.containsKey("item_count"), impl + ": flag on must translate sort(Map) keys");
+            assertFalse(sort.containsKey("itemCount"), impl + ": untranslated key must not appear with flag on");
+        }
+    }
+
+    @Test
+    public void projectValuesStayVerbatimByDefault() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.project(Map.of("total", "$itemCount"));
+            assertEquals("$itemCount", unwrapExpr(stagePart(agg, "$project").get("total")),
+                         impl + ": legacy default must not translate project values");
+        }
+    }
+
+    @Test
+    public void projectValuesTranslateWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.project(Map.of("total", "$itemCount"));
+            assertEquals("$item_count", unwrapExpr(stagePart(agg, "$project").get("total")),
+                         impl + ": flag on must translate $-refs in project values - the silent-zero case from #208 with a non-colliding key");
+        }
+    }
+
+    /** sort(String...) with $-prefix translates itself and then runs through the
+     * flag-gated sort(Map) key translation - pins that this stays correct */
+    @Test
+    public void sortPrefixedStringStaysCorrectWithFlagOn() {
+        for (Aggregator<AggEntity, Map> agg : bothImplementations()) {
+            String impl = agg.getClass().getSimpleName();
+            agg.setTranslateAggregationFieldNames(true);
+            agg.sort("$itemCount");
+            assertTrue(stagePart(agg, "$sort").containsKey("item_count"),
+                       impl + ": already-translated sort keys must pass through unchanged");
         }
     }
 


### PR DESCRIPTION
**PR D of 4** (stacked on PR C; retarget once C is merged).

The feature: new opt-in setting `translateAggregationFieldNames` (`ObjectMappingSettings`, per-aggregator override via `Aggregator.setTranslateAggregationFieldNames`). When enabled, Java property names are translated **uniformly** across the pipeline: group operator `$`-refs and id values, `addFields`/`set` keys and values, `sort(Map)` keys, `graphLookup` connect fields and `startWith`, and `$`-refs inside `Expr` values. Dot-paths translate their first segment; `$$`-variables and `$literal` subtrees are never touched. **Default off = exactly legacy behavior.** The config value is snapshotted at aggregator creation; the override wins at any time. 7.0 can flip the default (#208 two-stage plan).

- **`Aggregator.ref(Enum)` / `name(Enum)`**: explicit enum translation helpers, always translating, independent of the flag. Deliberately **no `Group` overloads** — `(String, Enum)` overloads would silently capture enums passed as *values* (`push("status", MyStatus.ACTIVE)` → `"$active"`) and make `sum("x", null)` ambiguous; a regression test pins that enum values stay values.
- **`graphLookup` enum overload** now translates connect fields against the from type (bugfix, same family as the 6.2.5 `lookup` fix / #198) — behavior change outside the flag, called out in CHANGELOG under *Changed*.
- All new `Aggregator` interface methods are default methods — third-party implementations keep compiling.
- Translation logic lives in internal `FieldNameTranslation` (one implementation for both aggregators, `Group` and `name()`); the warner from PR C stays a separate concern and now also points at the flag.
- Known limitation (documented): translation operates on the serialized pipeline, so `Expr.string("$...")` is indistinguishable from a field ref — wrap in `$literal`. Clean fix tracked in #221 (Expr visitor).

On the root cause: `project(Map)` translating its *keys* (output names) is the underlying wart — untouchable in 6.3 without breaking existing users. 7.0 options tracked in #208: deprecate key translation with a literal-projection replacement, or flip this flag's default so the pipeline is at least consistently translated.

18 new tests (flag on/off pinning, override precedence, ref/name, enum-value capture regression, dot-path, `$$`, `$literal` translation stop, Expr values, set values, graphLookup startWith, end-to-end issue repro through both implementations): 56/56 green.

Closes #208
Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)