### PR TITLE
feat(driver): real version and configurable appName in hello handshake metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+#### Driver: configurable `appName` in the connection handshake
+New setting `DriverSettings.appName` (default `"Morphium"`), sent to MongoDB as `client.application.name` in the `hello` handshake. Set it per service to tell instances apart in `db.currentOp()`, server logs and profiler output (MongoDB truncates values over 128 bytes). Third-party `MorphiumDriver` implementations keep compiling — the new interface methods are defaults.
+
+### Fixed
+
+#### Driver: handshake metadata sent the hardcoded version "6.2"
+The `hello` client metadata reported `driver.version: "6.2"` regardless of the actual Morphium version, making the field useless for telling patch levels apart on the server side. The real version is now read at runtime from `morphium-version.properties`, a Maven-filtered classpath resource (`MorphiumVersion.getVersion()`, fallback `"unknown"`) — this also works in GraalVM native images, unlike the jar manifest. Additionally, the connect handshake built its `HelloCommand` without a connection, so `driver.name` was always reported as `Morphium V6/unknown`; the driver name is now resolved (`Morphium/PooledDriver` etc.). Verified end-to-end against a real replicaset via `db.currentOp()`.
+
 ## [6.2.9] - 2026-07-14
 
 ### Added

--- a/morphium-core/pom.xml
+++ b/morphium-core/pom.xml
@@ -52,6 +52,16 @@
     <resources>
       <resource>
         <directory>${project.basedir}/src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>morphium-version.properties</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+        <excludes>
+          <exclude>morphium-version.properties</exclude>
+        </excludes>
       </resource>
     </resources>
   </build>

--- a/morphium-core/src/main/java/de/caluga/morphium/Morphium.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/Morphium.java
@@ -408,6 +408,7 @@ public class Morphium extends MorphiumBase implements AutoCloseable {
         morphiumDriver.setRetryReads(getConfig().driverSettings().isRetryReads());
         morphiumDriver.setRetryWrites(getConfig().driverSettings().isRetryWrites());
         morphiumDriver.setHeartbeatFrequency(getConfig().driverSettings().getHeartbeatFrequency());
+        morphiumDriver.setAppName(getConfig().driverSettings().getAppName());
         morphiumDriver.setMaxConnectionIdleTime(getConfig().driverSettings().getMaxConnectionIdleTime());
         morphiumDriver.setMaxConnectionLifetime(getConfig().driverSettings().getMaxConnectionLifeTime());
         morphiumDriver.setMaxWaitTime(getConfig().connectionSettings().getMaxWaitTime());

--- a/morphium-core/src/main/java/de/caluga/morphium/MorphiumVersion.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/MorphiumVersion.java
@@ -1,0 +1,41 @@
+package de.caluga.morphium;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Provides the Morphium version at runtime.
+ * <p>
+ * The version is read from {@code morphium-version.properties}, a resource filtered by Maven
+ * with the project version at build time. Reading a classpath resource (instead of the jar
+ * manifest) also works in GraalVM native images, provided the resource is included in the image.
+ */
+public final class MorphiumVersion {
+    public static final String UNKNOWN_VERSION = "unknown";
+    private static final String VERSION = load();
+
+    private MorphiumVersion() {
+    }
+
+    public static String getVersion() {
+        return VERSION;
+    }
+
+    private static String load() {
+        try (InputStream in = MorphiumVersion.class.getResourceAsStream("/morphium-version.properties")) {
+            if (in == null) {
+                return UNKNOWN_VERSION;
+            }
+            Properties p = new Properties();
+            p.load(in);
+            String version = p.getProperty("version", UNKNOWN_VERSION);
+            // running from sources without resource filtering leaves the placeholder unresolved
+            if (version.contains("${")) {
+                return UNKNOWN_VERSION;
+            }
+            return version;
+        } catch (Exception e) {
+            return UNKNOWN_VERSION;
+        }
+    }
+}

--- a/morphium-core/src/main/java/de/caluga/morphium/config/DriverSettings.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/config/DriverSettings.java
@@ -34,6 +34,9 @@ public class DriverSettings extends Settings {
 
 
     private String driverName = PooledDriver.driverName;
+    // Sent to MongoDB as client.application.name in the connection handshake; shows up in
+    // db.currentOp(), server logs and profiler output. MongoDB truncates values over 128 bytes.
+    private String appName = "Morphium";
     @Transient
     private ReadPreference defaultReadPreference = ReadPreference.nearest();
     @Transient
@@ -130,6 +133,15 @@ public class DriverSettings extends Settings {
         this.changeStreamBatchSize = changeStreamBatchSize;
         return this;
     }
+    public String getAppName() {
+        return appName;
+    }
+
+    public DriverSettings setAppName(String appName) {
+        this.appName = appName;
+        return this;
+    }
+
     public String getDriverName() {
         return driverName;
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/MorphiumDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/MorphiumDriver.java
@@ -30,6 +30,19 @@ public interface MorphiumDriver extends Closeable {
     //.----)   |   |  |____     |  |        |  |     |  | |  |\   | |  |__| | .----)   |
     //|_______/    |_______|    |__|        |__|     |__| |__| \__|  \______| |_______/
     String getName();
+
+    /**
+     * application name sent to MongoDB as {@code client.application.name} in the connection
+     * handshake - visible in db.currentOp(), server logs and profiler output
+     */
+    default String getAppName() {
+        return null;
+    }
+
+    default void setAppName(String appName) {
+        // optional - drivers that do not send a handshake may ignore this
+    }
+
     int getCompression();
     MorphiumDriver setCompression(int type);
     int getIdleSleepTime();

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/commands/HelloCommand.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/commands/HelloCommand.java
@@ -1,5 +1,6 @@
 package de.caluga.morphium.driver.commands;
 
+import de.caluga.morphium.MorphiumVersion;
 import de.caluga.morphium.annotations.Transient;
 import de.caluga.morphium.driver.Doc;
 import de.caluga.morphium.driver.MorphiumDriver;
@@ -102,12 +103,16 @@ public class HelloCommand extends MongoCommand<HelloCommand> {
         }
         ret.put("$db", "admin");
         String driverName = "unknown";
+        String appName = "Morphium";
         if (getConnection() != null && getConnection().getDriver() != null) {
             driverName = getConnection().getDriver().getName();
+            if (getConnection().getDriver().getAppName() != null) {
+                appName = getConnection().getDriver().getAppName();
+            }
         }
         if (includeClient) {
-            ret.put("client", Doc.of("application", Doc.of("name", "Morphium"),
-                                     "driver", Doc.of("name", "Morphium V6/" + driverName, "version", "6.2"),
+            ret.put("client", Doc.of("application", Doc.of("name", appName),
+                                     "driver", Doc.of("name", "Morphium/" + driverName, "version", MorphiumVersion.getVersion()),
                                      "os", Doc.of("type", System.getProperty("os.name"))));
         }
         // Advertise supported compressors to the server (MongoDB wire protocol compression negotiation)

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/DriverBase.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/DriverBase.java
@@ -46,6 +46,7 @@ public abstract class DriverBase implements MorphiumDriver {
     private javax.net.ssl.SSLContext sslContext = null;
     private boolean sslInvalidHostNameAllowed = false;
     private String authMechanism = null;
+    private String appName = "Morphium";
     private int defaultW = 1;
     private int connectionTimeout = 1000;
     private int maxConnectionIdleTime = 100000;
@@ -512,6 +513,16 @@ public abstract class DriverBase implements MorphiumDriver {
     @Override
     public void setDefaultW(int w) {
         defaultW = w;
+    }
+
+    @Override
+    public String getAppName() {
+        return appName;
+    }
+
+    @Override
+    public void setAppName(String appName) {
+        this.appName = appName;
     }
 
     @Override

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnection.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/SingleMongoConnection.java
@@ -237,7 +237,8 @@ public class SingleMongoConnection implements MongoConnection {
         long start = System.currentTimeMillis();
 
         while (null == result) {
-            HelloCommand cmd = new HelloCommand(null);
+            // pass this connection so the client metadata (driver name, appName) can be resolved
+            HelloCommand cmd = new HelloCommand(this);
 
             if (authDb != null) {
                 cmd.setUser(user);

--- a/morphium-core/src/main/resources/morphium-version.properties
+++ b/morphium-core/src/main/resources/morphium-version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/HelloCommandClientMetadataTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/HelloCommandClientMetadataTest.java
@@ -1,0 +1,69 @@
+package de.caluga.test.morphium.driver;
+
+import de.caluga.morphium.MorphiumVersion;
+import de.caluga.morphium.driver.MorphiumDriver;
+import de.caluga.morphium.driver.commands.HelloCommand;
+import de.caluga.test.ConnectionMock;
+import de.caluga.test.DriverMock;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+public class HelloCommandClientMetadataTest {
+
+    @Test
+    public void versionIsResolvedFromBuild() {
+        String version = MorphiumVersion.getVersion();
+        assertNotNull(version);
+        assertNotEquals(MorphiumVersion.UNKNOWN_VERSION, version);
+        assertFalse(version.contains("${"), "maven resource filtering did not run: " + version);
+        assertTrue(version.matches("\\d+\\..*"), "not a version number: " + version);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void helloSendsRealVersionAndDefaultAppName() {
+        HelloCommand cmd = new HelloCommand(new ConnectionMock());
+        Map<String, Object> map = cmd.asMap();
+        Map<String, Object> client = (Map<String, Object>) map.get("client");
+        assertNotNull(client);
+        Map<String, Object> driver = (Map<String, Object>) client.get("driver");
+        assertEquals(MorphiumVersion.getVersion(), driver.get("version"));
+        assertEquals("Morphium/mock", driver.get("name"));
+        Map<String, Object> application = (Map<String, Object>) client.get("application");
+        assertEquals("Morphium", application.get("name"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void helloSendsConfiguredAppName() {
+        ConnectionMock con = new ConnectionMock() {
+            private final MorphiumDriver drv = new DriverMock() {
+                @Override
+                public String getAppName() {
+                    return "myService";
+                }
+            };
+            @Override
+            public MorphiumDriver getDriver() {
+                return drv;
+            }
+        };
+        HelloCommand cmd = new HelloCommand(con);
+        Map<String, Object> map = cmd.asMap();
+        Map<String, Object> client = (Map<String, Object>) map.get("client");
+        Map<String, Object> application = (Map<String, Object>) client.get("application");
+        assertEquals("myService", application.get("name"));
+    }
+
+    @Test
+    public void noClientMetadataWhenDisabled() {
+        HelloCommand cmd = new HelloCommand(new ConnectionMock());
+        cmd.setIncludeClient(false);
+        assertFalse(cmd.asMap().containsKey("client"));
+    }
+}


### PR DESCRIPTION
Fixes #231

## What

- **Real version in the handshake:** new `MorphiumVersion` utility reads the version from `morphium-version.properties`, a Maven-filtered classpath resource (`version=${project.version}`), fallback `"unknown"`. Classpath resource instead of jar manifest so it also works in GraalVM native images (provided the resource is included in the image).
- **Configurable `appName`:** new `DriverSettings.appName` (default `"Morphium"`), sent as `client.application.name` — set it per service to tell instances apart in `db.currentOp()`, server logs and profiler output. Wired through `Morphium` → driver like the other settings. The new `MorphiumDriver` methods are **default methods**, so third-party driver implementations keep compiling.
- **Connect handshake driver name:** `SingleMongoConnection.getHelloResult()` built its `HelloCommand` with `connection = null`, so the actual handshake always reported `driver.name: "Morphium V6/unknown"`. It now passes the connection; the real driver name is sent. Also renamed the prefix `Morphium V6/` → `Morphium/` — the version now lives in the version field.

## Verification

- New unit test `HelloCommandClientMetadataTest` (4 tests): version resolution via resource filtering, default + configured appName, `includeClient=false`.
- `MorphiumConfigTest` green (15 tests), full multi-module `test-compile` clean.
- **End-to-end against a real replicaset:** `db.currentOp()` on the primary shows for the Morphium connection:
  ```json
  {
    "application": { "name": "morphiumE2ECheck" },
    "driver": { "name": "Morphium/PooledDriver", "version": "6.2.10-SNAPSHOT" },
    "os": { "type": "Mac OS X" }
  }
  ```