### PR TITLE
fix(inmem): $count on empty input emits no document, matching MongoDB (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,16 @@ Members confirmed for removal in 7.0 (#172 et al.) are now annotated `@Deprecate
 
 ### Changed
 
+#### Messaging: unified `processed_by` field-name handling (#219)
+The Mongo field name of `Msg.processedBy` is now resolved once per messaging instance via the object mapper instead of being hardcoded at ~15 call sites. The dual-name defensive read (`processed_by`/`processedBy`) in the exclusive-message path was removed — documents written with the non-canonical camelCase spelling (never produced by Morphium itself) are no longer recognized there.
+
 #### Aggregator: `graphLookup` enum overload now translates connect fields (#217)
 `graphLookup(Class, Expr, Enum, Enum, ...)` passed `connectFromField.name()` / `connectToField.name()` through untranslated — same defect family as the `lookup` enum overload fixed in 6.2.5 (#198). The enum overload now always translates both connect fields against the given from type, independent of the `translateAggregationFieldNames` flag. Code that relied on the raw enum name reaching the pipeline must use the String overload instead.
 
 ### Fixed
+
+#### InMemAggregator: `$count` on empty input emitted `{field: 0}` — MongoDB emits no document (#228)
+The in-memory `$count` stage always produced a result document; real MongoDB returns an empty result set when the stage input is empty. The stage now matches MongoDB, and `InMemAggregator.getCount()` gained the same empty-result guard `AggregatorImpl` already had.
 
 #### MorphiumConfig: `getMaximumRetriesBufferedWriter()` returned the AsyncWriter value (#227)
 The deprecated flat getter delegated to `WriterSettings.getMaximumRetriesAsyncWriter()` instead of `getMaximumRetriesBufferedWriter()` — callers silently got the async-writer retry count whenever the two settings differed (both default to 10, which is why it never surfaced). Found while writing the #218 replacement Javadoc.

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemAggregator.java
@@ -351,15 +351,17 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
         var originalPipeline = new ArrayList<>(getPipeline());
         addOperator(UtilsMap.of("$count", "num"));
         List<Map<String, Object>> res = doAggregation();
+        params.clear();
+        params.addAll(originalPipeline);
+
+        if (res.isEmpty()) {
+            return 0;
+        }
 
         if (res.get(0).get("num") instanceof Integer) {
-            params.clear();
-            params.addAll(originalPipeline);
             return ((Integer) res.get(0).get("num")).longValue();
         }
 
-        params.clear();
-        params.addAll(originalPipeline);
         return (Long) res.get(0).get("num");
     }
 
@@ -1059,7 +1061,10 @@ public class InMemAggregator<T, R> implements Aggregator<T, R> {
                 break;
 
             case "$count":
-                ret.add(UtilsMap.of((String) step.get(stage), data.size()));
+                // MongoDB emits no document at all when the stage input is empty
+                if (!data.isEmpty()) {
+                    ret.add(UtilsMap.of((String) step.get(stage), data.size()));
+                }
                 break;
 
             case "$group":

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/InMemAggregationTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/inmem/InMemAggregationTests.java
@@ -118,6 +118,18 @@ public class InMemAggregationTests extends MorphiumInMemTestBase {
     }
 
     @Test
+    public void inMemAggregationCountEmptyInputTest() throws Exception {
+        // parity with MongoDB (#228): $count on empty input emits no document at all
+        Aggregator<UncachedObject, Map> agg = morphium.createAggregator(UncachedObject.class, Map.class);
+        agg.count("myCount");
+        List<Map<String, Object>> lst = agg.aggregateMap();
+        assert (lst.isEmpty()) : "$count on empty input must yield no document, got: " + lst;
+
+        Aggregator<UncachedObject, Map> agg2 = morphium.createAggregator(UncachedObject.class, Map.class);
+        assert (agg2.getCount() == 0) : "getCount() on empty collection must be 0";
+    }
+
+    @Test
     public void inMemAggregationPushTest() throws Exception {
         for (int i = 0; i < 100; i++) {
             UncachedObject u = new UncachedObject("mod" + (i % 3), i);


### PR DESCRIPTION
Implements #228, found while reviewing the #223/#225 aggregation stack.

The in-memory `$count` stage always emitted `{field: <n>}`, even `{field: 0}` for empty input — real MongoDB returns an **empty result set** in that case. The stage now contributes no document on empty input, and `InMemAggregator.getCount()` gets the same `res.isEmpty() → 0` guard `AggregatorImpl` already had (it only worked before *because* of the parity gap). Pipeline restoration in `getCount()` moved before the early returns while at it.

New regression test `inMemAggregationCountEmptyInputTest` (empty `aggregateMap()` result + `getCount() == 0`). InMem aggregation suites green: 24 + 33 + 3.

Also carries the previously missing CHANGELOG entry for #219.

Same parity family as #203.

Closes #228