### PR TITLE
chore: mark 7.0-removal candidates with @Deprecated(forRemoval=true) (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Enabled by default. Configurable via `ElectionConfig.priorityTakeoverEnabled` / 
 #### InMemoryDriver: `$setOnInsert` and upsert/`new` support in `findAndModify` (#203)
 The `InMemoryDriver` now honors `$setOnInsert` and the `upsert`/`new` flags in `findAndModify`, matching MongoDB behavior. Includes a regression test for upsert via `$and`-nested `_id` filters (#202, #204).
 
+### Deprecated
+
+#### 7.0-removal candidates now carry `@Deprecated(since = "6.3", forRemoval = true)` (#218)
+Members confirmed for removal in 7.0 (#172 et al.) are now annotated `@Deprecated(since = "6.3", forRemoval = true)`, and their Javadoc names the replacement — IDEs flag usages a full minor release before anything is removed. Covered groups: the flat `MorphiumConfig` setters/getters (use the `Settings` sub-objects via `connectionSettings()`, `objectMappingSettings()`, ... instead), the `MorphiumBase.set…`/`unsetQ…` variants, the legacy `SingleCollectionMessaging` constructors, `Query.complexQuery`/`getById`/`textSearch`, `Msg.name`, `MorphiumMessaging.setProcessMultiple`, `MongoBob` and `@UseIfnull` (use `@IgnoreNullFromDB`). Members that stay deprecated-but-kept, and the BSON-spec deprecations in `MongoType`, are unchanged. Pure annotation/Javadoc change, zero runtime impact.
+
 ### Changed
 
 #### Aggregator: `graphLookup` enum overload now translates connect fields (#217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Members confirmed for removal in 7.0 (#172 et al.) are now annotated `@Deprecate
 
 ### Fixed
 
+#### MorphiumConfig: `getMaximumRetriesBufferedWriter()` returned the AsyncWriter value (#227)
+The deprecated flat getter delegated to `WriterSettings.getMaximumRetriesAsyncWriter()` instead of `getMaximumRetriesBufferedWriter()` — callers silently got the async-writer retry count whenever the two settings differed (both default to 10, which is why it never surfaced). Found while writing the #218 replacement Javadoc.
+
 #### Aggregator: `Group.stdDevSamp(String, Object)` emitted `stdDevSamp` without the `$` prefix
 The operator map was built as `{stdDevSamp: ...}` instead of `{$stdDevSamp: ...}`, so the String-based `stdDevSamp` accumulator never worked. (The `$stdDevPop` sibling was correct.)
 

--- a/morphium-core/src/main/java/de/caluga/morphium/MorphiumBase.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/MorphiumBase.java
@@ -1173,9 +1173,9 @@ public abstract class MorphiumBase {
      * This method sets a property.
      *
      * @deprecated There is a newer implementation.
-     * Please use {@link Query#set(String, Object, boolean, boolean, AsyncOperationCallback)}  instead.
+     * Please use {@link Query#set(Enum, Object, AsyncOperationCallback)}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> set(Query<T> query, Enum<?> field, Object val, AsyncOperationCallback<T> callback) {
         Map<String, Object> toSet = new HashMap<>();
         toSet.put(field.name(), val);
@@ -1188,7 +1188,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#set(String, Object, boolean, boolean, AsyncOperationCallback)}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> set(Query<T> query, String field, Object val) {
         return set(query, field, val, (AsyncOperationCallback<T>) null);
     }
@@ -1199,7 +1199,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#set(String, Object, boolean, boolean, AsyncOperationCallback)}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> set(Query<T> query, String field, Object val, AsyncOperationCallback<T> callback) {
         Map<String, Object> toSet = new HashMap<>();
         toSet.put(field, val);
@@ -1279,7 +1279,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#set(Enum, Object, boolean, boolean, AsyncOperationCallback)}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     @SuppressWarnings("unused")
     public <T> Map<String, Object> set(Query<T> query, Enum<?> field, Object val, boolean upsert, boolean multiple) {
         return set(query, field.name(), val, upsert, multiple, null);
@@ -1292,7 +1292,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#set(Enum, Object, boolean, boolean, AsyncOperationCallback)}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> set(Query<T> query, Enum<?> field, Object val, boolean upsert, boolean multiple, AsyncOperationCallback<T> callback) {
         return set(query, field.name(), val, upsert, multiple, callback);
     }
@@ -1308,7 +1308,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#set(String, Object, boolean, boolean, AsyncOperationCallback)}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> set(Query<T> query, String field, Object val, boolean upsert, boolean multiple) {
         return set(query, field, val, upsert, multiple, null);
     }
@@ -1319,7 +1319,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#set(String, Object, boolean, boolean, AsyncOperationCallback)}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> set(Query<T> query, String field, Object val, boolean upsert, boolean multiple, AsyncOperationCallback<T> callback) {
         Map<String, Object> map = new HashMap<>();
         map.put(field, val);
@@ -1332,7 +1332,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#set(Map, boolean, boolean, AsyncOperationCallback)}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public Map<String, Object> set(final Query<?> query, final Map<String, Object> map, final boolean upsert, final boolean multiple) {
         return query.set( map, upsert, multiple, null);
     }
@@ -1495,7 +1495,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#unset(String[])}  instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> unsetQ(Query<T> q, String... field) {
         return getWriterForClass(q.getType()).unset(q, null, false, field);
     }
@@ -1506,7 +1506,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#unset(boolean, String[])} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> unsetQ(Query<T> q, boolean multiple, String... field) {
         return getWriterForClass(q.getType()).unset(q, null, multiple, field);
     }
@@ -1517,7 +1517,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#unset(Enum[])} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> unsetQ(Query<T> q, Enum... field) {
         return getWriterForClass(q.getType()).unset(q, null, false, field);
     }
@@ -1529,7 +1529,7 @@ public abstract class MorphiumBase {
      * @deprecated There is a newer implementation.
      * Please use {@link Query#unset(boolean, Enum[])} instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public <T> Map<String, Object> unsetQ(Query<T> q, boolean multiple, Enum... field) {
         return getWriterForClass(q.getType()).unset(q, null, multiple, field);
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/MorphiumConfig.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/MorphiumConfig.java
@@ -134,32 +134,32 @@ public class MorphiumConfig {
     public AuthSettings authSettings() {return authSettings;}
     public ClusterSettings clusterSettings() {return clusterSettings;}
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#isMessagingStatusInfoListenerEnabled()} via {@code messagingSettings()} instead
      */
-     @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isMessagingStatusInfoListenerEnabled() {
         return messagingSettings.isMessagingStatusInfoListenerEnabled();
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#setMessagingStatusInfoListenerEnabled(boolean)} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMessagingStatusInfoListenerEnabled(boolean messagingStatusInfoListenerEnabled) {
         this.messagingSettings.setMessagingStatusInfoListenerEnabled(messagingStatusInfoListenerEnabled);
         return this;
     }
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#getMessagingStatusInfoListenerName()} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getMessagingStatusInfoListenerName() {
         return messagingSettings.getMessagingStatusInfoListenerName();
     }
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#setMessagingStatusInfoListenerName(String)} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMessagingStatusInfoListenerName(String name) {
         messagingSettings.setMessagingStatusInfoListenerName(name);
         return this;
@@ -350,17 +350,17 @@ public class MorphiumConfig {
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#getMessagingWindowSize()} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMessagingWindowSize() {
         return messagingSettings.getMessagingWindowSize();
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#setMessagingWindowSize(int)} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public void setMessagingWindowSize(int messagingWindowSize) {
         messagingSettings.setMessagingWindowSize(messagingWindowSize);
     }
@@ -375,120 +375,120 @@ public class MorphiumConfig {
 
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ClusterSettings#isReplicaset()} via {@code clusterSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isReplicaset() {
         return clusterSettings.isReplicaset();
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#getCompressionType()} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public CompressionType getCompressionType() {
         return driverSettings.getCompressionType();
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#setCompressionType(CompressionType)} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setCompressionType(CompressionType t) {
         driverSettings.setCompressionType(t);
         return this;
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ClusterSettings#setReplicaset(boolean)} via {@code clusterSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setReplicasetMonitoring(boolean replicaset) {
         clusterSettings.setReplicaset(replicaset);
         return this;
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#getValueEncryptionProviderClass()} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public Class <? extends ValueEncryptionProvider > getValueEncryptionProviderClass() {
         return encryptionSettings.getValueEncryptionProviderClass();
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#setValueEncryptionProviderClass(Class)} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setValueEncryptionProviderClass(Class <? extends ValueEncryptionProvider > valueEncryptionProviderClass) {
         encryptionSettings.setValueEncryptionProviderClass(valueEncryptionProviderClass);
         return this;
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#getEncryptionKeyProviderClass()} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public Class <? extends EncryptionKeyProvider > getEncryptionKeyProviderClass() {
         return encryptionSettings.getEncryptionKeyProviderClass();
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#setEncryptionKeyProviderClass(Class)} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setEncryptionKeyProviderClass(Class <? extends EncryptionKeyProvider > encryptionKeyProviderClass) {
         encryptionSettings.setEncryptionKeyProviderClass(encryptionKeyProviderClass);
         return this;
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#getCredentialsEncryptionKey()} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getCredentialsEncryptionKey() {
         return encryptionSettings.getCredentialsEncryptionKey();
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#setCredentialsEncryptionKey(String)} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setCredentialsEncryptionKey(String credentialsEncryptionKey) {
         encryptionSettings.setCredentialsEncryptionKey(credentialsEncryptionKey);
         return this;
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#getCredentialsDecryptionKey()} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getCredentialsDecryptionKey() {
         return encryptionSettings.getCredentialsDecryptionKey();
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#setCredentialsDecryptionKey(String)} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setCredentialsDecryptionKey(String credentialsDecryptionKey) {
         encryptionSettings.setCredentialsDecryptionKey(credentialsDecryptionKey);
         return this;
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#getDriverName()} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getDriverName() {
         return driverSettings.getDriverName();
     }
 
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#setDriverName(String)} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setDriverName(String driverName) {
         driverSettings.setDriverName(driverName);
         return this;
@@ -518,26 +518,26 @@ public class MorphiumConfig {
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#isWarnOnNoEntitySerialization()} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isWarnOnNoEntitySerialization() {
         return objectMappingSettings.isWarnOnNoEntitySerialization();
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#setWarnOnNoEntitySerialization(boolean)} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setWarnOnNoEntitySerialization(boolean warnOnNoEntitySerialization) {
         objectMappingSettings.setWarnOnNoEntitySerialization(warnOnNoEntitySerialization);
         return this;
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#isCheckForNew()} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isCheckForNew() {
         return objectMappingSettings.isCheckForNew();
     }
@@ -550,43 +550,43 @@ public class MorphiumConfig {
      * default false
      *
      * @param checkForNew boolean, check if object is really not stored yet
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#setCheckForNew(boolean)} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setCheckForNew(boolean checkForNew) {
         objectMappingSettings.setCheckForNew(checkForNew);
         return this;
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#getRetriesOnNetworkError()} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getRetriesOnNetworkError() {
         return connectionSettings.getRetriesOnNetworkError();
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#setRetriesOnNetworkError(int)} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setRetriesOnNetworkError(int retriesOnNetworkError) {
         connectionSettings.setRetriesOnNetworkError(retriesOnNetworkError);
         return this;
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#getSleepBetweenNetworkErrorRetries()} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getSleepBetweenNetworkErrorRetries() {
         return connectionSettings.getSleepBetweenNetworkErrorRetries();
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#setSleepBetweenNetworkErrorRetries(int)} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setSleepBetweenNetworkErrorRetries(int sleepBetweenNetworkErrorRetries) {
         connectionSettings.setSleepBetweenNetworkErrorRetries(sleepBetweenNetworkErrorRetries);
         return this;
@@ -594,110 +594,110 @@ public class MorphiumConfig {
 
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getWriteBufferTimeGranularity()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getWriteBufferTimeGranularity() {
         return writerSettings.getWriteBufferTimeGranularity();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setWriteBufferTimeGranularity(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setWriteBufferTimeGranularity(int writeBufferTimeGranularity) {
         writerSettings.setWriteBufferTimeGranularity(writeBufferTimeGranularity);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#getCache()} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumCache getCache() {
         return cacheSettings.getCache();
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setCache(MorphiumCache)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setCache(MorphiumCache cache) {
         cacheSettings.setCache(cache);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getWriteBufferTime()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getWriteBufferTime() {
         return writerSettings.getWriteBufferTime();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setWriteBufferTime(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setWriteBufferTime(int writeBufferTime) {
         writerSettings.setWriteBufferTime(writeBufferTime);
         return this;
     }
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getBufferedWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumWriter getBufferedWriter() {
         return writerSettings.getBufferedWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setBufferedWriter(MorphiumWriter)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setBufferedWriter(MorphiumWriter bufferedWriter) {
         writerSettings.setBufferedWriter(bufferedWriter);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumWriter getWriter() {
         return writerSettings.getWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setWriter(MorphiumWriter)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setWriter(MorphiumWriter writer) {
         writerSettings.setWriter(writer);
         return this;
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#getConnectionTimeout()} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getConnectionTimeout() {
         return connectionSettings.getConnectionTimeout();
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#setConnectionTimeout(int)} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setConnectionTimeout(int connectionTimeout) {
         connectionSettings.setConnectionTimeout(connectionTimeout);
         return this;
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#getMaxWaitTime()} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMaxWaitTime() {
         return connectionSettings.getMaxWaitTime();
     }
@@ -709,18 +709,18 @@ public class MorphiumConfig {
      * @return {@code this}
      */
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#setMaxWaitTime(int)} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMaxWaitTime(int maxWaitTime) {
         connectionSettings.setMaxWaitTime(maxWaitTime);
         return this;
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#getServerSelectionTimeout()} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getServerSelectionTimeout() {
         return driverSettings.getServerSelectionTimeout();
     }
@@ -741,35 +741,35 @@ public class MorphiumConfig {
      * @return {@code this}
      */
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#setServerSelectionTimeout(int)} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setServerSelectionTimeout(int serverSelectionTimeout) {
         driverSettings.setServerSelectionTimeout(serverSelectionTimeout);
         return this;
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#getCredentialsEncrypted()} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public Boolean getCredentialsEncrypted() {
         return encryptionSettings.getCredentialsEncrypted();
     }
 
     /**
-     * use encryptionSettings
+     * @deprecated use {@link EncryptionSettings#setCredentialsEncrypted(Boolean)} via {@code encryptionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setCredentialsEncrypted(Boolean credentialsEncrypted) {
         encryptionSettings.setCredentialsEncrypted(credentialsEncrypted);
         return this;
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link AuthSettings#getMongoAuthDb()} via {@code authSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getMongoAuthDb() {
         return  authSettings.getMongoAuthDb();
     }
@@ -826,43 +826,43 @@ public class MorphiumConfig {
 // }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link AuthSettings#setMongoAuthDb(String)} via {@code authSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMongoAuthDb(String mongoAuthDb) {
         authSettings.setMongoAuthDb(mongoAuthDb);
         return this;
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link AuthSettings#getMongoLogin()} via {@code authSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getMongoLogin() {
         return authSettings.getMongoLogin();
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link AuthSettings#setMongoLogin(String)} via {@code authSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMongoLogin(String mongoLogin) {
         authSettings.setMongoLogin(mongoLogin);
         return this;
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link AuthSettings#getMongoPassword()} via {@code authSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getMongoPassword() {
         return authSettings.getMongoPassword();
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link AuthSettings#setMongoPassword(String)} via {@code authSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMongoPassword(String mongoPassword) {
         authSettings.setMongoPassword(mongoPassword);
         return this;
@@ -887,34 +887,34 @@ public class MorphiumConfig {
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#getDefaultReadPreference()} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public ReadPreference getDefaultReadPreference() {
         return driverSettings.getDefaultReadPreference();
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#setDefaultReadPreference(ReadPreference)} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setDefaultReadPreference(ReadPreference defaultReadPreference) {
         driverSettings.setDefaultReadPreference(defaultReadPreference);
         return this;
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#getDefaultReadPreferenceType()} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getDefaultReadPreferenceType() {
         return driverSettings.getDefaultReadPreferenceType();
     }
 
     /**
-     * use driverSettings
+     * @deprecated use {@link DriverSettings#setDefaultReadPreferenceType(String)} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setDefaultReadPreferenceType(String stringDefaultReadPreference) {
         driverSettings.setDefaultReadPreferenceType(stringDefaultReadPreference);
         ReadPreferenceType readPreferenceType;
@@ -936,17 +936,17 @@ public class MorphiumConfig {
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#getWriteCacheTimeout()} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getWriteCacheTimeout() {
         return cacheSettings.getWriteCacheTimeout();
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setWriteCacheTimeout(int)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setWriteCacheTimeout(int writeCacheTimeout) {
         cacheSettings.setWriteCacheTimeout(writeCacheTimeout);
         return this;
@@ -957,113 +957,116 @@ public class MorphiumConfig {
      * setting hosts as Host:Port
      *
      * @param str list of hosts, with or without port
+     * @deprecated use {@code config.clusterSettings().setHostSeed(...)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setHostSeed(List<String> str) {
         clusterSettings.setHostSeed(str);
         return this;
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@code config.clusterSettings().setHostSeed(...)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setHostSeed(List<String> str, List<Integer> ports) {
         clusterSettings.setHostSeed(str, ports);
         return this;
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@link ClusterSettings#getHostSeed()} via {@code clusterSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public List<String> getHostSeed() {
         return clusterSettings.getHostSeed();
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@code config.clusterSettings().setHostSeed(...)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setHostSeed(String... hostPorts) {
         clusterSettings.setHostSeed(hostPorts);
         return this;
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@code config.clusterSettings().setHostSeed(...)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setHostSeed(String hostPorts) {
         clusterSettings.setHostSeed(hostPorts);
         return this;
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@code config.clusterSettings().setHostSeed(...)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setHostSeed(String hosts, String ports) {
         clusterSettings.setHostSeed(hosts, ports);
         return this;
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@code config.clusterSettings().addHostToSeed(...)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig addHostToSeed(String host, int port) {
         clusterSettings.addHostToSeed(host, port);
         return this;
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@code config.clusterSettings().addHostToSeed(...)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig addHostToSeed(String host) {
         clusterSettings.addHostToSeed(host);
         return this;
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@link ConnectionSettings#getMaxConnections()} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMaxConnections() {
         return connectionSettings.getMaxConnections();
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@link ConnectionSettings#setMaxConnections(int)} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMaxConnections(int maxConnections) {
         connectionSettings.setMaxConnections(maxConnections);
         return this;
     }
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@link ConnectionSettings#getDatabase()} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getDatabase() {
         return connectionSettings.getDatabase();
     }
 
     /**
-     * @deprecated use getConnectionSettings().METHOD
+     * @deprecated use {@link ConnectionSettings#setDatabase(String)} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setDatabase(String database) {
         connectionSettings.setDatabase(database);
         return this;
     }
-    @Deprecated
+    /** @deprecated use {@link CacheSettings#getHousekeepingTimeout()} via {@code cacheSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getHousekeepingTimeout() {
         return cacheSettings.getHousekeepingTimeout();
     }
 
-    @Deprecated
+    /** @deprecated use {@link CacheSettings#setHousekeepingTimeout(int)} via {@code cacheSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setHousekeepingTimeout(int housekeepingTimeout) {
         cacheSettings.setHousekeepingTimeout(housekeepingTimeout);
         return this;
@@ -1073,13 +1076,15 @@ public class MorphiumConfig {
      * for future use - set Global Caching time
      *
      * @return the global cache valid time
+     * @deprecated use {@link CacheSettings#getGlobalCacheValidTime()} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getGlobalCacheValidTime() {
         return cacheSettings.getGlobalCacheValidTime();
     }
 
-    @Deprecated
+    /** @deprecated use {@link CacheSettings#setGlobalCacheValidTime(int)} via {@code cacheSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setGlobalCacheValidTime(int globalCacheValidTime) {
         cacheSettings.setGlobalCacheValidTime(globalCacheValidTime);
         return this;
@@ -1109,137 +1114,137 @@ public class MorphiumConfig {
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setThreadConnectionMultiplier(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setThreadConnectionMultiplier(int mp) {
         writerSettings.setThreadConnectionMultiplier(mp);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getThreadConnectionMultiplier()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getThreadConnectionMultiplier() {
         return writerSettings.getThreadConnectionMultiplier();
     }
 
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getAsyncWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumWriter getAsyncWriter() {
         return writerSettings.getAsyncWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setAsyncWriter(MorphiumWriter)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setAsyncWriter(MorphiumWriter asyncWriter) {
         writerSettings.setAsyncWriter(asyncWriter);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getMaximumRetriesAsyncWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMaximumRetriesBufferedWriter() {
         return writerSettings.getMaximumRetriesAsyncWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setMaximumRetriesBufferedWriter(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMaximumRetriesBufferedWriter(int maximumRetriesBufferedWriter) {
         writerSettings.setMaximumRetriesBufferedWriter(maximumRetriesBufferedWriter);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getMaximumRetriesWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMaximumRetriesWriter() {
         return writerSettings.getMaximumRetriesWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setMaximumRetriesWriter(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMaximumRetriesWriter(int maximumRetriesWriter) {
         writerSettings.setMaximumRetriesWriter(maximumRetriesWriter);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getMaximumRetriesAsyncWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMaximumRetriesAsyncWriter() {
         return writerSettings.getMaximumRetriesAsyncWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setMaximumRetriesAsyncWriter(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMaximumRetriesAsyncWriter(int maximumRetriesAsyncWriter) {
         writerSettings.setMaximumRetriesAsyncWriter(maximumRetriesAsyncWriter);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getRetryWaitTimeBufferedWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getRetryWaitTimeBufferedWriter() {
         return writerSettings.getRetryWaitTimeBufferedWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setRetryWaitTimeBufferedWriter(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setRetryWaitTimeBufferedWriter(int retryWaitTimeBufferedWriter) {
         writerSettings.setRetryWaitTimeBufferedWriter(retryWaitTimeBufferedWriter);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getRetryWaitTimeWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getRetryWaitTimeWriter() {
         return writerSettings.getRetryWaitTimeWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setRetryWaitTimeWriter(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setRetryWaitTimeWriter(int retryWaitTimeWriter) {
         writerSettings.setRetryWaitTimeWriter(retryWaitTimeWriter);
         return this;
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#getRetryWaitTimeAsyncWriter()} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getRetryWaitTimeAsyncWriter() {
         return writerSettings.getRetryWaitTimeAsyncWriter();
     }
 
     /**
-     * use writerSettings
+     * @deprecated use {@link WriterSettings#setRetryWaitTimeAsyncWriter(int)} via {@code writerSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setRetryWaitTimeAsyncWriter(int retryWaitTimeAsyncWriter) {
         writerSettings.setRetryWaitTimeAsyncWriter(retryWaitTimeAsyncWriter);
         return this;
@@ -1368,287 +1373,289 @@ public class MorphiumConfig {
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#isReadCacheEnabled()} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isReadCacheEnabled() {
         return cacheSettings.isReadCacheEnabled();
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setReadCacheEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setReadCacheEnabled(boolean readCacheEnabled) {
         cacheSettings.setReadCacheEnabled(readCacheEnabled);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setReadCacheEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig disableReadCache() {
         cacheSettings.setReadCacheEnabled(false);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setReadCacheEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig enableReadCache() {
         cacheSettings.setReadCacheEnabled(true);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#isAsyncWritesEnabled()} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isAsyncWritesEnabled() {
         return cacheSettings.isAsyncWritesEnabled();
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setAsyncWritesEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setAsyncWritesEnabled(boolean asyncWritesEnabled) {
         cacheSettings.setAsyncWritesEnabled(asyncWritesEnabled);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setAsyncWritesEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig disableAsyncWrites() {
         cacheSettings.setAsyncWritesEnabled(false);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setAsyncWritesEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig enableAsyncWrites() {
         cacheSettings.setAsyncWritesEnabled(true);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#isBufferedWritesEnabled()} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isBufferedWritesEnabled() {
         return cacheSettings.isBufferedWritesEnabled();
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setBufferedWritesEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setBufferedWritesEnabled(boolean bufferedWritesEnabled) {
         cacheSettings.setBufferedWritesEnabled(bufferedWritesEnabled);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setBufferedWritesEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig disableBufferedWrites() {
         cacheSettings.setBufferedWritesEnabled(false);
         return this;
     }
 
     /**
-     * use CacheSettings
+     * @deprecated use {@link CacheSettings#setBufferedWritesEnabled(boolean)} via {@code cacheSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig enableBufferedWrites() {
         cacheSettings.setBufferedWritesEnabled(true);
         return this;
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#isAutoValues()} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isAutoValuesEnabled() {
         return objectMappingSettings.isAutoValues();
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#setAutoValues(boolean)} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setAutoValuesEnabled(boolean enabled) {
         objectMappingSettings.setAutoValues(enabled);
         return this;
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#setAutoValues(boolean)} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig enableAutoValues() {
         objectMappingSettings.setAutoValues(true);
         return this;
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#setAutoValues(boolean)} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig disableAutoValues() {
         objectMappingSettings.setAutoValues(false);
         return this;
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#isCamelCaseConversionEnabled()} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isCamelCaseConversionEnabled() {
         return objectMappingSettings.isCamelCaseConversionEnabled();
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#setCamelCaseConversionEnabled(boolean)} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setCamelCaseConversionEnabled(boolean camelCaseConversionEnabled) {
         objectMappingSettings.setCamelCaseConversionEnabled(camelCaseConversionEnabled);
         return this;
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#getThreadPoolMessagingCoreSize()} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getThreadPoolMessagingCoreSize() {
         return messagingSettings.getThreadPoolMessagingCoreSize();
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#setThreadPoolMessagingCoreSize(int)} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setThreadPoolMessagingCoreSize(int threadPoolMessagingCoreSize) {
         messagingSettings.setThreadPoolMessagingCoreSize(threadPoolMessagingCoreSize);
         return this;
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#getThreadPoolMessagingMaxSize()} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getThreadPoolMessagingMaxSize() {
         return messagingSettings.getThreadPoolMessagingMaxSize();
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#setThreadPoolMessagingMaxSize(int)} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setThreadPoolMessagingMaxSize(int threadPoolMessagingMaxSize) {
         messagingSettings.setThreadPoolMessagingMaxSize(threadPoolMessagingMaxSize);
         return this;
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#getThreadPoolMessagingKeepAliveTime()} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public long getThreadPoolMessagingKeepAliveTime() {
         return messagingSettings.getThreadPoolMessagingKeepAliveTime();
     }
 
     /**
-     * use messagingSettings
+     * @deprecated use {@link MessagingSettings#setThreadPoolMessagingKeepAliveTime(long)} via {@code messagingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setThreadPoolMessagingKeepAliveTime(long threadPoolMessagingKeepAliveTime) {
         messagingSettings.setThreadPoolMessagingKeepAliveTime(threadPoolMessagingKeepAliveTime);
         return this;
     }
 
     /**
-     * use threadPoolSettings
+     * @deprecated use {@link ThreadPoolSettings#getThreadPoolAsyncOpCoreSize()} via {@code threadPoolSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getThreadPoolAsyncOpCoreSize() {
         return threadPoolSettings.getThreadPoolAsyncOpCoreSize();
     }
 
     /**
-     * use threadPoolSettings
+     * @deprecated use {@link ThreadPoolSettings#setThreadPoolAsyncOpCoreSize(int)} via {@code threadPoolSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setThreadPoolAsyncOpCoreSize(int threadPoolAsyncOpCoreSize) {
         threadPoolSettings.setThreadPoolAsyncOpCoreSize(threadPoolAsyncOpCoreSize);
         return this;
     }
 
     /**
-     * use threadPoolSettings
+     * @deprecated use {@link ThreadPoolSettings#getThreadPoolAsyncOpMaxSize()} via {@code threadPoolSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getThreadPoolAsyncOpMaxSize() {
         return threadPoolSettings.getThreadPoolAsyncOpMaxSize();
     }
 
     /**
-     * use threadPoolSettings
+     * @deprecated use {@link ThreadPoolSettings#setThreadPoolAsyncOpMaxSize(int)} via {@code threadPoolSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setThreadPoolAsyncOpMaxSize(int threadPoolAsyncOpMaxSize) {
         threadPoolSettings.setThreadPoolAsyncOpMaxSize(threadPoolAsyncOpMaxSize);
         return this;
     }
 
     /**
-     * use threadPoolSettings
+     * @deprecated use {@link ThreadPoolSettings#getThreadPoolAsyncOpKeepAliveTime()} via {@code threadPoolSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public long getThreadPoolAsyncOpKeepAliveTime() {
         return threadPoolSettings.getThreadPoolAsyncOpKeepAliveTime();
     }
 
     /**
-     * use threadPoolSettings
+     * @deprecated use {@link ThreadPoolSettings#setThreadPoolAsyncOpKeepAliveTime(long)} via {@code threadPoolSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setThreadPoolAsyncOpKeepAliveTime(long threadPoolAsyncOpKeepAliveTime) {
         threadPoolSettings.setThreadPoolAsyncOpKeepAliveTime(threadPoolAsyncOpKeepAliveTime);
         return this;
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#isObjectSerializationEnabled()} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isObjectSerializationEnabled() {
         return objectMappingSettings.isObjectSerializationEnabled();
     }
 
     /**
-     * use ObjectMappingSettings
+     * @deprecated use {@link ObjectMappingSettings#setObjectSerializationEnabled(boolean)} via {@code objectMappingSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setObjectSerializationEnabled(boolean objectSerializationEnabled) {
         objectMappingSettings.setObjectSerializationEnabled(objectSerializationEnabled);
         return this;
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#getHeartbeatFrequency()} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getHeartbeatFrequency() {
         return driverSettings.getHeartbeatFrequency();
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#setHeartbeatFrequency(int)} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setHeartbeatFrequency(int heartbeatFrequency) {
         driverSettings.setHeartbeatFrequency(heartbeatFrequency);
         return this;
@@ -1656,15 +1663,16 @@ public class MorphiumConfig {
 
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#setMinConnections(int)} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMinConnections(int minConnections) {
         connectionSettings.setMinConnections(minConnections);
         return this;
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#getLocalThreshold()} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getLocalThreshold() {
         return driverSettings.getLocalThreshold();
     }
@@ -1694,47 +1702,52 @@ public class MorphiumConfig {
      * Refer to the MongoDB documentation for details on localThreshold: reference/program/mongos/#cmdoption--localThreshold
      *                        Local Threshold
      * @since 2.13.0
+     * @deprecated use {@link DriverSettings#setLocalThreshold(int)} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setLocalThreshold(int localThreshold) {
         driverSettings.setLocalThreshold(localThreshold);
         return this;
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#getMaxConnectionIdleTime()} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMaxConnectionIdleTime() {
         return driverSettings.getMaxConnectionIdleTime();
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#setMaxConnectionIdleTime(int)} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMaxConnectionIdleTime(int maxConnectionIdleTime) {
         driverSettings.setMaxConnectionIdleTime(maxConnectionIdleTime);
         return this;
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#getMaxConnectionLifeTime()} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMaxConnectionLifeTime() {
         return driverSettings.getMaxConnectionLifeTime();
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#setMaxConnectionLifeTime(int)} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setMaxConnectionLifeTime(int maxConnectionLifeTime) {
         driverSettings.setMaxConnectionLifeTime(maxConnectionLifeTime);
         return this;
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ClusterSettings#getRequiredReplicaSetName()} via {@code clusterSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getRequiredReplicaSetName() {
         return clusterSettings.getRequiredReplicaSetName();
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ClusterSettings#setRequiredReplicaSetName(String)} via {@code clusterSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setRequiredReplicaSetName(String requiredReplicaSetName) {
         clusterSettings.setRequiredReplicaSetName(requiredReplicaSetName);
         return this;
@@ -1801,38 +1814,45 @@ public class MorphiumConfig {
     public void setSslInvalidHostNameAllowed(boolean sslInvalidHostNameAllowed) {
         connectionSettings.setSslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
     }
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#getReadTimeout()} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getReadTimeout() {
         return driverSettings.getReadTimeout();
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#setReadTimeout(int)} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setReadTimeout(int readTimeout) {
         driverSettings.setReadTimeout(readTimeout);
         return this;
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#isRetryReads()} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isRetryReads() {
         return driverSettings.isRetryReads();
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#setRetryReads(boolean)} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public void setRetryReads(boolean retryReads) {
         driverSettings.setRetryReads(retryReads);
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#isRetryWrites()} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public boolean isRetryWrites() {
         return driverSettings.isRetryWrites();
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#setRetryWrites(boolean)} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public void setRetryWrites(boolean retryWrites) {
         driverSettings.setRetryWrites(retryWrites);
     }
 
-    @Deprecated
+    /** @deprecated use {@link DriverSettings#getUuidRepresentation()} via {@code driverSettings()} instead */
+    @Deprecated(since = "6.3", forRemoval = true)
     public String getUuidRepresentation() {
         return driverSettings.getUuidRepresentation();
     }
@@ -1862,33 +1882,33 @@ public class MorphiumConfig {
     }
 
     /**
-     * use collectionCheckSettings
+     * @deprecated use {@link CollectionCheckSettings#getIndexCheck()} via {@code collectionCheckSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public IndexCheck getIndexCheck() {
         return collectionCheckSettings.getIndexCheck();
     }
 
     /**
-     * use collectionCheckSettings
+     * @deprecated use {@link CollectionCheckSettings#setIndexCheck(IndexCheck)} via {@code collectionCheckSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public void setIndexCheck(IndexCheck indexCheck) {
         collectionCheckSettings.setIndexCheck(indexCheck);
     }
 
     /**
-     * use collectionCheckSettings
+     * @deprecated use {@link CollectionCheckSettings#getCappedCheck()} via {@code collectionCheckSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public CappedCheck getCappedCheck() {
         return collectionCheckSettings.getCappedCheck();
     }
 
     /**
-     * use collectionCheckSettings
+     * @deprecated use {@link CollectionCheckSettings#setCappedCheck(CappedCheck)} via {@code collectionCheckSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public MorphiumConfig setCappedCheck(CappedCheck cappedCheck) {
         collectionCheckSettings.setCappedCheck(cappedCheck);
         return this;
@@ -1909,17 +1929,17 @@ public class MorphiumConfig {
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link DriverSettings#getIdleSleepTime()} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getIdleSleepTime() {
         return driverSettings.getIdleSleepTime();
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link DriverSettings#setIdleSleepTime(int)} via {@code driverSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public void setIdleSleepTime(int idleSleepTime) {
         driverSettings.setIdleSleepTime(idleSleepTime);
     }
@@ -1933,9 +1953,9 @@ public class MorphiumConfig {
     }
 
     /**
-     * use ConnectionSettings
+     * @deprecated use {@link ConnectionSettings#getMinConnections()} via {@code connectionSettings()} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public int getMinConnections() {
         return connectionSettings.getMinConnections();
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/MorphiumConfig.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/MorphiumConfig.java
@@ -1149,11 +1149,11 @@ public class MorphiumConfig {
     }
 
     /**
-     * @deprecated use {@link WriterSettings#getMaximumRetriesAsyncWriter()} via {@code writerSettings()} instead
+     * @deprecated use {@link WriterSettings#getMaximumRetriesBufferedWriter()} via {@code writerSettings()} instead
      */
     @Deprecated(since = "6.3", forRemoval = true)
     public int getMaximumRetriesBufferedWriter() {
-        return writerSettings.getMaximumRetriesAsyncWriter();
+        return writerSettings.getMaximumRetriesBufferedWriter();
     }
 
     /**

--- a/morphium-core/src/main/java/de/caluga/morphium/annotations/UseIfnull.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/annotations/UseIfnull.java
@@ -26,10 +26,12 @@ import java.lang.annotation.Target;
  *   <li>Add @IgnoreNullFromDB to fields that previously did NOT have @UseIfNull and you want to keep the protection</li>
  * </ul>
  *
+ * <p>Will be removed in 7.0.</p>
+ *
  * @author stephan
  * @see IgnoreNullFromDB
  */
-@Deprecated
+@Deprecated(since = "6.3", forRemoval = true)
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface UseIfnull {

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/bson/MongoBob.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/bson/MongoBob.java
@@ -4,9 +4,12 @@ package de.caluga.morphium.driver.bson;/**
 
 /**
  * BOB implementation for BSON
+ *
+ * @deprecated wrap raw BSON bytes in a plain {@code byte[]} (encoded as BSON binary)
+ * instead; will be removed in 7.0 together with its {@code BsonEncoder} support.
  **/
 @SuppressWarnings("WeakerAccess")
-@Deprecated
+@Deprecated(since = "6.3", forRemoval = true)
 public class MongoBob {
     private byte[] data;
 

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/MorphiumMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/MorphiumMessaging.java
@@ -138,7 +138,14 @@ public interface MorphiumMessaging extends Closeable {
 
     boolean isProcessMultiple();
 
-    @Deprecated
+    /**
+     * legacy switch for processing several messages at once. This concept is obsolete:
+     * how many messages are processed in parallel is controlled by the window size, use
+     * {@link #setWindowSize(int)} instead.
+     *
+     * @deprecated use {@link #setWindowSize(int)} instead; will be removed in 7.0
+     */
+    @Deprecated(since = "6.3", forRemoval = true)
     MorphiumMessaging setProcessMultiple(boolean processMultiple);
 
     String getQueueName();

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/Msg.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/Msg.java
@@ -73,8 +73,9 @@ public class Msg {
     private int priority = 1000;
     private Boolean exclusive = false;
 
-    //backward compatibility
-    @Deprecated
+    // backward compatibility only - replaced by the field {@code topic}
+    // (kept so that pre-6.x messages stored with "name" can still be read; see preStore/postLoad)
+    @Deprecated(since = "6.3", forRemoval = true)
     private String name;
 
     public Msg() {

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
@@ -135,9 +135,9 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
      * @param m               - morphium
      * @param pause           - pause between checks
      * @param processMultiple - deprecated, set windowSize to 1 if needed
-     * @deprecated - use morphium.createMessaging() instead
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, int pause, boolean processMultiple) {
         this(m, null, pause, processMultiple);
 
@@ -146,25 +146,25 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
     }
 
     /**
-     * @deprecated - use morphium.createMessaging() instead
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, int pause) {
         this(m, null, pause, true, 10);
     }
 
     /**
-     * @deprecated - use morphium.createMessaging() instead
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m) {
         this(m, null, 500, false, 100);
     }
 
     /**
-     * @deprecated - use morphium.createMessaging() instead
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, int pause, boolean processMultiple, boolean multithreadded,
                                      int windowSize) {
         this(m, null, pause, multithreadded, windowSize);
@@ -173,15 +173,18 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
             setWindowSize(1);
     }
 
-    @Deprecated
+    /**
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
+     */
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, int pause, boolean multithreadded, int windowSize) {
         this(m, null, pause, multithreadded, windowSize);
     }
 
     /**
-     * @deprecated - use morphium.createMessaging() instead
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, String queueName, int pause, boolean processMultiple) {
         this(m, queueName, pause, false, m.getConfig().getMessagingWindowSize());
 
@@ -189,16 +192,19 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
             setWindowSize(1);
     }
 
-    @Deprecated
+    /**
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
+     */
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, String queueName, int pause, boolean multithreadded, int windowSize) {
         this(m, queueName, pause, multithreadded, windowSize,
              m.isReplicaSet() || m.getDriver().getName().equals(InMemoryDriver.driverName));
     }
 
     /**
-     * @deprecated - use morphium.createMessaging() instead
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, String queueName, int pause, boolean processMultiple,
                                      boolean multithreadded, int windowSize) {
         this(m, queueName, pause, multithreadded, windowSize,
@@ -209,9 +215,9 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
     }
 
     /**
-     * @deprecated - processMultiple is unused
+     * @deprecated processMultiple is unused; use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, String queueName, int pause, boolean processMultiple,
                                      boolean multithreadded, int windowSize, boolean useChangeStream) {
         this(m, queueName, pause, multithreadded, windowSize, useChangeStream);
@@ -232,8 +238,10 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
      *                         depending on your configuration
      * @param pause: when waiting for incoming messages, especially when
      *        multithreadded == false, how long to wait between polls
+     *
+     * @deprecated use {@link Morphium#createMessaging()} or {@link Morphium#createMessaging(MessagingSettings)} instead
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public SingleCollectionMessaging(Morphium m, String queueName, int pause, boolean multithreadded, int windowSize,
                                      boolean useChangeStream) {
         this();
@@ -2120,7 +2128,10 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
         return windowSize == 1;
     }
 
-    @Deprecated
+    /**
+     * @deprecated use {@link #setWindowSize(int)} instead (windowSize 1 corresponds to processMultiple == false)
+     */
+    @Deprecated(since = "6.3", forRemoval = true)
     @Override
     public MorphiumMessaging setProcessMultiple(boolean processMultiple) {
         if (processMultiple) {

--- a/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/query/Query.java
@@ -250,12 +250,14 @@ public class Query<T> implements Cloneable {
     }
 
     /**
-     * use rawQuery instead
+     * runs a raw query map against the collection.
      *
      * @param query
      * @return
+     * @deprecated use {@link #rawQuery(Map)} to set the query and the standard API
+     *             (e.g. {@code rawQuery(query).asList()}) instead; will be removed in 7.0
      */
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public List<T> complexQuery(Map<String, Object> query) {
         return complexQuery(query, (String) null, 0, 0);
     }
@@ -648,17 +650,20 @@ public class Query<T> implements Cloneable {
     }
 
     /**
-     * use rawQuery to set query, and standard API
+     * runs a raw query map against the collection with sort, skip and limit.
      *
      * @param query - query to be sent
      * @param sort
      * @param skip - amount to skip
      * @param limit - maximium number of results
      * @return
+     * @deprecated use {@link #rawQuery(Map)} to set the query and the standard API
+     *             ({@code sort()}, {@code skip()}, {@code limit()}, {@code asList()}) instead;
+     *             will be removed in 7.0
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
 
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public List<T> complexQuery(Map<String, Object> query, Map<String, Integer> sort, int skip, int limit) {
         Cache ca = getARHelper().getAnnotationFromHierarchy(type, Cache.class); // type.getAnnotation(Cache.class);
         boolean useCache = ca != null && ca.readCache() && morphium.isReadCacheEnabledForThread() && !morphium.getDriver().getName().equals(InMemoryDriver.driverName);
@@ -1682,7 +1687,13 @@ public class Query<T> implements Cloneable {
         }
     }
 
-    @Deprecated
+    /**
+     * asynchronously gets an entity by its id.
+     *
+     * @deprecated use a standard query on the id field instead, e.g.
+     *             {@code q().f("_id").eq(id).get(callback)}; will be removed in 7.0
+     */
+    @Deprecated(since = "6.3", forRemoval = true)
     public void getById(final Object id, final AsyncOperationCallback<T> callback) {
         if (callback == null) {
             throw new IllegalArgumentException("Callback is null");
@@ -1703,7 +1714,13 @@ public class Query<T> implements Cloneable {
         getExecutor().submit(c);
     }
 
-    @Deprecated
+    /**
+     * gets an entity by its id.
+     *
+     * @deprecated use a standard query on the id field instead, e.g.
+     *             {@code q().f("_id").eq(id).get()}; will be removed in 7.0
+     */
+    @Deprecated(since = "6.3", forRemoval = true)
     public T getById(Object id) {
         @SuppressWarnings("unchecked")
         List<String> flds = getARHelper().getFields(type, Id.class);
@@ -2360,15 +2377,28 @@ public class Query<T> implements Cloneable {
         return text(metaScoreField, lang, true, true, text);
     }
 
-    @Deprecated
+    /**
+     * runs a text search using the legacy {@code text} command.
+     *
+     * @deprecated use the {@code $text} query operator via {@link #text(String...)} and the
+     *             standard API (e.g. {@code text(texts).asList()}) instead; will be removed in 7.0
+     */
+    @Deprecated(since = "6.3", forRemoval = true)
     public List<T> textSearch(String ... texts) {
         // noinspection deprecation
         return textSearch(TextSearchLanguages.mongo_default, texts);
     }
 
+    /**
+     * runs a text search using the legacy {@code text} command.
+     *
+     * @deprecated use the {@code $text} query operator via
+     *             {@link #text(TextSearchLanguages, String...)} and the standard API
+     *             (e.g. {@code text(lang, texts).asList()}) instead; will be removed in 7.0
+     */
     @SuppressWarnings("CastCanBeRemovedNarrowingVariableType")
 
-    @Deprecated
+    @Deprecated(since = "6.3", forRemoval = true)
     public List<T> textSearch(TextSearchLanguages lang, String ... texts) {
         if (texts.length == 0) {
             return new ArrayList<>();


### PR DESCRIPTION
Implements #218, prep work for #172 as agreed in the 6.3 plan (2026-07-06).

Every member confirmed for removal in 7.0 is now annotated `@Deprecated(since = "6.3", forRemoval = true)`, and its Javadoc names the concrete replacement — users get one full minor release of IDE warnings before 7.0 removes anything.

## What got annotated (180 members)

- **MorphiumConfig flat accessors (147)** → `Settings` sub-objects; every `{@link}` target was verified against the actual delegation in the method body (several existing hints pointed at the wrong sub-object and were corrected, e.g. `getMongoAuthDb` → `AuthSettings`, not `DriverSettings`). Overloaded targets (`setHostSeed`/`addHostToSeed`) use `{@code}` form.
- **MorphiumBase `set…`/`unsetQ…` (12)** → the corresponding `Query#set/unset` overloads. (The issue estimated ~25; the rest of the hits are commented-out code.)
- **SingleCollectionMessaging (11)**: 10 constructors + `setProcessMultiple` → `Morphium#createMessaging(…)` / `setWindowSize(int)`.
- **Query (6)**: `complexQuery` ×2 → `rawQuery` + standard API, `getById` ×2 → standard id query, `textSearch` ×2 → the `text(…)` operators.
- **Msg.name** → `topic` (kept only so pre-6.x documents stored with "name" stay readable).
- **MorphiumMessaging.setProcessMultiple** → `setWindowSize(int)` (legacy switch; window size controls parallelism).
- **MongoBob** (still encoded by `BsonEncoder`; the encoder support is removed along with it in 7.0) and **@UseIfnull** → `@IgnoreNullFromDB`.

## Deliberately unchanged

- `MongoType` UNDEFINED/DB_PTR/SYMBOL/JAVASCRIPT_SCOPE — deprecated by the BSON spec, not a Morphium API lifecycle.
- The deprecated legacy methods in `Morphium.java` (`set(…, Map<Enum,…>)`, `delete(List, forceCollectionName)`, `find(Query)`) — not on the confirmed 7.0-removal list, stay plain `@Deprecated`.
- `MorphiumConfig.asProperties(String, boolean)` — delegates to `asProperties(String)` on MorphiumConfig itself, not to a settings sub-object.

## Notable side-find (fixed in the second commit, #227)

`MorphiumConfig.getMaximumRetriesBufferedWriter()` delegates to `WriterSettings.getMaximumRetriesAsyncWriter()` — looks like a pre-existing copy-paste bug. The new Javadoc points at the *actual* target; the behavior is untouched. Fixed here: the getter now delegates to `getMaximumRetriesBufferedWriter()` and the Javadoc names the correct target. Tracked as #227.

Apart from that one-line fix, pure annotation/Javadoc change with zero runtime impact. `mvn test-compile` green across all modules; aggregation smoke tests green.

Closes #218


Closes #227