### PR TITLE
fix(index): remove trailing underscore from auto-generated index names

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/IndexDescription.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/IndexDescription.java
@@ -45,10 +45,23 @@ public class IndexDescription {
             @SuppressWarnings("unchecked")
             Map<String, Object> keymap = (Map<String, Object>) incoming.get("key");
             for (var k : keymap.keySet()) {
+                // MongoDB's own naming convention is "<field>_<direction>" per key, joined by
+                // "_" between entries -- there is no separator after the LAST entry. Appending
+                // "_" unconditionally after every entry (as this used to do) produces a
+                // trailing underscore ("campaignNumber_1_" instead of "campaignNumber_1"), which
+                // silently breaks index creation on any database where an index on the same
+                // field already exists under the correct name: MongoDB rejects the mismatched
+                // name with "Error 85 - Index already exists with a different name", Morphium
+                // only logs that as a warning, and the index (with any unique constraint) is
+                // never created. This bug predates 6.3.0 -- it is present unchanged as far back
+                // as the v6.2.5 tag -- so it is a plain bugfix, not a behaviour change requiring
+                // a migration path.
+                if (sb.length() > 0) {
+                    sb.append("_");
+                }
                 sb.append(k);
                 sb.append("_");
                 sb.append(keymap.get(k).toString());
-                sb.append("_");
             }
             incoming.put("name", sb.toString());
         }

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/IndexDescriptionTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/IndexDescriptionTest.java
@@ -46,4 +46,30 @@ public class IndexDescriptionTest {
         assertEquals(idx.getHidden(), idx2.getHidden());
         assertEquals(idx.getSparse(), idx2.getSparse());
     }
+
+    // Regression test: fromMap() used to append a trailing "_" separator after every key
+    // instead of only BETWEEN keys, producing names like "campaignNumber_1_" instead of the
+    // MongoDB-standard "campaignNumber_1". That mismatch breaks index creation on any database
+    // where the correctly-named index already exists (MongoDB rejects it with "Error 85 - Index
+    // already exists with a different name", which Morphium only logs as a warning). Neither
+    // pre-existing test above catches this: both set an explicit name, which skips the
+    // auto-naming branch entirely.
+    @Test
+    public void fromMap_singleField_generatesNameWithoutTrailingUnderscore() throws Exception {
+        var idx = IndexDescription.fromMaps(Doc.of("campaignNumber", 1), null);
+        assertEquals("campaignNumber_1", idx.getName());
+    }
+
+    @Test
+    public void fromMap_multiField_generatesNameJoinedByUnderscoreWithoutTrailingUnderscore() throws Exception {
+        var idx = IndexDescription.fromMaps(Doc.of("campaignNumber", 1, "fileName", 1), null);
+        assertEquals("campaignNumber_1_fileName_1", idx.getName());
+    }
+
+    @Test
+    public void fromMap_explicitName_isNotOverwritten() throws Exception {
+        var idx = IndexDescription.fromMaps(Doc.of("campaignNumber", 1),
+                Doc.of("name", "myCustomIndexName"));
+        assertEquals("myCustomIndexName", idx.getName());
+    }
 }


### PR DESCRIPTION
Hi Stephan,

Bugfix for the index-naming issue reported against 6.3.0-SNAPSHOT (trailing underscore on auto-generated index names, breaking upgrades of existing databases). Full report and analysis below; here's the summary.

## Root cause

`IndexDescription.fromMap()` builds the auto-generated index name with a `StringBuilder`, and used to append `"_"` unconditionally after every `<field>_<direction>` segment instead of only *between* segments. That produces `campaignNumber_1_` for a single-field index and `campaignNumber_1_fileName_1_` for a two-field one — both violate MongoDB's own `<field>_<direction>` convention.

Practical effect: on a database where the correctly-named index already exists (e.g. created by an older Morphium version, or by MongoDB's own default naming), Morphium tries to create a same-definition index under the wrong name, MongoDB rejects it with "Error 85 - Index already exists with a different name", Morphium only logs that as a warning, and the index — including any `unique` constraint — is silently never created. Writes relying on that uniqueness then fail with `E11000` against the never-created, wrongly-named index.

## Not a 6.3.0 regression

`git blame` traces the trailing-underscore append to 2022-06-30 (`f9e84d27a3`), and it's byte-identical in the `v6.2.5` tag. It's been there for years — it only surfaces now because reproducing it needs a database that already has a correctly-named index to collide with; a fresh database never shows it. Plain bugfix, no migration path needed.

## Checked for duplication elsewhere

No second occurrence of the same name-building logic. Every call site (`Morphium#ensureIndicesFor`, the quarkus-morphium migration path, everything else) goes through `IndexDescription.fromMaps()`/`fromMap()`, so there was exactly one place to fix. Worth noting: `InMemoryDriver`'s own index-name builder already joins correctly (`if (b.length() > 0) b.append('_')`) and was never affected — which is also why no existing unit test caught this; every test exercising auto-naming through the in-memory driver saw correct names from that separate, unaffected builder.

## Fix

Separator moved from "append after every entry" to "append between entries" — same effect as a `String.join`.

## Tests

Three new regression tests: single-field name, multi-field name, and an explicit-name case proving the auto-naming branch is still skipped when a name is supplied (neither pre-existing test caught this, since both set an explicit name).

Mutation-proofed: temporarily restoring the old unconditional trailing-underscore append reddens exactly the two new auto-naming tests with the reported symptom (`expected: <...1_fileName_1> but was: <...1_fileName_1_>`), leaving the explicit-name tests green. Reverted after confirming.

## Verification

`morphium-core` installs clean. `IndexDescriptionTest` 5/5 green. All index-related suites in `morphium-core` green (`IndexMaintenanceTest`, `InMemoryDriverIndexPlanningTest`, `CollectionIndexStoreTest`, `IndexKeyTest`, `IndexPlannerTest`, `UniqueIndexTest`, `InMemUniqueIndexTest`, `ListIndexesFidelityTest`, `DropIndexesCommandTest`, `ConnectionIndexTest`). `morphium-jakarta-data` 82/82 green. Full `morphium-core` reactor test run got to 103 test classes / 0 failures before I stopped it for time — no regressions surfaced anywhere, including the long-running messaging suites.

Copilot review on a fork PR ahead of this one came back clean (both changed files reviewed, no comments).

## Ask

Targeting the 6.3.0 line rather than 6.4.0, since 6.3.0-SNAPSHOT is already in use downstream — this was caught by datona-ota-authority (Quarkus 3.37, quarkus-morphium 6.3.0-SNAPSHOT) against a MongoDB replica set with indexes from 6.2.5: 14/1794 tests failing with `E11000` on the upgraded database, none failing on a fresh one.
