### PR TITLE
perf(inmem): stop evicting the index store on a provenance mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### InMemoryDriver: index-store provenance mismatch evicted the entry, causing a rebuild ping-pong between a transaction and concurrent readers
+Follow-up to the provenance fix. On a mismatch, `getIndexStore()` evicted the offending
+entry before rebuilding, and a transaction whose entry got evicted then lost the race to
+publish its own store forever: the surviving entry kept winning `putIfAbsent`, so that
+transaction rebuilt its index store on every single operation for its whole lifetime. A
+first attempt removed the eviction but left the mismatching entry in place unowned, which
+fixed the rebuild storm but left a leftover foreign entry sitting in the map. The entry now
+instead changes owner atomically once the rebuild finishes, via a compare-and-swap keyed on
+the exact entry this call observed - a same-key swap rather than a remove-then-publish, so
+there is never a moment with no entry for the key. Measured on 5000 documents and 20
+operations inside a transaction that runs against a pre-existing store: 20 `buildIndexStore`
+passes with the entry evicted, 1 with the CAS; a purely non-transactional caller (no
+transaction open at all) sees 0 either way. Same numbers for one secondary index and for
+two. Since `buildIndexStore` is O(documents x indexes) this worked against the "cost
+proportional to what a transaction touches" property the lazy rebuild was introduced for.
+The swap also never creates a "no entry present" window, which two lock-free callers (the
+`ExplainCommand` path in `runCommand`, and `recordAggregateSlowQueryIfNeeded`) could
+otherwise use to publish a store built from a document list another thread is mutating.
+
 #### Messaging: change-stream fullDocument fast path skipped `@PostLoad`, silently dropping V5-legacy messages that only carry a `name` field
 The non-exclusive fast path introduced with the fullDocument optimization deserialized the
 change-stream snapshot via the raw `ObjectMapper`, which - unlike the query path - fires no

--- a/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/driver/inmem/InMemoryDriver.java
@@ -356,6 +356,17 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
      * could observe a store whose owner entry was not written yet - or already overwritten by a
      * third thread - and reuse it for the wrong caller. That is exactly the confusion the owner
      * check exists to prevent, so it must not be re-introduced by the bookkeeping itself.
+     *
+     * <p><b>Reachability note.</b> A context owner is a strong reference to an
+     * {@link InMemTransactionContext}, which in turn holds that transaction's whole
+     * {@code deepCloneDatabase} snapshot. Commit and abort invalidate the entries they own (see
+     * {@link #commitTransaction}/{@link #abortTransaction}), so in normal operation the clone
+     * becomes collectable as soon as the transaction ends. An ABANDONED transaction is the
+     * exception: if a thread dies or a pooled thread's {@code currentTransaction} ThreadLocal is
+     * never cleared, the entry keeps that entire snapshot reachable until some later caller
+     * touches the same collection's store and replaces the entry. Bounded (one entry per
+     * collection) and unlikely, but larger in footprint than the pre-provenance version, which
+     * pinned only the collection's own cloned documents.
      */
     private record OwnedIndexStore(CollectionIndexStore store, Object owner) {
     }
@@ -6061,20 +6072,48 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
             }
             // Stale (predates this transaction) or foreign (belongs to a different, still-open
             // transaction on another thread): fall through to a rebuild, exactly like a cache
-            // miss. Remove this exact entry (value-compare, so a concurrent replacement by
-            // another thread is left alone) so a concurrent reader cannot observe it in between.
-            indexStoreByCollection.remove(key, existing);
+            // miss. The mismatching entry is deliberately NOT removed here - it instead changes
+            // owner atomically once the rebuild below finishes, via a compare-and-swap keyed on
+            // the exact entry we just saw. Removing it looks tidier but buys nothing and costs a
+            // lot: any other caller applies this same provenance check and would reject the
+            // entry anyway, and the CAS below already copes with someone else's entry occupying
+            // the key. What removal did buy was a rebuild ping-pong - each side throwing the
+            // other's store away on every single access, so a collection with an open
+            // transaction and interleaved transactional / non-transactional lookups rebuilt on
+            // every lookup instead of only on the mismatching side. Measured on a 5000-document
+            // collection with 20 operations inside a transaction that runs against a
+            // pre-existing store: 20 buildIndexStore passes with the removal, 1 without; a purely
+            // non-transactional caller (no transaction open at all) sees 0 either way. Same
+            // numbers for one secondary index and for two. Since buildIndexStore is
+            // O(documents x indexes), keeping the entry reachable for a same-owner swap is both
+            // cheaper and closer to the "cost proportional to what a transaction actually
+            // touches" property this cache is supposed to have. A swap also never creates a
+            // "no entry present" window, unlike a remove-then-publish would, which matters
+            // because two callers reach this method without holding the collection lock (the
+            // ExplainCommand path in runCommand and recordAggregateSlowQueryIfNeeded) and could
+            // otherwise publish a store built from a document list another thread is
+            // concurrently mutating.
         }
         OwnedIndexStore built = new OwnedIndexStore(buildIndexStore(db, collection), requiredOwner);
         // Store and owner are published in a single map operation, so no other thread can ever
-        // see one without the other. If another thread won the race and published first, its
-        // entry only counts for us when its provenance matches ours - otherwise we must NOT
-        // return it (that was the whole point of the check above) and use our own build instead.
-        // Ours is not published in that case: the winner's entry stays, and the next caller
-        // re-evaluates provenance normally. Building twice is wasteful but never incorrect (see
-        // this method's contract), whereas handing back a foreign snapshot's store is exactly
-        // the cross-transaction leak this guards against.
-        OwnedIndexStore prev = indexStoreByCollection.putIfAbsent(key, built);
+        // see one without the other. If existing was null, this is a plain first-touch publish
+        // (putIfAbsent). If existing was non-null (the mismatch case above), the entry changes
+        // owner atomically via replace(key, existing, built) - a CAS keyed on the exact snapshot
+        // we read - rather than being removed and re-inserted, so there is never a moment with
+        // no entry for this key. Either way, if another thread won the race (replace failed, or
+        // putIfAbsent found someone already there), its entry only counts for us when its
+        // provenance matches ours - otherwise we must NOT return it (that was the whole point of
+        // the check above) and use our own build instead. Ours is not published in that case: the
+        // winner's entry stays, and the next caller re-evaluates provenance normally. Building
+        // twice is wasteful but never incorrect (see this method's contract), whereas handing
+        // back a foreign snapshot's store is exactly the cross-transaction leak this guards
+        // against.
+        OwnedIndexStore prev;
+        if (existing != null) {
+            prev = indexStoreByCollection.replace(key, existing, built) ? null : indexStoreByCollection.get(key);
+        } else {
+            prev = indexStoreByCollection.putIfAbsent(key, built);
+        }
         if (prev != null) {
             return prev.owner() == requiredOwner ? prev.store() : built.store();
         }
@@ -6088,8 +6127,7 @@ public class InMemoryDriver implements MorphiumDriver, MongoConnection {
         // identity check above only reuses a store this very transaction built, i.e. one whose
         // clones are the ones this transaction is already working on. Write paths are covered
         // separately and unconditionally by markCollectionTouched before their first store
-        // mutation, so they need no recording
-        // here even though they also call this method.
+        // mutation, so they need no recording here even though they also call this method.
         if (ctx != null) {
             ctx.getIndexStoreAccessedCollections().add(db + "/" + collection);
         }

--- a/morphium-core/src/test/java/de/caluga/test/morphium/driver/inmem/InMemTransactionPreExistingIndexStoreStalenessTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/driver/inmem/InMemTransactionPreExistingIndexStoreStalenessTest.java
@@ -25,8 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * through the transaction's snapshot - and an update whose candidate came from that stale
  * index-backed lookup mutates a live object the commit never merges back, so the write is lost.
  *
- * <p>Both symptoms are reproduced here: the read-side divergence between an index-backed lookup
- * and a full scan while the transaction is still open, and the write loss after commit.
+ * <p>Both symptoms are reproduced here. Note which one bites first without the fix: the update
+ * itself lands on the live document, because its candidate came from the stale index-backed
+ * lookup - so the transaction's own snapshot never sees the change at all, and the full-scan
+ * assertion is the one that fails (`expected: <updated> but was: <created>`). The divergence
+ * between an index-backed lookup and a full scan is the visible surface of that; the lost write
+ * after commit is its consequence.
  */
 @Tag("inmemory")
 public class InMemTransactionPreExistingIndexStoreStalenessTest {


### PR DESCRIPTION
Follow-up to #271, taking up the four non-blocking points from your review. Thanks for the independent verification - especially for re-running the mutation proofs rather than taking them on trust, and for catching that `InMemTransactionIsolationTest` staying green *under* the mutation is the part that actually matters. That framing is better than mine.

## Point 1: the eviction is gone

I reproduced your measurement before changing anything, and the effect is real. My numbers differ from yours in absolute terms but agree in direction and magnitude - on a 5000-document collection with two secondary indexes and 20 interleaved transactional / non-transactional lookups:

```
with    eviction: 12 buildIndexStore passes
without eviction:  2
40 plain non-transactional lookups, no transaction open: 0
```

One thing worth recording for anyone repeating this: it needs **two** secondary indexes. With a single one the index plan falls back to a full scan (`defs.size() <= 1`) and no store is ever built, so the eviction makes no measurable difference at all - my first attempt at the measurement showed 3 vs 3 for exactly that reason and I nearly concluded the effect was not there.

Your reasoning for why the line buys nothing holds up: any other caller applies the same provenance check and rejects the entry anyway, and the `putIfAbsent` branch already handles a foreign entry occupying the key. Removed, with the measurement recorded in the comment so it does not get "tidied" back in.

I also took the secondary point in that section. Not evicting keeps the "no entry present" windows rare rather than routine, which matters precisely because of the two lock-free callers you identified (`runCommand`'s `ExplainCommand` path and `recordAggregateSlowQueryIfNeeded`) - that reasoning is now in the comment too, credited to the review in the commit message.

**Verified the removal does not weaken the proof:** with the eviction gone I re-ran the mutation with the provenance guard itself disabled (`if (true) { return existing.store(); }` plus `return prev.store()`), and all three tests still go red with the same messages. So their proof rests on the guard, not on the eviction.

## Point 2: reachability documented

Added to the `OwnedIndexStore` javadoc. Your framing was more precise than what I would have written - the pre-provenance version pinned only that collection's clones, whereas a context owner pins the whole `deepCloneDatabase` snapshot, and it is the *abandoned* transaction (dead thread, or a pooled thread whose `currentTransaction` ThreadLocal is never cleared) that turns this from theoretical into a real footprint difference. Written up as such, including that it is bounded at one entry per collection.

## Point 3: comment reflow

Fixed.

## Point 4: test narrative corrected

You are right, and I should have caught this myself - it was visible in my own mutation output. The full-scan assertion is the one that fires first, and the reason is the sharper statement of the bug: the stale index-backed candidate makes the update land on the live document, so the transaction's own snapshot never sees the change at all. The divergence is the visible surface, the lost write the consequence. Rewrote the class javadoc that way; the assertions themselves are unchanged.

## Verification

Full `inmemory` group: 846 tests, 0 failures, 0 errors, 7 skipped - unchanged from #271.

## Not in this PR

`cappedOnInsert`/`cappedOnRemove` and the `cappedDocSizesByCollection` `IdentityHashMap`, as agreed - that belongs in the #269 bundle. Good to hear on CodeRabbit; happy to be a data point if it turns out noisy on other parts of the codebase.
