### PR TITLE
perf(messaging): server-side topic filter on the main change stream

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/DualChannelMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/DualChannelMessaging.java
@@ -872,12 +872,17 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
         // snapshot below - it never changes with the listener set.
         Set<String> watchedTopics = new HashSet<>(registered);
         watchedTopics.add(statusInfoListenerName);
+        // V5-legacy senders store only "name" - "topic" does not exist on those documents,
+        // and postLoad() maps it far too late for a server-side filter. preStore() sets
+        // name = topic on every 6.x send, so this clause only ever rescues legacy documents.
+        String legacyTopicField = "fullDocument.name";
         Map<String, Object> broadcastRelevant = new LinkedHashMap<>();
         broadcastRelevant.put(recipientsField, null);
         // Broadcast answers (inAnswerTo set, no recipients) target the requester's waiter
         // whatever topic they carry - they bypass the topic clause (#283).
         broadcastRelevant.put("$or", Arrays.asList(
             UtilsMap.of(topicField, UtilsMap.of("$in", new ArrayList<>(watchedTopics))),
+            UtilsMap.of(legacyTopicField, UtilsMap.of("$in", new ArrayList<>(watchedTopics))),
             UtilsMap.of(inAnswerToField, UtilsMap.of("$ne", null))
         ));
         Map<String, Object> insertRelevant = new LinkedHashMap<>();

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/DualChannelMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/DualChannelMessaging.java
@@ -109,6 +109,9 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
     private volatile long lastCsRestartMs = 0;
     private final AtomicLong csStallRestarts = new AtomicLong(0);
     private List<Map<String, Object>> changeStreamPipeline;
+    // Topic snapshot the live main-CS pipeline was built with; compared against
+    // listenerByName.keySet() by the poll loop to detect a stale filter.
+    private volatile Set<String> csFilterTopics = Set.of();
     private int changeStreamMaxWait;
     // Throttles the main-thread-death log so we don't spam every poll cycle once detected.
     private volatile long lastMainThreadDeathLogMs = 0;
@@ -721,10 +724,40 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
         log.warn("Main change stream for '{}' silent for {}ms while polling found backlog — restarting (restart #{})",
                  getCollectionName(), silenceMs, csStallRestarts.incrementAndGet());
 
+        replaceMainCsMonitor(old);
+    }
+
+    /**
+     * Rebuild the main change stream when the registered topic set no longer matches the
+     * filter the live stream was built with (listener added/removed after the stream
+     * started — the topic clause in the server-side $match would otherwise silently drop
+     * broadcasts for newly registered topics, degrading them to fallback-poll latency).
+     * Runs on every poll tick; a no-op unless the topic set actually changed. Bursts of
+     * registrations therefore coalesce into a single rebuild. Delivery during the gap is
+     * covered by the poll (addListenerForTopic bumps requestPoll).
+     *
+     * Only call from the polling thread, same discipline as restartMainCsIfStalled().
+     */
+    private void rebuildMainCsIfFilterStale() {
+        if (!running || !useChangeStream) return;
+        if (changeStreamMonitor == null) return;
+        if (listenerByName.keySet().equals(csFilterTopics)) return;
+
+        log.info("Topic set changed for '{}' ({} -> {}) — rebuilding main change stream filter",
+                 getCollectionName(), csFilterTopics, listenerByName.keySet());
+        changeStreamPipeline = buildMainCsPipeline();
+        replaceMainCsMonitor(changeStreamMonitor);
+    }
+
+    /**
+     * Terminate the given monitor and start a fresh one for the current
+     * changeStreamPipeline, rewired identically to the original.
+     */
+    private void replaceMainCsMonitor(ChangeStreamMonitor old) {
         try {
             old.terminate();
         } catch (Exception e) {
-            log.warn("Error terminating stalled change stream for '{}': {}", getCollectionName(), e.getMessage());
+            log.warn("Error terminating change stream for '{}': {}", getCollectionName(), e.getMessage());
         }
 
         try {
@@ -741,6 +774,14 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
         } catch (Exception e) {
             log.error("Failed to restart change stream for '{}'", getCollectionName(), e);
         }
+    }
+
+    /**
+     * @return snapshot of the topics the live main change stream filter was built with —
+     *         diagnostic counterpart to getCsStallRestarts()
+     */
+    public Set<String> getCsFilterTopics() {
+        return csFilterTopics;
     }
 
     /**
@@ -785,7 +826,13 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
                 getCollectionName());
     }
 
-    private void initChangeStreams() {
+    /**
+     * Build the $match pipeline for the main change stream, filtered server-side to
+     * what THIS instance can actually process. Snapshot of the registered topics is
+     * recorded in csFilterTopics so the poll loop can detect when the live stream's
+     * filter no longer matches the listener set (see rebuildMainCsIfFilterStale()).
+     */
+    private List<Map<String, Object>> buildMainCsPipeline() {
         // pipeline for reducing incoming traffic
         List<Map<String, Object>> pipeline = new ArrayList<>();
         Map<String, Object> match = new LinkedHashMap<>();
@@ -807,17 +854,37 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
         // fallback poll (~FALLBACK_POLL_INTERVAL × pause latency).
         //
         // This filter restricts inserts to messages that are actually for this instance:
-        //   - sender != my id        → don't echo my own inserts
-        //   - recipients null/me     → broadcast or addressed to me
+        //   - sender != my id                  → don't echo my own inserts
+        //   - recipients me                    → addressed to me (answers and DMs from legacy
+        //     senders on the main collection pass regardless of topic)
+        //   - recipients null + topic listened → broadcasts only for topics with a registered
+        //     listener; everything else would be dropped client-side after a wasted wakeup,
+        //     decode and processing-executor slot ("no listener for topic")
         // lock_released events are passed through unchanged (no fullDocument).
         // Use translated Mongo field names so the pipeline survives camelCase mapping changes.
         String senderField = "fullDocument." + morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.sender.name());
         String recipientsField = "fullDocument." + morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.recipients.name());
+        String topicField = "fullDocument." + morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.topic.name());
+        String inAnswerToField = "fullDocument." + morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.inAnswerTo.name());
+        Set<String> registered = Set.copyOf(listenerByName.keySet());
+        // The status-info topic is always watched: registry discovery must keep working
+        // regardless of listener registration state (#283). NOT part of the staleness
+        // snapshot below - it never changes with the listener set.
+        Set<String> watchedTopics = new HashSet<>(registered);
+        watchedTopics.add(statusInfoListenerName);
+        Map<String, Object> broadcastRelevant = new LinkedHashMap<>();
+        broadcastRelevant.put(recipientsField, null);
+        // Broadcast answers (inAnswerTo set, no recipients) target the requester's waiter
+        // whatever topic they carry - they bypass the topic clause (#283).
+        broadcastRelevant.put("$or", Arrays.asList(
+            UtilsMap.of(topicField, UtilsMap.of("$in", new ArrayList<>(watchedTopics))),
+            UtilsMap.of(inAnswerToField, UtilsMap.of("$ne", null))
+        ));
         Map<String, Object> insertRelevant = new LinkedHashMap<>();
         insertRelevant.put("operationType", "insert");
         insertRelevant.put(senderField, UtilsMap.of("$ne", id));
         insertRelevant.put("$or", Arrays.asList(
-            UtilsMap.of(recipientsField, null),
+            broadcastRelevant,
             UtilsMap.of(recipientsField, id)
         ));
         // Requeue detection: clearing processedBy via a plain DB update makes a message
@@ -835,9 +902,15 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
             insertRelevant
         ));
         pipeline.add(UtilsMap.of("$match", relevanceMatch));
+        csFilterTopics = registered;
+        return pipeline;
+    }
+
+    private void initChangeStreams() {
         // Use longer maxWait for change streams to avoid constant network polling
         // Change streams are designed to block server-side; short timeouts waste CPU/network
         changeStreamMaxWait = Math.max(pause * 10, morphium.getConfig().connectionSettings().getMaxWaitTime());
+        List<Map<String, Object>> pipeline = buildMainCsPipeline();
         changeStreamPipeline = pipeline;
         ChangeStreamMonitor lockMonitor = new ChangeStreamMonitor(morphium, getLockCollectionName(), false, changeStreamMaxWait,
             List.of(Doc.of("$match", Doc.of("operationType", Doc.of("$eq", "delete")))));
@@ -1535,6 +1608,8 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
                 try {
                     // Liveness-check first — see checkMainThreadAlive() for the failure mode.
                     checkMainThreadAlive();
+                    // Keep the server-side topic filter in sync with the registered listeners.
+                    rebuildMainCsIfFilterStale();
                     // Cleanup old message tracking entries to prevent unbounded memory growth
                     long cleanupTime = System.currentTimeMillis();
                     locallyProcessedMessageIds.entrySet().removeIf(entry ->

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
@@ -892,12 +892,17 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
         // snapshot below - it never changes with the listener set.
         Set<String> watchedTopics = new HashSet<>(registered);
         watchedTopics.add(statusInfoListenerName);
+        // V5-legacy senders store only "name" - "topic" does not exist on those documents,
+        // and postLoad() maps it far too late for a server-side filter. preStore() sets
+        // name = topic on every 6.x send, so this clause only ever rescues legacy documents.
+        String legacyTopicField = "fullDocument.name";
         Map<String, Object> broadcastRelevant = new LinkedHashMap<>();
         broadcastRelevant.put(recipientsField, null);
         // Broadcast answers (inAnswerTo set, no recipients) target the requester's waiter
         // whatever topic they carry - they bypass the topic clause (#283).
         broadcastRelevant.put("$or", Arrays.asList(
             UtilsMap.of(topicField, UtilsMap.of("$in", new ArrayList<>(watchedTopics))),
+            UtilsMap.of(legacyTopicField, UtilsMap.of("$in", new ArrayList<>(watchedTopics))),
             UtilsMap.of(inAnswerToField, UtilsMap.of("$ne", null))
         ));
         Map<String, Object> insertRelevant = new LinkedHashMap<>();

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
@@ -86,6 +86,9 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
     private volatile long lastCsRestartMs = 0;
     private final AtomicLong csStallRestarts = new AtomicLong(0);
     private List<Map<String, Object>> changeStreamPipeline;
+    // Topic snapshot the live main-CS pipeline was built with; compared against
+    // listenerByName.keySet() by the poll loop to detect a stale filter.
+    private volatile Set<String> csFilterTopics = Set.of();
     private int changeStreamMaxWait;
     // Throttles the main-thread-death log so we don't spam every poll cycle once detected.
     private volatile long lastMainThreadDeathLogMs = 0;
@@ -742,10 +745,40 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
         log.warn("Main change stream for '{}' silent for {}ms while polling found backlog — restarting (restart #{})",
                  getCollectionName(), silenceMs, csStallRestarts.incrementAndGet());
 
+        replaceMainCsMonitor(old);
+    }
+
+    /**
+     * Rebuild the main change stream when the registered topic set no longer matches the
+     * filter the live stream was built with (listener added/removed after the stream
+     * started — the topic clause in the server-side $match would otherwise silently drop
+     * broadcasts for newly registered topics, degrading them to fallback-poll latency).
+     * Runs on every poll tick; a no-op unless the topic set actually changed. Bursts of
+     * registrations therefore coalesce into a single rebuild. Delivery during the gap is
+     * covered by the poll (addListenerForTopic bumps requestPoll).
+     *
+     * Only call from the polling thread, same discipline as restartMainCsIfStalled().
+     */
+    private void rebuildMainCsIfFilterStale() {
+        if (!running || !useChangeStream) return;
+        if (changeStreamMonitor == null) return;
+        if (listenerByName.keySet().equals(csFilterTopics)) return;
+
+        log.info("Topic set changed for '{}' ({} -> {}) — rebuilding main change stream filter",
+                 getCollectionName(), csFilterTopics, listenerByName.keySet());
+        changeStreamPipeline = buildMainCsPipeline();
+        replaceMainCsMonitor(changeStreamMonitor);
+    }
+
+    /**
+     * Terminate the given monitor and start a fresh one for the current
+     * changeStreamPipeline, rewired identically to the original.
+     */
+    private void replaceMainCsMonitor(ChangeStreamMonitor old) {
         try {
             old.terminate();
         } catch (Exception e) {
-            log.warn("Error terminating stalled change stream for '{}': {}", getCollectionName(), e.getMessage());
+            log.warn("Error terminating change stream for '{}': {}", getCollectionName(), e.getMessage());
         }
 
         try {
@@ -762,6 +795,14 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
         } catch (Exception e) {
             log.error("Failed to restart change stream for '{}'", getCollectionName(), e);
         }
+    }
+
+    /**
+     * @return snapshot of the topics the live main change stream filter was built with —
+     *         diagnostic counterpart to getCsStallRestarts()
+     */
+    public Set<String> getCsFilterTopics() {
+        return csFilterTopics;
     }
 
     /**
@@ -806,7 +847,13 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
                 getCollectionName());
     }
 
-    private void initChangeStreams() {
+    /**
+     * Build the $match pipeline for the main change stream, filtered server-side to
+     * what THIS instance can actually process. Snapshot of the registered topics is
+     * recorded in csFilterTopics so the poll loop can detect when the live stream's
+     * filter no longer matches the listener set (see rebuildMainCsIfFilterStale()).
+     */
+    private List<Map<String, Object>> buildMainCsPipeline() {
         // pipeline for reducing incoming traffic
         List<Map<String, Object>> pipeline = new ArrayList<>();
         Map<String, Object> match = new LinkedHashMap<>();
@@ -828,17 +875,36 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
         // fallback poll (~FALLBACK_POLL_INTERVAL × pause latency).
         //
         // This filter restricts inserts to messages that are actually for this instance:
-        //   - sender != my id        → don't echo my own inserts
-        //   - recipients null/me     → broadcast or addressed to me
+        //   - sender != my id                  → don't echo my own inserts
+        //   - recipients me                    → addressed to me (answers pass regardless of topic)
+        //   - recipients null + topic listened → broadcasts only for topics with a registered
+        //     listener; everything else would be dropped client-side after a wasted wakeup,
+        //     decode and processing-executor slot ("no listener for topic", see queueOrRun path)
         // lock_released events are passed through unchanged (no fullDocument).
         // Use translated Mongo field names so the pipeline survives camelCase mapping changes.
         String senderField = "fullDocument." + morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.sender.name());
         String recipientsField = "fullDocument." + morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.recipients.name());
+        String topicField = "fullDocument." + morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.topic.name());
+        String inAnswerToField = "fullDocument." + morphium.getARHelper().getMongoFieldName(Msg.class, Msg.Fields.inAnswerTo.name());
+        Set<String> registered = Set.copyOf(listenerByName.keySet());
+        // The status-info topic is always watched: registry discovery must keep working
+        // regardless of listener registration state (#283). NOT part of the staleness
+        // snapshot below - it never changes with the listener set.
+        Set<String> watchedTopics = new HashSet<>(registered);
+        watchedTopics.add(statusInfoListenerName);
+        Map<String, Object> broadcastRelevant = new LinkedHashMap<>();
+        broadcastRelevant.put(recipientsField, null);
+        // Broadcast answers (inAnswerTo set, no recipients) target the requester's waiter
+        // whatever topic they carry - they bypass the topic clause (#283).
+        broadcastRelevant.put("$or", Arrays.asList(
+            UtilsMap.of(topicField, UtilsMap.of("$in", new ArrayList<>(watchedTopics))),
+            UtilsMap.of(inAnswerToField, UtilsMap.of("$ne", null))
+        ));
         Map<String, Object> insertRelevant = new LinkedHashMap<>();
         insertRelevant.put("operationType", "insert");
         insertRelevant.put(senderField, UtilsMap.of("$ne", id));
         insertRelevant.put("$or", Arrays.asList(
-            UtilsMap.of(recipientsField, null),
+            broadcastRelevant,
             UtilsMap.of(recipientsField, id)
         ));
         // Requeue detection: clearing processedBy via a plain DB update makes a message
@@ -856,9 +922,15 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
             insertRelevant
         ));
         pipeline.add(UtilsMap.of("$match", relevanceMatch));
+        csFilterTopics = registered;
+        return pipeline;
+    }
+
+    private void initChangeStreams() {
         // Use longer maxWait for change streams to avoid constant network polling
         // Change streams are designed to block server-side; short timeouts waste CPU/network
         changeStreamMaxWait = Math.max(pause * 10, morphium.getConfig().connectionSettings().getMaxWaitTime());
+        List<Map<String, Object>> pipeline = buildMainCsPipeline();
         changeStreamPipeline = pipeline;
         ChangeStreamMonitor lockMonitor = new ChangeStreamMonitor(morphium, getLockCollectionName(), false, changeStreamMaxWait,
             List.of(Doc.of("$match", Doc.of("operationType", Doc.of("$eq", "delete")))));
@@ -932,6 +1004,8 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
                 try {
                     // Liveness-check first — see checkMainThreadAlive() for the failure mode.
                     checkMainThreadAlive();
+                    // Keep the server-side topic filter in sync with the registered listeners.
+                    rebuildMainCsIfFilterStale();
                     // Cleanup old message tracking entries to prevent unbounded memory growth
                     long cleanupTime = System.currentTimeMillis();
                     locallyProcessedMessageIds.entrySet().removeIf(entry ->

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/TopicFilterChangeStreamTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/TopicFilterChangeStreamTest.java
@@ -181,6 +181,60 @@ public class TopicFilterChangeStreamTest extends MultiDriverTestBase {
 
     @ParameterizedTest
     @MethodSource("getMorphiumInstancesNoSingle")
+    public void v5LegacyNameOnlyBroadcastPassesFilter(Morphium morphium) throws Exception {
+        try (morphium) {
+            for (String impl : IMPLEMENTATIONS) {
+                log.info("=====> v5LegacyNameOnlyBroadcastPassesFilter with " + impl);
+
+                try (Morphium m = new Morphium(configFor(morphium, impl))) {
+                    m.dropCollection(Msg.class);
+                    MorphiumMessaging receiver = m.createMessaging();
+                    AtomicInteger got = new AtomicInteger(0);
+
+                    try {
+                        receiver.start();
+                        assertTrue(receiver.waitForReady(30, TimeUnit.SECONDS), "receiver not ready");
+                        receiver.addListenerForTopic("tf_legacy", (mm, msg) -> {
+                            got.incrementAndGet();
+                            return null;
+                        });
+                        TestUtils.waitForConditionToBecomeTrue(15000, "filter not rebuilt for tf_legacy",
+                            () -> csFilterTopics(receiver).contains("tf_legacy"));
+
+                        // a pre-6.x sender stores only "name" - no "topic" field on the document.
+                        // The change-stream filter must pass it; postLoad() maps name -> topic only
+                        // client-side. Delivery must be CS-prompt, well below the fallback interval.
+                        java.util.Map<String, Object> v5Doc = new java.util.HashMap<>();
+                        v5Doc.put("name", "tf_legacy");
+                        v5Doc.put("msg", "legacy message");
+                        v5Doc.put("value", "v5_value");
+                        v5Doc.put("sender", "v5_sender");
+                        v5Doc.put("senderHost", "v5_host");
+                        v5Doc.put("timestamp", System.currentTimeMillis());
+                        v5Doc.put("ttl", 30000L);
+                        v5Doc.put("priority", 1000);
+                        v5Doc.put("timingOut", true);
+                        v5Doc.put("deleteAfterProcessing", false);
+                        v5Doc.put("deleteAfterProcessingTime", 0);
+                        v5Doc.put("exclusive", false);
+                        v5Doc.put("processedBy", null);
+                        v5Doc.put("recipients", null);
+                        v5Doc.put("inAnswerTo", null);
+                        m.storeMap(receiver.getCollectionName(), v5Doc);
+
+                        TestUtils.waitForConditionToBecomeTrue(5000,
+                            "name-only legacy broadcast not delivered promptly (" + impl + ")",
+                            () -> got.get() == 1);
+                    } finally {
+                        receiver.terminate();
+                    }
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
     public void filterShrinksOnListenerRemoval(Morphium morphium) throws Exception {
         try (morphium) {
             for (String impl : IMPLEMENTATIONS) {

--- a/morphium-core/src/test/java/de/caluga/test/morphium/messaging/TopicFilterChangeStreamTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/morphium/messaging/TopicFilterChangeStreamTest.java
@@ -1,0 +1,212 @@
+package de.caluga.test.morphium.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.MorphiumConfig;
+import de.caluga.morphium.messaging.DualChannelMessaging;
+import de.caluga.morphium.messaging.MessageListener;
+import de.caluga.morphium.messaging.MorphiumMessaging;
+import de.caluga.morphium.messaging.Msg;
+import de.caluga.morphium.messaging.SingleCollectionMessaging;
+import de.caluga.test.mongo.suite.base.MultiDriverTestBase;
+import de.caluga.test.mongo.suite.base.TestUtils;
+
+@Tag("messaging")
+public class TopicFilterChangeStreamTest extends MultiDriverTestBase {
+
+    private static final List<String> IMPLEMENTATIONS = List.of(SingleCollectionMessaging.NAME, DualChannelMessaging.NAME);
+
+    private MorphiumConfig configFor(Morphium base, String impl) {
+        MorphiumConfig cfg = base.getConfig().createCopy();
+        cfg.messagingSettings().setMessagingImplementation(impl);
+        cfg.encryptionSettings().setCredentialsEncrypted(base.getConfig().encryptionSettings().getCredentialsEncrypted());
+        cfg.encryptionSettings().setCredentialsDecryptionKey(base.getConfig().encryptionSettings().getCredentialsDecryptionKey());
+        cfg.encryptionSettings().setCredentialsEncryptionKey(base.getConfig().encryptionSettings().getCredentialsEncryptionKey());
+        return cfg;
+    }
+
+    private Set<String> csFilterTopics(MorphiumMessaging messaging) {
+        if (messaging instanceof SingleCollectionMessaging scm) return scm.getCsFilterTopics();
+        if (messaging instanceof DualChannelMessaging dcm) return dcm.getCsFilterTopics();
+        throw new IllegalArgumentException("unexpected messaging implementation: " + messaging.getClass());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
+    public void listenedTopicDeliveredForeignTopicNot(Morphium morphium) throws Exception {
+        try (morphium) {
+            for (String impl : IMPLEMENTATIONS) {
+                log.info("=====> listenedTopicDeliveredForeignTopicNot with " + impl);
+
+                try (Morphium m = new Morphium(configFor(morphium, impl))) {
+                    m.dropCollection(Msg.class);
+                    MorphiumMessaging sender = m.createMessaging();
+                    MorphiumMessaging receiver = m.createMessaging();
+                    AtomicInteger gotListened = new AtomicInteger(0);
+                    AtomicInteger gotForeign = new AtomicInteger(0);
+
+                    try {
+                        sender.start();
+                        assertTrue(sender.waitForReady(30, TimeUnit.SECONDS), "sender not ready");
+                        receiver.start();
+                        assertTrue(receiver.waitForReady(30, TimeUnit.SECONDS), "receiver not ready");
+
+                        receiver.addListenerForTopic("tf_listened", (mm, msg) -> {
+                            gotListened.incrementAndGet();
+                            return null;
+                        });
+
+                        sender.sendMessage(new Msg("tf_foreign", "msg", "value"));
+                        sender.sendMessage(new Msg("tf_listened", "msg", "value"));
+
+                        TestUtils.waitForConditionToBecomeTrue(15000, "listened topic not delivered (" + impl + ")",
+                            () -> gotListened.get() == 1);
+                        // the foreign message was sent BEFORE the listened one and both took the same
+                        // path - if it were going to be delivered, it would have arrived by now
+                        Thread.sleep(1000);
+                        assertEquals(0, gotForeign.get(), "message without listener must not be delivered (" + impl + ")");
+                        assertEquals(1, gotListened.get(), "listened message delivered exactly once (" + impl + ")");
+                    } finally {
+                        sender.terminate();
+                        receiver.terminate();
+                    }
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
+    public void filterRebuildsOnLateListenerRegistration(Morphium morphium) throws Exception {
+        try (morphium) {
+            for (String impl : IMPLEMENTATIONS) {
+                log.info("=====> filterRebuildsOnLateListenerRegistration with " + impl);
+
+                try (Morphium m = new Morphium(configFor(morphium, impl))) {
+                    m.dropCollection(Msg.class);
+                    MorphiumMessaging sender = m.createMessaging();
+                    MorphiumMessaging receiver = m.createMessaging();
+                    AtomicInteger gotB = new AtomicInteger(0);
+
+                    try {
+                        sender.start();
+                        assertTrue(sender.waitForReady(30, TimeUnit.SECONDS), "sender not ready");
+                        receiver.start();
+                        assertTrue(receiver.waitForReady(30, TimeUnit.SECONDS), "receiver not ready");
+
+                        receiver.addListenerForTopic("tf_a", (mm, msg) -> null);
+                        TestUtils.waitForConditionToBecomeTrue(15000, "filter not rebuilt for tf_a (" + impl + ")",
+                            () -> csFilterTopics(receiver).contains("tf_a"));
+
+                        // message sent before tf_b is registered - must be picked up on registration
+                        sender.sendMessage(new Msg("tf_b", "msg", "early"));
+                        Thread.sleep(500);
+                        assertEquals(0, gotB.get(), "tf_b has no listener yet (" + impl + ")");
+
+                        receiver.addListenerForTopic("tf_b", (mm, msg) -> {
+                            gotB.incrementAndGet();
+                            return null;
+                        });
+                        TestUtils.waitForConditionToBecomeTrue(15000, "pre-registration tf_b message not picked up (" + impl + ")",
+                            () -> gotB.get() == 1);
+                        TestUtils.waitForConditionToBecomeTrue(15000, "filter not rebuilt for tf_b (" + impl + ")",
+                            () -> csFilterTopics(receiver).contains("tf_b"));
+
+                        // now the rebuilt change stream must deliver new tf_b messages
+                        sender.sendMessage(new Msg("tf_b", "msg", "late"));
+                        TestUtils.waitForConditionToBecomeTrue(15000, "post-rebuild tf_b message not delivered (" + impl + ")",
+                            () -> gotB.get() == 2);
+
+                        Set<String> topics = csFilterTopics(receiver);
+                        assertTrue(topics.contains("tf_a") && topics.contains("tf_b"),
+                            "filter topics must track registered listeners (" + impl + "), got: " + topics);
+                    } finally {
+                        sender.terminate();
+                        receiver.terminate();
+                    }
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
+    public void broadcastAnswerBypassesTopicFilter(Morphium morphium) throws Exception {
+        try (morphium) {
+            for (String impl : IMPLEMENTATIONS) {
+                log.info("=====> broadcastAnswerBypassesTopicFilter with " + impl);
+
+                try (Morphium m = new Morphium(configFor(morphium, impl))) {
+                    m.dropCollection(Msg.class);
+                    MorphiumMessaging requester = m.createMessaging();
+                    MorphiumMessaging responder = m.createMessaging();
+
+                    try {
+                        requester.start();
+                        assertTrue(requester.waitForReady(30, TimeUnit.SECONDS), "requester not ready");
+                        responder.start();
+                        assertTrue(responder.waitForReady(30, TimeUnit.SECONDS), "responder not ready");
+
+                        responder.addListenerForTopic("tf_req", (mm, msg) -> {
+                            // craft a BROADCAST answer: inAnswerTo set, no recipient, and a topic
+                            // the requester has no listener for - must still reach its waiter
+                            Msg ans = new Msg("tf_unrelated", "answer", "value");
+                            ans.setInAnswerTo(msg.getMsgId());
+                            mm.sendMessage(ans);
+                            return null;
+                        });
+
+                        Msg answer = requester.sendAndAwaitFirstAnswer(new Msg("tf_req", "question", "value"), 15000);
+                        assertTrue(answer != null && "tf_unrelated".equals(answer.getTopic()),
+                            "broadcast answer on unlistened topic must reach the waiter (" + impl + ")");
+                    } finally {
+                        requester.terminate();
+                        responder.terminate();
+                    }
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
+    public void filterShrinksOnListenerRemoval(Morphium morphium) throws Exception {
+        try (morphium) {
+            for (String impl : IMPLEMENTATIONS) {
+                log.info("=====> filterShrinksOnListenerRemoval with " + impl);
+
+                try (Morphium m = new Morphium(configFor(morphium, impl))) {
+                    m.dropCollection(Msg.class);
+                    MorphiumMessaging receiver = m.createMessaging();
+                    MessageListener<Msg> listener = (mm, msg) -> null;
+
+                    try {
+                        receiver.start();
+                        assertTrue(receiver.waitForReady(30, TimeUnit.SECONDS), "receiver not ready");
+
+                        receiver.addListenerForTopic("tf_tmp", listener);
+                        TestUtils.waitForConditionToBecomeTrue(15000, "filter not rebuilt after add (" + impl + ")",
+                            () -> csFilterTopics(receiver).contains("tf_tmp"));
+
+                        receiver.removeListenerForTopic("tf_tmp", listener);
+                        TestUtils.waitForConditionToBecomeTrue(15000, "filter not rebuilt after remove (" + impl + ")",
+                            () -> !csFilterTopics(receiver).contains("tf_tmp"));
+                    } finally {
+                        receiver.terminate();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements the server-side topic filter discussed in #283 — closes #283.

The insert-relevance `$match` (introduced in 99b7a7cf) filters on sender and recipients only. Broadcasts (`recipients=null`) therefore reach every consumer's cursor regardless of topic — each foreign broadcast costs a wakeup, a fullDocument decode and a processing-executor slot before the client drops it as "no listener for topic". Under bursts (our production case: monitoring floods on a shared bus) the discards delay the consumer's real messages queued behind them.

**What this PR does**

- insert events pass if `sender != me` AND (`recipients` contains me, OR `recipients` is null AND the topic clause matches)
- the topic clause: `topic $in` registered listener topics **plus the status-info topic** (always watched, so registry discovery works regardless of listener registration state), OR `inAnswerTo` set — broadcast answers bypass the topic filter and still reach their waiter
- direct messages and answers (`recipients=me`) pass unchanged regardless of topic; `lock_released` and requeue detection untouched
- listeners register at runtime: the poll tick compares the live pipeline's topic snapshot (`csFilterTopics`) against `listenerByName` and rebuilds the monitor once per change — registration bursts coalesce into one rebuild (debounced, as the issue asks), and delivery in the gap is covered by the fallback poll, which `addListenerForTopic` already triggers
- same treatment for `SingleCollectionMessaging` and `DualChannelMessaging`; `MultiCollectionMessaging` is per-topic by construction and needs no change
- new diagnostic `getCsFilterTopics()` alongside `getCsStallRestarts()`

**Backwards compatibility**

The filter only affects each instance's own cursor; mixed-version clusters are unaffected. Worst case (stale filter before rebuild) degrades to fallback-poll latency — no loss path, since the poll queries against the current listener set.

**Tests**

`TopicFilterChangeStreamTest` covers both implementations: listened-vs-foreign delivery, late-registration rebuild (including pickup of messages sent before registration), broadcast answers on unlistened topics reaching their waiter, and filter shrink on listener removal. Full messaging regression (13 classes, 48 tests) green on PooledDriver against a MongoDB 7 replica set and on InMemDriver.