### PR TITLE
refactor(messaging): unify processed_by field-name handling (#219)

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/MessageRejectedException.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/MessageRejectedException.java
@@ -44,7 +44,8 @@ public class MessageRejectedException extends RuntimeException {
                     if (!m.isExclusive()) {
                         cmd = new UpdateMongoCommand(msg.getMorphium().getDriver().getPrimaryConnection(msg.getMorphium().getWriteConcernForClass(Msg.class)));
                         cmd.setColl(msg.getCollectionName()).setDb(msg.getMorphium().getDatabase());
-                        cmd.addUpdate(Doc.of("_id", m.getMsgId()), Doc.of("$addToSet", Doc.of("processed_by", msg.getSenderId())), null, false, false, null, null, null);
+                        String processedByFieldName = msg.getMorphium().getARHelper().getMongoFieldName(Msg.class, Msg.Fields.processedBy.name());
+                        cmd.addUpdate(Doc.of("_id", m.getMsgId()), Doc.of("$addToSet", Doc.of(processedByFieldName, msg.getSenderId())), null, false, false, null, null, null);
                         cmd.execute();
                         //not exclusive message is marked as processed by me
                     } else {

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/MultiCollectionMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/MultiCollectionMessaging.java
@@ -105,6 +105,8 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
 
     private ScheduledThreadPoolExecutor decouplePool;
     private MessagingRegistry networkRegistry;
+    // Mongo field name of Msg.processedBy ("processed_by"), resolved once via the object mapper in init()
+    private String processedByFieldName;
 
     // Ready signaling for tests - latch is counted down when change streams are fully initialized
     private final CountDownLatch readyLatch = new CountDownLatch(1);
@@ -455,7 +457,7 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
         long sum = 0;
         for (var msgName : monitorsByTopic.keySet()) {
             Query<Msg> q1 = morphium.createQueryFor(Msg.class, getCollectionName(msgName));
-            q1.f(Msg.Fields.sender).ne(getSenderId()).f("processed_by.0").notExists();
+            q1.f(Msg.Fields.sender).ne(getSenderId()).f(processedByFieldName + ".0").notExists();
             sum += q1.countAll();
         }
         return sum;
@@ -774,8 +776,7 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
 
     @SuppressWarnings("unchecked")
     private void pollAndProcessDms(String name) {
-        // Use stored field name explicitly for inMem parity (processed_by is persisted in snake_case)
-        var q = morphium.createQueryFor(Msg.class, getDMCollectionName()).f("processed_by.0").notExists() // not processed
+        var q = morphium.createQueryFor(Msg.class, getDMCollectionName()).f(processedByFieldName + ".0").notExists() // not processed
                 .f(Msg.Fields.topic).nin(getPausedTopics())
                 .f(Msg.Fields.topic).eq(name).f(Msg.Fields.msgId).nin(new ArrayList(processingMessages));
         int window = getWindowSize();
@@ -817,7 +818,7 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
         // Query for unprocessed messages in DM collection
         // Exclude messages already being processed or recently completed
         var q = morphium.createQueryFor(Msg.class, dmCollectionName)
-                .f("processed_by.0").notExists() // not processed
+                .f(processedByFieldName + ".0").notExists() // not processed
                 .f(Msg.Fields.msgId).nin(new ArrayList<>(processingMessages));
 
         int window = getWindowSize();
@@ -880,7 +881,7 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
 
         Query<Msg> q1 = morphium.createQueryFor(Msg.class, getCollectionName(msgName));
         q1.f(Msg.Fields.exclusive).eq(true) // exclusive message
-          .f("processed_by.0").notExists() // not processed yet (more efficient than eq(null))
+          .f(processedByFieldName + ".0").notExists() // not processed yet (more efficient than eq(null))
           .f(Msg.Fields.sender).ne(getSenderId()); // not sent by me
         if (!processingIds.isEmpty()) {
             q1.f(Msg.Fields.msgId).nin(processingIds); // not processed by me
@@ -888,8 +889,7 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
 
         Query<Msg> q2 = morphium.createQueryFor(Msg.class, getCollectionName(msgName));
         q2.f(Msg.Fields.exclusive).eq(false) // non-exclusive message
-          // Use stored field name explicitly for inMem parity (processed_by is persisted in snake_case)
-          .f("processed_by").ne(getSenderId()) // not processed by me
+          .f(processedByFieldName).ne(getSenderId()) // not processed by me
           .f(Msg.Fields.sender).ne(getSenderId()); // not sent by me
         if (!processingIds.isEmpty()) {
             q2.f(Msg.Fields.msgId).nin(processingIds); // not processing already
@@ -1115,7 +1115,7 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
         Query<Msg> idq = morphium.createQueryFor(Msg.class, collName);
         idq.f("_id").eq(queryId);
         Map<String, Object> qobj = idq.toQueryObject();
-        Map<String, Object> set = Doc.of("processed_by", id);
+        Map<String, Object> set = Doc.of(processedByFieldName, id);
         Map<String, Object> update = Doc.of("$addToSet", set);
         UpdateMongoCommand cmd = null;
 
@@ -1757,13 +1757,13 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
                 Query<Msg> q1 = morphium.createQueryFor(Msg.class, getCollectionName(msgName));
                 // pending = not processed by anyone (exclusive) or not processed by me
                 // (broadcast)
-                q1.f(Msg.Fields.sender).ne(getSenderId()).f("processed_by.0").notExists();
+                q1.f(Msg.Fields.sender).ne(getSenderId()).f(processedByFieldName + ".0").notExists();
                 total += q1.countAll();
             }
 
             // Include direct messages for this node in its DM collection
             Query<Msg> qdm = morphium.createQueryFor(Msg.class, getDMCollectionName());
-            qdm.f(Msg.Fields.sender).ne(getSenderId()).f("processed_by.0").notExists();
+            qdm.f(Msg.Fields.sender).ne(getSenderId()).f(processedByFieldName + ".0").notExists();
             total += qdm.countAll();
         } catch (Exception e) {
             log.warn("Error calculating number of messages", e);
@@ -2014,6 +2014,7 @@ public class MultiCollectionMessaging implements MorphiumMessaging {
     @Override
     public void init(Morphium m, MessagingSettings overrides) {
         morphium = m;
+        processedByFieldName = morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.processedBy.name());
 
         if (overrides == m.getConfig().messagingSettings()) {
             // create copy of settings, if same as morphiums

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
@@ -101,6 +101,8 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
     private final AtomicInteger changeStreamEventsReceived = new AtomicInteger(0);
     private MessagingSettings settings = null;
     private MessagingRegistry networkRegistry;
+    // Mongo field name of Msg.processedBy ("processed_by"), resolved once via the object mapper in init()
+    private String processedByFieldName;
 
     // Ready signaling for tests - latch is counted down when change streams are fully initialized
     private final CountDownLatch readyLatch = new CountDownLatch(1);
@@ -261,6 +263,7 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
     public void init(Morphium m, MessagingSettings settings) {
         morphium = m;
         this.settings = settings;
+        processedByFieldName = morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.processedBy.name());
         statusInfoListenerEnabled = settings.isMessagingStatusInfoListenerEnabled();
         decouplePool = new ScheduledThreadPoolExecutor(windowSize,
             Thread.ofPlatform().name("decouple_thr-", 0).factory());
@@ -430,7 +433,7 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
     @Override
     public long getPendingMessagesCount() {
         Query<Msg> q1 = morphium.createQueryFor(Msg.class, getCollectionName());
-        q1.f(Msg.Fields.sender).ne(id).f("processed_by.0").notExists();
+        q1.f(Msg.Fields.sender).ne(id).f(processedByFieldName + ".0").notExists();
         return q1.countAll();
     }
 
@@ -506,7 +509,7 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
                 Boolean exclusive = (Boolean) msg.get("exclusive");
                 if (exclusive != null && exclusive) {
                     @SuppressWarnings("unchecked")
-                    List<String> processedBy = (List<String>) (msg.containsKey("processed_by") ? msg.get("processed_by") : msg.get("processedBy"));
+                    List<String> processedBy = (List<String>) msg.get(processedByFieldName);
                     // Only skip if explicitly marked as processed by someone
                     if (processedBy != null && !processedBy.isEmpty()) {
                         // Exclusive message already processed, skip
@@ -1132,8 +1135,7 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
 
             if (listenerByName.isEmpty()) {
                 // No listeners - only answers will be processed
-                // Use stored field name explicitly for inMem parity (processed_by is persisted in snake_case)
-                return q.q().f(Msg.Fields.sender).ne(id).f("processed_by").ne(id).f(Msg.Fields.inAnswerTo)
+                return q.q().f(Msg.Fields.sender).ne(id).f(processedByFieldName).ne(id).f(Msg.Fields.inAnswerTo)
                        .in(waitingForAnswers.keySet()).limit(windowSize).idList();
             }
 
@@ -1156,10 +1158,9 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
             }
 
             // q1: Exclusive messages, not locked yet, not processed yet
-            var q1 = q.q().f(Msg.Fields.exclusive).eq(true).f("processed_by.0").notExists();
+            var q1 = q.q().f(Msg.Fields.exclusive).eq(true).f(processedByFieldName + ".0").notExists();
             // q2: non-exclusive messages, cannot be locked, not processed by me yet
-            // Use stored field name explicitly for inMem parity (processed_by is persisted in snake_case)
-            var q2 = q.q().f(Msg.Fields.exclusive).ne(true).f("processed_by").ne(id);
+            var q2 = q.q().f(Msg.Fields.exclusive).ne(true).f(processedByFieldName).ne(id);
             q.f("_id").nin(idsToIgnore);
             q.f(Msg.Fields.sender).ne(id);  // Don't receive messages sent by myself
             q.f(Msg.Fields.recipients).in(Arrays.asList(null, id));
@@ -1569,7 +1570,7 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
         idq.f("_id").eq(queryId);
         // Don't modify local copy until database update succeeds
         Map<String, Object> qobj = idq.toQueryObject();
-        Map<String, Object> set = Doc.of("processed_by", id);
+        Map<String, Object> set = Doc.of(processedByFieldName, id);
         Map<String, Object> update = Doc.of("$addToSet", set);
         UpdateMongoCommand cmd = null;
 


### PR DESCRIPTION
Implements #219.

The Mongo field name of `Msg.processedBy` is now resolved **once per messaging instance** via the object mapper — `morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.processedBy.name())` in `init()`, the funnel all constructors and `Morphium.createMessaging()` pass through (same pattern the classes already use for other resolved names). All ~15 hardcoded `"processed_by"` / `"processed_by.0"` literals in `SingleCollectionMessaging` and `MultiCollectionMessaging` now use it, as does the default rejection handler in `MessageRejectedException` (resolved via the messaging instance passed to the handler).

The dual-name defensive read (`processed_by` / `processedBy`) in the exclusive-message path is removed — the written name is guaranteed consistent now. `V5V6CompatibilityTest` verified: compat documents only ever carry `processedBy` as null/empty, which the removed fallback never acted on.

No schema change, no behavior change for data written with the canonical name. `@Index` annotation strings in `Msg` untouched (metadata, not call sites).

Tests (InMemoryDriver): BasicMessagingTests, BasicMessagingEdgeCaseTests, ExclusiveMessageBasicTests, AnsweringBasicTests, MessagingBroadcastTests, StatusInfoListenerTests, V5V6CompatibilityTest — 28/28 green. Full multi-driver suite runs in the homelab before release.

Closes #219