### PR TITLE
fix(driver): re-seed empty hosts map after full replica-set outage (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ New setting `DriverSettings.appName` (default `"Morphium"`), sent to MongoDB as 
 
 ### Fixed
 
+#### PooledDriver: empty hosts map is re-seeded from the host seed — driver no longer permanently dead after a full replica-set outage (#233)
+When every replica-set member was unreachable long enough (rolling restart with overlapping windows, short network partition), `onConnectionError` evicted all hosts and the driver had no way back: the heartbeat only iterates the hosts map, and `handleHelloResult` — the only place re-adding hosts — only runs from heartbeat threads. Every operation failed with `No primary node found - not connected yet?` until the application was restarted, even though the cluster was healthy again (observed in production on morphium 6.1.8, 2026-07-16; the defect existed unchanged on develop). The heartbeat now re-seeds the hosts map from the configured host seed when it finds it empty, restarting the normal discovery cycle.
+
 #### InMemoryDriver: event dispatcher no longer uses virtual threads — JVM-wide logging deadlock under JDK 21 (#234)
 The change-stream event dispatcher used a virtual-thread factory. Under load, dispatcher threads pinned to their carriers while parked on the logback appender lock could occupy every carrier of the common ForkJoinPool; the unmounted virtual thread holding the lock then never got scheduled again, freezing every thread that logs (observed as a 20+ minute hang of the InMem CI phase in `SingleCollectionMessaging.terminate()` → `log.info()`). This is the same JDK-21 pinning/starvation class that led to the earlier project-wide virtual-thread rollback; the dispatcher had been missed. It now uses daemon platform threads.
 

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/wire/PooledDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/wire/PooledDriver.java
@@ -572,6 +572,8 @@ public class PooledDriver extends DriverBase {
                     log.debug("Error during borrowed connection cleanup", e);
                 }
 
+                reseedIfAllHostsEvicted();
+
                 for (var entry : hosts.entrySet()) {
                     var hst = entry.getKey();
                     var host = entry.getValue();
@@ -830,6 +832,30 @@ public class PooledDriver extends DriverBase {
                     fastestHost = host;
                 }
                 default -> { /* no update needed */ }
+        }
+    }
+
+    /**
+     * After a full cluster outage every host may have been evicted by
+     * onConnectionError() (MAX_FAILURES exceeded on all of them). The heartbeat
+     * only iterates the hosts map, and handleHelloResult() — the only place that
+     * (re-)adds hosts — only runs from heartbeat threads. With an empty map the
+     * driver could therefore never recover, even after the cluster returned (#233).
+     * Re-seeding from the configured host seed restarts the normal discovery
+     * cycle (hello → handleHelloResult → primary election).
+     */
+    void reseedIfAllHostsEvicted() {
+        if (!hosts.isEmpty() || getHostSeed() == null) {
+            return;
+        }
+
+        for (String seedHost : getHostSeed()) {
+            String normalizedHost = normalizeHostKey(seedHost);
+            hosts.putIfAbsent(normalizedHost, new Host(getHost(normalizedHost), getPortFromHost(normalizedHost)));
+        }
+
+        if (!hosts.isEmpty()) {
+            log.warn("All hosts had been evicted - re-seeded {} host(s) from the host seed for re-discovery", hosts.size());
         }
     }
 

--- a/morphium-core/src/test/java/de/caluga/morphium/driver/wire/PooledDriverReseedTest.java
+++ b/morphium-core/src/test/java/de/caluga/morphium/driver/wire/PooledDriverReseedTest.java
@@ -1,0 +1,73 @@
+package de.caluga.morphium.driver.wire;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #233: after a full replica-set outage every host gets
+ * evicted from the PooledDriver's hosts map (onConnectionError after
+ * MAX_FAILURES). Since the heartbeat only iterates that map and
+ * handleHelloResult() — the only place re-adding hosts — only runs from
+ * heartbeat threads, an empty map used to leave the driver dead forever, even
+ * after the cluster returned. The heartbeat now re-seeds from the host seed.
+ */
+@Tag("core")
+public class PooledDriverReseedTest {
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Host> hostsOf(PooledDriver drv) throws Exception {
+        Field f = PooledDriver.class.getDeclaredField("hosts");
+        f.setAccessible(true);
+        return (Map<String, Host>) f.get(drv);
+    }
+
+    @Test
+    public void reseedsFromHostSeedWhenAllHostsWereEvicted() throws Exception {
+        PooledDriver drv = new PooledDriver();
+        drv.setHostSeed("MongoA.example.com", "mongob.example.com:27018");
+        assertThat(hostsOf(drv)).isEmpty();
+
+        drv.reseedIfAllHostsEvicted();
+
+        assertThat(hostsOf(drv).keySet())
+        .containsExactlyInAnyOrder("mongoa.example.com:27017", "mongob.example.com:27018");
+    }
+
+    @Test
+    public void reseededHostsStartWithoutFailures() throws Exception {
+        PooledDriver drv = new PooledDriver();
+        drv.setHostSeed("mongoa.example.com");
+
+        drv.reseedIfAllHostsEvicted();
+
+        Host h = hostsOf(drv).get("mongoa.example.com:27017");
+        assertThat(h).isNotNull();
+        assertThat(h.getFailures()).isZero();
+    }
+
+    @Test
+    public void doesNotTouchHostsWhileAnyHostIsStillKnown() throws Exception {
+        PooledDriver drv = new PooledDriver();
+        drv.setHostSeed("mongoa.example.com", "mongob.example.com");
+        Map<String, Host> hosts = hostsOf(drv);
+        hosts.put("mongob.example.com:27017", new Host("mongob.example.com", 27017));
+
+        drv.reseedIfAllHostsEvicted();
+
+        assertThat(hosts.keySet()).containsExactly("mongob.example.com:27017");
+    }
+
+    @Test
+    public void emptyHostSeedStaysEmpty() throws Exception {
+        PooledDriver drv = new PooledDriver();
+
+        drv.reseedIfAllHostsEvicted();
+
+        assertThat(hostsOf(drv)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Problem

When every replica-set member is unreachable long enough (rolling restart with overlapping windows, short network partition), `onConnectionError` evicts all hosts from the `hosts` map. From that point the driver can never recover: the heartbeat only iterates the hosts map, and `handleHelloResult` — the only place that re-adds hosts — only runs from heartbeat threads. Every operation fails with `No primary node found - not connected yet?` until the application is restarted, even though the cluster has long recovered.

Root-caused from the 2026-07-16 incident (charon1/charon2 on morphium 6.1.8; two of three RS members down 07:17–08:11, the third briefly around 08:00–08:10 — both applications permanently dead afterwards, old sockets still ESTABLISHED, zero heartbeat threads left in the JVM). The defect existed unchanged on develop.

## Fix

`reseedIfAllHostsEvicted()` in the heartbeat tick: when the hosts map is empty, re-seed it from the configured host seed (fresh `Host` entries, zero failure counters), restarting the normal discovery cycle (hello → `handleHelloResult` → primary election). A null host seed is tolerated — an uncaught exception here would cancel the scheduled heartbeat permanently, the very failure class this fixes.

## Tests

`PooledDriverReseedTest` (4 cases): re-seed with key normalization, fresh failure counters, no-op while any host is still known, null/empty seed tolerated. Plus `PooledDriverPrimaryDiscoveryTest` re-run green.

Closes #233