### PR TITLE
fix(inmem): platform threads for the event dispatcher — virtual-thread logging deadlock (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ New setting `DriverSettings.appName` (default `"Morphium"`), sent to MongoDB as 
 
 ### Fixed
 
+#### Expr: `$in` rejects a non-array second operand — matching MongoDB (error 40081)
+The `$in` aggregation expression (also used in query `$expr`) silently returned `false` when its array operand resolved to null (e.g. a missing field path), a scalar or any other non-array — pipelines that fail on real MongoDB (`$in requires an array as a second argument`) passed against the in-memory evaluation. It now throws an `IllegalArgumentException` instead. **This reverts the lenient behavior introduced in 6.2.9**, which had replaced the previous `NullPointerException` with `false`; the clean error message stays. Java arrays are accepted as operand alongside `List`, and elements are compared null-safely.
+
+#### InMemoryDriver: `$in` / `$nin` reject scalar and null operands — matching MongoDB (`$in needs an array`)
+The 6.2.9 operand normalization went too far: besides accepting Java arrays and `Iterable`s (which stays), it silently wrapped scalars into single-element lists and turned `null` into an empty list — `{$in: "a"}` behaved like `{$in: ["a"]}`, hiding query bugs that real MongoDB rejects with `BadValue: $in needs an array`. Non-array operands now fail query validation (also on empty collections) with an `IllegalArgumentException`.
+
+#### InMemoryDriver: `$unset` supports array-index path segments (e.g. `ratings.0.rating`)
+The dotted-path `$unset` support added in 6.2.9 stopped at `List` intermediates, so valid paths through array indexes were a silent no-op. Numeric segments now index into arrays, matching MongoDB semantics: `ratings.0.rating` removes the field inside the first element, and `$unset` on an array element itself (`tags.1`) sets it to `null` instead of removing it. Non-numeric segments on arrays and out-of-range indexes remain a no-op.
+
 #### Driver: handshake metadata sent the hardcoded version "6.2"
 The `hello` client metadata reported `driver.version: "6.2"` regardless of the actual Morphium version, making the field useless for telling patch levels apart on the server side. The real version is now read at runtime from `morphium-version.properties`, a Maven-filtered classpath resource (`MorphiumVersion.getVersion()`, fallback `"unknown"`) — this also works in GraalVM native images, unlike the jar manifest. Additionally, the connect handshake built its `HelloCommand` without a connection, so `driver.name` was always reported as `Morphium V6/unknown`; the driver name is now resolved (`Morphium/PooledDriver` etc.). Verified end-to-end against a real replicaset via `db.currentOp()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ New setting `DriverSettings.appName` (default `"Morphium"`), sent to MongoDB as 
 
 ### Fixed
 
+#### InMemoryDriver: event dispatcher no longer uses virtual threads — JVM-wide logging deadlock under JDK 21 (#234)
+The change-stream event dispatcher used a virtual-thread factory. Under load, dispatcher threads pinned to their carriers while parked on the logback appender lock could occupy every carrier of the common ForkJoinPool; the unmounted virtual thread holding the lock then never got scheduled again, freezing every thread that logs (observed as a 20+ minute hang of the InMem CI phase in `SingleCollectionMessaging.terminate()` → `log.info()`). This is the same JDK-21 pinning/starvation class that led to the earlier project-wide virtual-thread rollback; the dispatcher had been missed. It now uses daemon platform threads.
+
 #### Expr: `$in` rejects a non-array second operand — matching MongoDB (error 40081)
 The `$in` aggregation expression (also used in query `$expr`) silently returned `false` when its array operand resolved to null (e.g. a missing field path), a scalar or any other non-array — pipelines that fail on real MongoDB (`$in requires an array as a second argument`) passed against the in-memory evaluation. It now throws an `IllegalArgumentException` instead. **This reverts the lenient behavior introduced in 6.2.9**, which had replaced the previous `NullPointerException` with `false`; the clean error message stays. Java arrays are accepted as operand alongside `List`, and elements are compared null-safely.
 

--- a/morphium-core/src/main/java/de/caluga/morphium/aggregation/Expr.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/aggregation/Expr.java
@@ -9,6 +9,7 @@ import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
@@ -532,25 +533,26 @@ public abstract class Expr {
             public Object evaluate(Map<String, Object> context) {
                 Object v = eval(elem, context);
                 Object arr = eval(array, context);
-                boolean found = false;
 
-                // The array operand can resolve to null (e.g. a missing field path
-                // like "$source_shortcuts") or to a non-list value; in that case the
-                // element simply is not contained -> no match instead of an NPE/CCE.
-                if (arr instanceof List) {
-                    for (Object o : (List<Object>) arr) {
-                        if (o instanceof Expr) {
-                            o = eval(((Expr) o), context);
-                        }
+                if (!(arr instanceof List) && (arr == null || !arr.getClass().isArray())) {
+                    throw new IllegalArgumentException("$in requires an array as its second operand");
+                }
 
-                        if (Objects.equals(o, v)) {
-                            found = true;
-                            break;
-                        }
+                int size = arr instanceof List ? ((List<?>) arr).size() : Array.getLength(arr);
+
+                for (int i = 0; i < size; i++) {
+                    Object value = arr instanceof List ? ((List<?>) arr).get(i) : Array.get(arr, i);
+
+                    if (value instanceof Expr) {
+                        value = eval((Expr) value, context);
+                    }
+
+                    if (Objects.equals(value, v)) {
+                        return true;
                     }
                 }
 
-                return found;
+                return false;
             }
         };
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -225,11 +225,12 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
                     Integer.getInteger("inmemory.scheduledThreads", DEFAULT_EXEC_THREADS));
     // Executor for dispatching change stream events asynchronously
     // This prevents insert/update/delete operations from blocking on event delivery
-    // Using cached thread pool with virtual threads to handle high event volumes
-    // without blocking
+    // Platform threads on purpose: virtual threads can deadlock the whole JVM here
+    // under JDK 21 — dispatchers pinned on the logback appender lock occupy all
+    // carriers while the unmounted lock holder never gets scheduled again (#234).
     private final java.util.concurrent.ExecutorService eventDispatcher = java.util.concurrent.Executors
         .newCachedThreadPool(
-                        Thread.ofVirtual().name("event-dispatcher-", 0).factory());
+                        Thread.ofPlatform().name("event-dispatcher-", 0).daemon(true).factory());
     private boolean running = true;
     private int expireCheck = 10000;
     private ScheduledFuture<?> expire;

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -4332,32 +4332,88 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
 
     /**
      * Removes a field for a $unset operation. Supports dotted paths into nested
-     * documents (e.g. "a.b.c"): navigates through the existing sub-documents and
-     * removes the leaf key. If any intermediate segment is missing or not a
-     * document, this is a no-op (matching MongoDB semantics).
+     * documents and indexed array elements (e.g. "a.0.b"). If any intermediate
+     * segment is missing or cannot be traversed, this is a no-op.
      */
-    @SuppressWarnings("unchecked")
     private void unsetField(Map<String, Object> obj, String key) {
         if (!key.contains(".")) {
             obj.remove(key);
             return;
         }
 
-        String[] path = key.split("\\.");
-        Map<String, Object> current = obj;
+        unsetPath(obj, key.split("\\."), 0);
+    }
 
-        for (int i = 0; i < path.length - 1; i++) {
-            Object existing = current.get(path[i]);
+    @SuppressWarnings("unchecked")
+    private void unsetPath(Object current, String[] path, int offset) {
+        String segment = path[offset];
+        boolean leaf = offset == path.length - 1;
 
-            if (!(existing instanceof Map)) {
-                // Path does not exist (or is not a sub-document) -> nothing to unset
-                return;
+        if (current instanceof Map) {
+            Map<String, Object> document = (Map<String, Object>) current;
+            if (leaf) {
+                document.remove(segment);
+            } else {
+                Object next = mutablePathContainer(document.get(segment));
+                if (next != document.get(segment)) {
+                    document.put(segment, next);
+                }
+                unsetPath(next, path, offset + 1);
             }
-
-            current = (Map<String, Object>) existing;
+            return;
         }
 
-        current.remove(path[path.length - 1]);
+        if (!(current instanceof List) || !isArrayIndex(segment)) {
+            return;
+        }
+
+        List<Object> array = (List<Object>) current;
+        int index;
+
+        try {
+            index = Integer.parseInt(segment);
+        } catch (NumberFormatException ignored) {
+            return;
+        }
+
+        if (index >= array.size()) {
+            return;
+        }
+
+        if (leaf) {
+            array.set(index, null);
+        } else {
+            Object next = mutablePathContainer(array.get(index));
+            if (next != array.get(index)) {
+                array.set(index, next);
+            }
+            unsetPath(next, path, offset + 1);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object mutablePathContainer(Object value) {
+        if (value instanceof Map) {
+            return new HashMap<>((Map<String, Object>) value);
+        }
+        if (value instanceof List) {
+            return new ArrayList<>((List<Object>) value);
+        }
+        return value;
+    }
+
+    private boolean isArrayIndex(String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     @SuppressWarnings({"ConstantConditions", "unchecked"})

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/QueryHelper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/QueryHelper.java
@@ -94,6 +94,9 @@ public class QueryHelper {
             if (key.startsWith("$") && !isKnownOperator(key)) {
                 throw new IllegalArgumentException("unknown top level operator: " + key);
             }
+            if (("$in".equals(key) || "$nin".equals(key)) && !isValueList(query.get(key))) {
+                throw new IllegalArgumentException(key + " requires an array operand");
+            }
 
             // Skip recursion into operators whose payload is not a query document
             // (e.g. $expr/$jsonSchema/$where carry aggregation expressions, not queries).
@@ -109,6 +112,9 @@ public class QueryHelper {
                 for (String subKey : subQuery.keySet()) {
                     if (subKey.startsWith("$") && !isKnownOperator(subKey)) {
                         throw new IllegalArgumentException("unknown operator: " + subKey);
+                    }
+                    if (("$in".equals(subKey) || "$nin".equals(subKey)) && !isValueList(subQuery.get(subKey))) {
+                        throw new IllegalArgumentException(subKey + " requires an array operand");
                     }
                     // Only recurse into operators whose payload is itself a query document.
                     if (!QUERY_CONTAINER_OPERATORS.contains(subKey)) {
@@ -2457,7 +2463,13 @@ public class QueryHelper {
             return list;
         }
 
-        return value == null ? Collections.emptyList() : List.of(value);
+        throw new IllegalArgumentException("$in/$nin requires an array operand");
+    }
+
+    private static boolean isValueList(Object value) {
+        return value instanceof List
+               || value instanceof Iterable
+               || value != null && value.getClass().isArray();
     }
 
     private static final class LookupResult {

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/AggregationExpressionTests.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/AggregationExpressionTests.java
@@ -9,6 +9,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("core")
 public class AggregationExpressionTests {
@@ -37,5 +43,23 @@ public class AggregationExpressionTests {
         val = Utils.toJsonString(e.toQueryObject());
         log.info(val);
         assert (val.equals("{ \"$filter\" : { \"input\" :  [ 1, 14, \"asV\"], \"as\" : \"str\", \"cond\" : \"NEN\" }  } "));
+    }
+
+    @Test
+    public void inRejectsNonArrayOperand() {
+        Expr missingArray = Expr.in(Expr.string("value"), Expr.field("missing"));
+        Expr scalarArray = Expr.in(Expr.string("value"), Expr.string("value"));
+
+        assertThrows(IllegalArgumentException.class, () -> missingArray.evaluate(Map.of()));
+        assertThrows(IllegalArgumentException.class, () -> scalarArray.evaluate(Map.of()));
+    }
+
+    @Test
+    public void inSupportsListsJavaArraysAndNullElements() {
+        Expr expression = Expr.in(Expr.nullExpr(), Expr.field("values"));
+
+        assertTrue((Boolean) expression.evaluate(Map.of("values", Arrays.asList("value", null))));
+        assertTrue((Boolean) expression.evaluate(Map.of("values", new String[]{"value", null})));
+        assertFalse((Boolean) expression.evaluate(Map.of("values", List.of("value"))));
     }
 }

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemInArrayOperandTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemInArrayOperandTest.java
@@ -1,6 +1,7 @@
 package de.caluga.test.morphium.driver;
 
 import de.caluga.morphium.driver.Doc;
+import de.caluga.morphium.driver.MorphiumDriverException;
 import de.caluga.morphium.driver.commands.ClearCollectionCommand;
 import de.caluga.morphium.driver.commands.FindCommand;
 import de.caluga.morphium.driver.commands.InsertMongoCommand;
@@ -14,6 +15,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Regression test: $in / $nin operands supplied as a Java array (e.g. a String[]
@@ -94,5 +96,39 @@ public class InMemInArrayOperandTest {
 
         assertEquals(2, ((Number) res.get("n")).intValue());
         assertEquals(2, ((Number) res.get("nModified")).intValue());
+    }
+
+    @Test
+    public void testInWithPrimitiveArrayOperand() throws Exception {
+        var drv = newDriver();
+        String db = "in_array_db";
+        String coll = "primitive_items";
+        new ClearCollectionCommand(drv).setDb(db).setColl(coll).doClear();
+        new InsertMongoCommand(drv).setDb(db).setColl(coll).setDocuments(List.of(
+            Doc.of("_id", "a", "v", 1),
+            Doc.of("_id", "b", "v", 2))).execute();
+
+        List<Map<String, Object>> found = new FindCommand(drv).setDb(db).setColl(coll)
+            .setFilter(Doc.of("v", Doc.of("$in", new int[]{2, 3}))).execute();
+
+        assertThat(found).extracting(d -> d.get("_id")).containsExactly("b");
+    }
+
+    @Test
+    public void testInRejectsScalarAndNullOperandsOnEmptyCollection() throws Exception {
+        var drv = newDriver();
+        String db = "in_array_db";
+        String coll = "invalid_items";
+        new ClearCollectionCommand(drv).setDb(db).setColl(coll).doClear();
+
+        MorphiumDriverException scalarError = assertThrows(MorphiumDriverException.class,
+            () -> new FindCommand(drv).setDb(db).setColl(coll)
+                .setFilter(Doc.of("v", Doc.of("$in", 2))).execute());
+        MorphiumDriverException nullError = assertThrows(MorphiumDriverException.class,
+            () -> new FindCommand(drv).setDb(db).setColl(coll)
+                .setFilter(Doc.of("v", Doc.of("$nin", null))).execute());
+
+        assertThat(scalarError).hasRootCauseInstanceOf(IllegalArgumentException.class);
+        assertThat(nullError).hasRootCauseInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemUnsetDottedPathTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/InMemUnsetDottedPathTest.java
@@ -132,4 +132,35 @@ public class InMemUnsetDottedPathTest {
         assertThat(found.get(0)).doesNotContainKey("flag");
         assertThat(found.get(0)).containsKey("keep");
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnsetDottedPathThroughArrayIndex() throws Exception {
+        var drv = newDriver();
+        String db = "unset_dotted_db";
+        String coll = "array_items";
+        new ClearCollectionCommand(drv).setDb(db).setColl(coll).doClear();
+
+        ObjectId id = new ObjectId();
+        new InsertMongoCommand(drv).setDb(db).setColl(coll).setDocuments(List.of(Doc.of(
+            "_id", id,
+            "ratings", List.of(Doc.of("rating", 5, "keep", true), Doc.of("rating", 3)),
+            "tags", List.of("a", "b", "c")))).execute();
+
+        Map<String, Object> result = new UpdateMongoCommand(drv).setDb(db).setColl(coll)
+            .addUpdate(Doc.of(
+                "q", Doc.of("_id", id),
+                "u", Doc.of("$unset", Doc.of("ratings.0.rating", "", "tags.1", "")),
+                "multi", false))
+            .execute();
+
+        assertEquals(1, ((Number) result.get("nModified")).intValue());
+        Map<String, Object> stored = new FindCommand(drv).setDb(db).setColl(coll)
+            .setFilter(Doc.of("_id", id)).execute().get(0);
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) stored.get("ratings");
+        List<Object> tags = (List<Object>) stored.get("tags");
+        assertThat(ratings.get(0)).doesNotContainKey("rating").containsEntry("keep", true);
+        assertThat(ratings.get(1)).containsEntry("rating", 3);
+        assertThat(tags).containsExactly("a", null, "c");
+    }
 }


### PR DESCRIPTION
## Problem

The InMemoryDriver's change-stream event dispatcher used a virtual-thread factory (`Thread.ofVirtual()`). Under load, dispatcher threads pinned to their carriers while parked on the logback appender lock could occupy every carrier of the common ForkJoinPool; the unmounted virtual thread holding the lock then never got scheduled again — freezing every thread in the JVM that logs.

Observed twice in one day as a 20+ minute full hang of the InMem CI phase (`SingleCollectionMessaging.terminate()` → `log.info()`; thread dump: 16 threads parked on the `OutputStreamAppender` ReentrantLock, no mounted holder anywhere, all 10 carriers occupied). This is the same JDK-21 pinning/starvation class that led to the earlier project-wide virtual-thread rollback — this dispatcher had been missed.

## Fix

Daemon platform threads for the dispatcher pool. It is small and long-lived, so virtual threads brought no benefit here anyway. JEP 491 (JDK 24) would remove the pinning problem, but we build for JDK 21.

## Tests

`ExclusiveMessageTests` — the reliable deadlock trigger — passes 5/5 in 37s with the fix (previously hung indefinitely), plus `InMemAggregationTests` 24/24.

Closes #234