### PR TITLE
fix(messaging): take the countAll out of the lock-release change-stream callback (#286)

### DIFF
--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/DualChannelMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/DualChannelMessaging.java
@@ -843,11 +843,14 @@ public class DualChannelMessaging extends Thread implements ShutdownListener, Mo
             List.of(Doc.of("$match", Doc.of("operationType", Doc.of("$eq", "delete")))));
         lockChangeStreamMonitor = lockMonitor;
         lockMonitor.addListener(evt -> {
-            // some lock removed
-            if (morphium.createQueryFor(Msg.class, getCollectionName()).f("_id").eq(evt.getDocumentKey()).countAll() != 0) {
-                // log.info("Lock CSE");
-                requestPoll.incrementAndGet();
-            }
+            // Some lock removed - ask for a poll. Deliberately no query here (#286): this runs on
+            // the change-stream callback thread, so a countAll per lock-delete event blocks the
+            // stream itself, and it buys nothing. requestPoll is a counter the poll loop reads,
+            // zeroes and answers with ONE findMessages(), so M lock deletes in a burst coalesce
+            // into a single poll either way - the gate traded M synchronous queries on this
+            // thread against at most one query in the poll thread. findMessages() decides what is
+            // actually pending, which it queries for correctly regardless.
+            requestPoll.incrementAndGet();
             return running;
         });
         changeStreamMonitor = new ChangeStreamMonitor(morphium, getCollectionName(), false, changeStreamMaxWait, pipeline);

--- a/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/messaging/SingleCollectionMessaging.java
@@ -864,11 +864,14 @@ public class SingleCollectionMessaging extends Thread implements ShutdownListene
             List.of(Doc.of("$match", Doc.of("operationType", Doc.of("$eq", "delete")))));
         lockChangeStreamMonitor = lockMonitor;
         lockMonitor.addListener(evt -> {
-            // some lock removed
-            if (morphium.createQueryFor(Msg.class, getCollectionName()).f("_id").eq(evt.getDocumentKey()).countAll() != 0) {
-                // log.info("Lock CSE");
-                requestPoll.incrementAndGet();
-            }
+            // Some lock removed - ask for a poll. Deliberately no query here (#286): this runs on
+            // the change-stream callback thread, so a countAll per lock-delete event blocks the
+            // stream itself, and it buys nothing. requestPoll is a counter the poll loop reads,
+            // zeroes and answers with ONE findMessages(), so M lock deletes in a burst coalesce
+            // into a single poll either way - the gate traded M synchronous queries on this
+            // thread against at most one query in the poll thread. findMessages() decides what is
+            // actually pending, which it queries for correctly regardless.
+            requestPoll.incrementAndGet();
             return running;
         });
         changeStreamMonitor = new ChangeStreamMonitor(morphium, getCollectionName(), false, changeStreamMaxWait, pipeline);


### PR DESCRIPTION
Closes #286.

The lock monitor's listener ran a synchronous query per lock-delete event, on every instance, **on the change-stream callback thread**:

```java
lockMonitor.addListener(evt -> {
    if (morphium.createQueryFor(Msg.class, getCollectionName())
            .f("_id").eq(evt.getDocumentKey()).countAll() != 0) {
        requestPoll.incrementAndGet();
    }
    return running;
});
```

Seven days of production logs from a 6.3.0 deployment show the cost: four `WATCH: callback took …` warnings in the week, **every one of them on `coll=msg_lck`** and none on the message collection, at 114ms, 114ms, 1705ms and **9812ms** — the two large ones twenty seconds apart during a message burst. Ten seconds of a blocked messaging change stream turns `sendAndAwait` calls into timeouts.

## Why the gate does not pay for itself

It was added in `2aa05b20` because the always-poll version "made every instance poll on every lock release". That misses the coalescing. `requestPoll` is an `AtomicInteger`, and the poll loop consumes it as (`SingleCollectionMessaging.java:962-968`):

```java
if (requestPoll.get() > 0 || !useChangeStream || shouldFallbackPoll) {
    ...
    requestPoll.set(0);
    boolean foundBacklog = findMessages();
```

Read, zero, **one** `findMessages()`. M lock deletes in a burst produce a single poll either way. So the gate traded M synchronous queries on the callback thread against at most one query in the poll thread — and since it sits on the callback thread, the cost shows up as a stalled stream rather than as query load.

## What this changes

The listener just increments. The 2023 guarantee behind the lock watch — prompt retry of a pending message whose lock disappeared — is untouched: the signal still fires on every lock delete, and `findMessages()` decides what is actually pending, which it queries for correctly regardless of what the listener believed. Worst case is one extra coalesced poll per poll-loop iteration, which is what the fallback poll costs anyway.

Same change in `DualChannelMessaging`, which forked this listener unchanged.

**Deliberately not done:** making the gate more selective (pendingness via `processed_by.0` instead of existence). That is the intuitive small fix and it does not help — the query stays on the callback thread, and the query is the stall. I went down that path first; the comment in the code now says so, to stop someone "repairing" the gate back in.

## Verification

Against a real 3-node MongoDB replica set with the `PooledDriver`, which is what actually exercises this code — on InMem/PoppyDB lock releases travel through the main stream, so the separate lock monitor barely runs there:

- full `messaging` tag: **140 tests, 0 failures, 0 errors**
- `ExclusiveOnceReproTest#exclusiveDoubleProcessedWhenLockLostMidProcessing`, covering exactly the guarantee this touches: green
- `ExclusiveMessageTests` (5) and `ExclusiveMessageBasicTests` (6): green, and green on the InMem driver too

## Scope

Diagnostics and cost only. Removing the lock monitor altogether, the `requeuedAt` marker and the pipeline clause for it stay in #285 for 6.4.0.

@Bardioc1977 — not your area, but @IainJennings may want to look, since this came out of his #285 and he has the symptom in production.
