### PR TITLE
PoppyDB: a restarted empty node can no longer wipe the replica set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,58 @@ analysis). The deduplication behavior is unchanged, only the log level.
 
 ### Fixed
 
+#### PoppyDB: a restarted empty node could wipe the whole replica set
+Reproduced kill chain: kill one node of a 3-node RS, restart it empty (fresh data dir), and it
+could both win the next election and cause the surviving, data-bearing followers to drop their
+local databases to match it. Two independent holes made this possible. First,
+`ElectionManager`'s Raft log-recency check existed but was vacuous — `lastLogIndex` had no
+production writer, so it stayed 0 on every node and an empty restarted candidate compared as
+"at least as up to date" as a voter sitting on real data. Second, on the follower side, a
+replication resume that finds its window already gone falls back to a full resync, and that
+fallback trusted whatever the primary reported unconditionally — reconnecting to a now-empty
+primary meant "wipe local data to match" with no discriminator between a legitimately empty
+primary (post-`dropDatabase`) and a stale one that had simply forgotten everything.
+
+The fix has three parts, each closing a different leg:
+- **Vote safety**: the log-recency check now enforces the one invariant that can be honestly
+  made without a real replicated log — a candidate reporting index 0 never wins against a voter
+  sitting above 0; three empty nodes still elect cleanly on cold start. A related hole let a
+  freshly-synced node still report index 0 to the election (initial sync suppresses the change
+  stream, so the normal live-write feed never fired) — such nodes now seed their true position
+  right after sync completes, so they neither wrongly grant votes to an empty candidate nor get
+  wrongly denied candidacy themselves.
+- **Candidacy restraint**: an empty node now holds off campaigning for as long as it can see a
+  data-bearing peer, preventing the term churn an empty node's repeated candidacies would
+  otherwise cause even after vote safety alone denies it the win.
+- **Fail-closed resync**: a follower now refuses a destructive drop-to-match resync whenever
+  the primary's replication sequence at registration is *behind* the sequence the follower's own
+  data was last known to reflect — the discriminator that tells a restarted/stale primary apart
+  from a legitimately empty one, since a real primary's sequence only ever advances, including
+  across a replicated `dropDatabase`. The refusal logs an ERROR, keeps local data intact, and
+  retries with a paced (2s) backoff until a genuinely caught-up primary answers or an operator
+  intervenes; the replication stats now expose `refusingDestructiveResync` /
+  `refusedResyncCount` so this state is observable rather than silent. Sequence knowledge now
+  also carries over across leader changes — a freshly constructed replication manager used to
+  start its own sequence at 0 and immediately self-seed from whatever the new leader reported,
+  which made the guard structurally unable to fire on that path.
+
+Composition note, stated plainly: the resync guard is a sequence-height heuristic, not a
+lineage check. A wrongly-promoted empty primary that manages to take on enough fresh writes
+before a follower reconnects could, in principle, still pass it — the guard alone is not the
+safety boundary. The actual barrier against that scenario is the election-side fix: an empty
+node must never be able to win the election in the first place, which is what vote safety and
+candidacy restraint together guarantee. The resync guard is defense in depth on top of that,
+not a substitute for it.
+
+Operator note: if the *last* data-bearing node in a cluster dies permanently, the surviving
+empty nodes deliberately hold back candidacy indefinitely rather than elect one of themselves —
+restarting any one of the survivors clears its peer-index memory and lets the cluster elect
+again, so recovery is "restart one node", not "restart the cluster".
+
+Regression coverage: `EmptyNodeRestartWipeTest` reproduces both directions of the original bug
+(empty node restarted as would-be primary, and as a would-be follower reconnecting to an empty
+primary) against a real in-process 3-node replica set.
+
 #### PoppyDB: j:true write concern no longer promises durability that does not exist
 A `j: true` write concern was silently accepted and acknowledged although PoppyDB has no
 journal (persistence is periodic snapshots). Like mongod running without journaling, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,20 +125,24 @@ The fix has three parts, each closing a different leg:
   data was last known to reflect — the discriminator that tells a restarted/stale primary apart
   from a legitimately empty one, since a real primary's sequence only ever advances, including
   across a replicated `dropDatabase`. The refusal logs an ERROR, keeps local data intact, and
-  retries with a paced (2s) backoff until a genuinely caught-up primary answers or an operator
-  intervenes; the replication stats now expose `refusingDestructiveResync` /
-  `refusedResyncCount` so this state is observable rather than silent. Sequence knowledge now
-  also carries over across leader changes — a freshly constructed replication manager used to
-  start its own sequence at 0 and immediately self-seed from whatever the new leader reported,
-  which made the guard structurally unable to fire on that path.
+  retries with watch re-registration paced at 2s and sync-loop retry backing off exponentially
+  from 1s to 30s, until a genuinely caught-up primary answers or an operator intervenes; the
+  replication stats now expose `refusingDestructiveResync` / `refusedResyncCount` so this state
+  is observable rather than silent. Sequence knowledge now also carries over across leader
+  changes — a freshly constructed replication manager used to start its own sequence at 0 and
+  immediately self-seed from whatever the new leader reported, which made the guard structurally
+  unable to fire on that path.
 
 Composition note, stated plainly: the resync guard is a sequence-height heuristic, not a
 lineage check. A wrongly-promoted empty primary that manages to take on enough fresh writes
 before a follower reconnects could, in principle, still pass it — the guard alone is not the
 safety boundary. The actual barrier against that scenario is the election-side fix: an empty
 node must never be able to win the election in the first place, which is what vote safety and
-candidacy restraint together guarantee. The resync guard is defense in depth on top of that,
-not a substitute for it.
+candidacy restraint together guarantee — guaranteed for the single-restart case; if a majority
+of nodes restart empty simultaneously, an empty node can still be elected (the fail-closed resync
+then still protects each surviving node's local data, but the cluster serves empty until a
+data-bearing node takes over). The resync guard is defense in depth on top of that, not a
+substitute for it.
 
 Operator note: if the *last* data-bearing node in a cluster dies permanently, the surviving
 empty nodes deliberately hold back candidacy indefinitely rather than elect one of themselves —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,12 @@ The fix has three parts, each closing a different leg:
   is observable rather than silent. Sequence knowledge now also carries over across leader
   changes — a freshly constructed replication manager used to start its own sequence at 0 and
   immediately self-seed from whatever the new leader reported, which made the guard structurally
-  unable to fire on that path.
+  unable to fire on that path. Change-stream sequences are primary-local: after a successful
+  sync/shortcut against a primary, a follower now *adopts* that primary's own counter as its new
+  base rather than keeping the higher of the two — the old and new primaries' counters are
+  unrelated numbers, and keeping a stale, inflated one made every later reconnect to that (still
+  perfectly healthy) primary look like a resume-window loss, which then tripped the guard against
+  the new primary's own honest, lower counter and refused every subsequent legitimate resync.
 
 Composition note, stated plainly: the resync guard is a sequence-height heuristic, not a
 lineage check. A wrongly-promoted empty primary that manages to take on enough fresh writes

--- a/poppydb/src/main/java/de/caluga/poppydb/PoppyDB.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/PoppyDB.java
@@ -154,6 +154,15 @@ public class PoppyDB {
     // the most recently known-good position. volatile: written only under the class monitor
     // (synchronized methods), but read here defensively for the same reason replicationManager is.
     private volatile long lastKnownAppliedSequence = 0;
+    // Companion to lastKnownAppliedSequence above (2026-08-14 production-CI fix, I-2): the
+    // "host:port" the watermark sequence was actually earned against - see
+    // ReplicationManager#carryOverLastAppliedSequence(long, String)'s javadoc for why comparing
+    // sequences across a genuine leader change is unsound (production incident: 82 refusal loops
+    // over 40+ minutes). Always updated TOGETHER with lastKnownAppliedSequence, from the same
+    // predecessor read, so the pair is never inconsistent with each other. null means "no
+    // predecessor ever recorded" (cold boot) - carryOverSourceFor()'s null result correctly never
+    // matches any real ReplicationManager#getLeaderAddress().
+    private volatile String lastKnownAppliedSequenceSource = null;
     // Held behind an AtomicReference (rather than a plain volatile field copied into each
     // connection at accept time) so every MongoCommandHandler resolves the coordinator live
     // via a Supplier - onLeadershipChange swaps this reference and every existing connection
@@ -905,27 +914,34 @@ public class PoppyDB {
             oldReplicationManager.stop();
             replicationManager = null;
         }
-        // carryOverSequenceFor() is called AFTER stop() returns, not before (2026-08-14 review
-        // hardening - TOCTOU): stop() flushes the batch processor's last drained batch before
-        // returning, which can still advance lastAppliedSequence past whatever a pre-stop
-        // snapshot would have captured. The reference is still valid here - stop() does not
-        // invalidate it, only the `replicationManager` field assignment above does - so this
-        // reads the predecessor's definitive final position instead of a possibly-stale one.
+        // carryOverSequenceFor()/carryOverSourceFor() are called AFTER stop() returns, not before
+        // (2026-08-14 review hardening - TOCTOU): stop() flushes the batch processor's last
+        // drained batch before returning, which can still advance lastAppliedSequence past
+        // whatever a pre-stop snapshot would have captured. The reference is still valid here -
+        // stop() does not invalidate it, only the `replicationManager` field assignment above
+        // does - so this reads the predecessor's definitive final position instead of a
+        // possibly-stale one.
         long carriedLastAppliedSequence = carryOverSequenceFor(oldReplicationManager);
+        // Paired with the sequence above (2026-08-14 production-CI fix, I-2) - see
+        // ReplicationManager#carryOverLastAppliedSequence(long, String)'s javadoc: the sequence
+        // alone is meaningless without knowing WHICH primary it was earned against, since a
+        // leader change is the normal case that makes two RMs' sequence spaces incomparable.
+        String carriedSource = carryOverSourceFor(oldReplicationManager);
 
         // Persist for a possible failed-start retry of THIS attempt (see lastKnownAppliedSequence's
         // javadoc): must happen regardless of whether newReplicationManager.start() below ever
-        // succeeds - if it throws, replicationManager stays null and only this field (not the
-        // oldReplicationManager local, which dies with this method invocation) survives into the
-        // next startReplicationToLeader() call the retry chain makes.
+        // succeeds - if it throws, replicationManager stays null and only these two fields (not
+        // the oldReplicationManager local, which dies with this method invocation) survive into
+        // the next startReplicationToLeader() call the retry chain makes. Always updated together.
         lastKnownAppliedSequence = carriedLastAppliedSequence;
+        lastKnownAppliedSequenceSource = carriedSource;
 
         String leaderHost = parts[0];
         int leaderPort = Integer.parseInt(parts[1]);
 
         // Start replication from new leader
         ReplicationManager newReplicationManager = new ReplicationManager(driver, leaderHost, leaderPort);
-        newReplicationManager.carryOverLastAppliedSequence(carriedLastAppliedSequence);
+        newReplicationManager.carryOverLastAppliedSequence(carriedLastAppliedSequence, carriedSource);
         newReplicationManager.setInternalConnectionSecurity(
                 authRequired, rootUser, rootPassword, sslEnabled ? internalSslContext : null);
         newReplicationManager.setMyAddress(host + ":" + port);
@@ -1703,6 +1719,20 @@ public class PoppyDB {
         return predecessor != null ? predecessor.getLastAppliedSequence() : lastKnownAppliedSequence;
     }
 
+    /**
+     * Companion to {@link #carryOverSequenceFor(ReplicationManager)} (2026-08-14 production-CI
+     * fix, I-2): the {@code "host:port"} the sequence returned by that method was actually earned
+     * against - a live predecessor's own {@link ReplicationManager#getLeaderAddress()}, or the
+     * durable {@link #lastKnownAppliedSequenceSource} watermark on a failed-start retry, mirroring
+     * {@code carryOverSequenceFor}'s own fallback exactly (same {@code predecessor} parameter,
+     * same null-means-fallback shape) so the two are always read as a matched pair. Passed
+     * together into {@link ReplicationManager#carryOverLastAppliedSequence(long, String)}, whose
+     * javadoc explains why the sequence is meaningless without this.
+     */
+    String carryOverSourceFor(ReplicationManager predecessor) {
+        return predecessor != null ? predecessor.getLeaderAddress() : lastKnownAppliedSequenceSource;
+    }
+
     /** Test hook: read the durable carry-over watermark (see {@link #lastKnownAppliedSequence}'s javadoc). */
     long getLastKnownAppliedSequenceForTest() {
         return lastKnownAppliedSequence;
@@ -1711,6 +1741,16 @@ public class PoppyDB {
     /** Test hook: seed the durable carry-over watermark without going through a real replication attempt. */
     void setLastKnownAppliedSequenceForTest(long sequence) {
         lastKnownAppliedSequence = sequence;
+    }
+
+    /** Test hook: read the durable carry-over source watermark (see its field javadoc). */
+    String getLastKnownAppliedSequenceSourceForTest() {
+        return lastKnownAppliedSequenceSource;
+    }
+
+    /** Test hook: seed the durable carry-over source watermark without a real replication attempt. */
+    void setLastKnownAppliedSequenceSourceForTest(String source) {
+        lastKnownAppliedSequenceSource = source;
     }
 
     public ElectionManager getElectionManager() {

--- a/poppydb/src/main/java/de/caluga/poppydb/PoppyDB.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/PoppyDB.java
@@ -879,6 +879,19 @@ public class PoppyDB {
             return;
         }
 
+        // Captured BEFORE stop()/nulling below, and BEFORE constructing the replacement: a fresh
+        // ReplicationManager's own lastAppliedSequence starts at 0, and its first watch
+        // registration would otherwise unconditionally seed it from whatever the NEW leader
+        // reports (recordPrimarySequenceAtRegistration's compareAndSet(0, primarySeq)) - making
+        // the destructive-resync guard in startInitialSyncOnce() vacuously pass every time on
+        // this path (see ReplicationManager#carryOverLastAppliedSequence's javadoc for the full
+        // "why"). Carrying the predecessor's real position forward is what lets that guard also
+        // protect a leader change, not just a same-address reconnect - defense-in-depth alongside
+        // the election-layer empty-vs-data invariant (Tasks 1/2/4). 0 (no predecessor, or a
+        // predecessor that never synced) is the correct cold-boot default and a no-op below.
+        long carriedLastAppliedSequence =
+                replicationManager != null ? replicationManager.getLastAppliedSequence() : 0;
+
         if (replicationManager != null) {
             replicationManager.stop();
             replicationManager = null;
@@ -889,6 +902,7 @@ public class PoppyDB {
 
         // Start replication from new leader
         ReplicationManager newReplicationManager = new ReplicationManager(driver, leaderHost, leaderPort);
+        newReplicationManager.carryOverLastAppliedSequence(carriedLastAppliedSequence);
         newReplicationManager.setInternalConnectionSecurity(
                 authRequired, rootUser, rootPassword, sslEnabled ? internalSslContext : null);
         newReplicationManager.setMyAddress(host + ":" + port);

--- a/poppydb/src/main/java/de/caluga/poppydb/PoppyDB.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/PoppyDB.java
@@ -892,6 +892,13 @@ public class PoppyDB {
         newReplicationManager.setInternalConnectionSecurity(
                 authRequired, rootUser, rootPassword, sslEnabled ? internalSslContext : null);
         newReplicationManager.setMyAddress(host + ":" + port);
+        // Follower-side half of the election log-recency feed (see ElectionManager#updateLogIndex's
+        // javadoc): keep our applied replication sequence flowing into ElectionManager so the
+        // vote-deny check has real data to compare against instead of a vacuous 0.
+        if (electionManager != null) {
+            newReplicationManager.setOnLogIndexUpdate((index, term) ->
+                    electionManager.updateLogIndex(index, electionManager.getCurrentTerm()));
+        }
         try {
             newReplicationManager.start();
             replicationManager = newReplicationManager;

--- a/poppydb/src/main/java/de/caluga/poppydb/PoppyDB.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/PoppyDB.java
@@ -142,6 +142,18 @@ public class PoppyDB {
     // volatile: mutated under synchronized on the election/leadership paths but read unsynchronized
     // from Netty event-loop threads via the isSecondarySyncing() supplier passed to each handler.
     private volatile ReplicationManager replicationManager = null;
+    // Durable carry-over watermark for ReplicationManager#carryOverLastAppliedSequence (2026-08-14
+    // review hardening). startReplicationToLeader() reads the predecessor RM's lastAppliedSequence
+    // into a purely LOCAL variable before building the replacement - which dies with the attempt
+    // if newReplicationManager.start() then throws (real, if narrow: an auth/TLS connect failure).
+    // replicationManager stays null in that case, so the retry chain's NEXT
+    // startReplicationToLeader() call would otherwise read 0 again, silently making the
+    // destructive-resync guard vacuous on the retry. This field persists that value across such
+    // retries independent of whether any particular attempt ever successfully starts - updated
+    // every time startReplicationToLeader() reads (and stops) a predecessor, so it always reflects
+    // the most recently known-good position. volatile: written only under the class monitor
+    // (synchronized methods), but read here defensively for the same reason replicationManager is.
+    private volatile long lastKnownAppliedSequence = 0;
     // Held behind an AtomicReference (rather than a plain volatile field copied into each
     // connection at accept time) so every MongoCommandHandler resolves the coordinator live
     // via a Supplier - onLeadershipChange swaps this reference and every existing connection
@@ -879,23 +891,34 @@ public class PoppyDB {
             return;
         }
 
-        // Captured BEFORE stop()/nulling below, and BEFORE constructing the replacement: a fresh
-        // ReplicationManager's own lastAppliedSequence starts at 0, and its first watch
-        // registration would otherwise unconditionally seed it from whatever the NEW leader
-        // reports (recordPrimarySequenceAtRegistration's compareAndSet(0, primarySeq)) - making
-        // the destructive-resync guard in startInitialSyncOnce() vacuously pass every time on
-        // this path (see ReplicationManager#carryOverLastAppliedSequence's javadoc for the full
-        // "why"). Carrying the predecessor's real position forward is what lets that guard also
-        // protect a leader change, not just a same-address reconnect - defense-in-depth alongside
-        // the election-layer empty-vs-data invariant (Tasks 1/2/4). 0 (no predecessor, or a
-        // predecessor that never synced) is the correct cold-boot default and a no-op below.
-        long carriedLastAppliedSequence =
-                replicationManager != null ? replicationManager.getLastAppliedSequence() : 0;
-
-        if (replicationManager != null) {
-            replicationManager.stop();
+        // Carries the predecessor RM's real position into the replacement (2026-08-14
+        // empty-node-wipe fix): a fresh ReplicationManager's own lastAppliedSequence starts at 0,
+        // and its first watch registration would otherwise unconditionally seed it from whatever
+        // the NEW leader reports (recordPrimarySequenceAtRegistration's compareAndSet(0,
+        // primarySeq)) - making the destructive-resync guard in startInitialSyncOnce() vacuously
+        // pass every time on this path (see ReplicationManager#carryOverLastAppliedSequence's
+        // javadoc for the full "why"). Carrying it forward is what lets that guard also protect a
+        // leader change, not just a same-address reconnect - defense-in-depth alongside the
+        // election-layer empty-vs-data invariant (Tasks 1/2/4).
+        ReplicationManager oldReplicationManager = replicationManager;
+        if (oldReplicationManager != null) {
+            oldReplicationManager.stop();
             replicationManager = null;
         }
+        // carryOverSequenceFor() is called AFTER stop() returns, not before (2026-08-14 review
+        // hardening - TOCTOU): stop() flushes the batch processor's last drained batch before
+        // returning, which can still advance lastAppliedSequence past whatever a pre-stop
+        // snapshot would have captured. The reference is still valid here - stop() does not
+        // invalidate it, only the `replicationManager` field assignment above does - so this
+        // reads the predecessor's definitive final position instead of a possibly-stale one.
+        long carriedLastAppliedSequence = carryOverSequenceFor(oldReplicationManager);
+
+        // Persist for a possible failed-start retry of THIS attempt (see lastKnownAppliedSequence's
+        // javadoc): must happen regardless of whether newReplicationManager.start() below ever
+        // succeeds - if it throws, replicationManager stays null and only this field (not the
+        // oldReplicationManager local, which dies with this method invocation) survives into the
+        // next startReplicationToLeader() call the retry chain makes.
+        lastKnownAppliedSequence = carriedLastAppliedSequence;
 
         String leaderHost = parts[0];
         int leaderPort = Integer.parseInt(parts[1]);
@@ -1656,6 +1679,38 @@ public class PoppyDB {
     /** Test hook: the secondary-side replication manager (null on a node that is currently primary). */
     ReplicationManager getReplicationManagerForTest() {
         return replicationManager;
+    }
+
+    /**
+     * The sequence to carry into a replacement {@link ReplicationManager} being started in
+     * {@link #startReplicationToLeader(String, long)}: the (already-stopped, but still readable)
+     * predecessor's own final position if one was actually stopped this attempt, otherwise the
+     * durable {@link #lastKnownAppliedSequence} watermark left behind by a previous attempt -
+     * which is exactly what a failed-start retry (predecessor {@code null}, since
+     * {@code replicationManager} was already nulled and no live RM survived to hand a value
+     * forward) falls back to instead of silently losing the position and reading a vacuous 0.
+     *
+     * <p>Deliberately pure (reads but never writes {@link #lastKnownAppliedSequence} - the
+     * caller persists the result separately) and package-private: lets a test exercise the
+     * fallback decision in isolation - including the {@code predecessor == null} branch that in
+     * production only a failed {@code newReplicationManager.start()} retry ever reaches - without
+     * needing to force a real synchronous {@code start()} throw (which in this driver stack
+     * realistically requires an auth/TLS connect mismatch; disproportionate machinery for
+     * covering this one fallback decision - see {@code carryOverSequenceFallsBackToPersistedWatermarkWhenNoPredecessor}
+     * in {@code ReplicationFailClosedTest}).
+     */
+    long carryOverSequenceFor(ReplicationManager predecessor) {
+        return predecessor != null ? predecessor.getLastAppliedSequence() : lastKnownAppliedSequence;
+    }
+
+    /** Test hook: read the durable carry-over watermark (see {@link #lastKnownAppliedSequence}'s javadoc). */
+    long getLastKnownAppliedSequenceForTest() {
+        return lastKnownAppliedSequence;
+    }
+
+    /** Test hook: seed the durable carry-over watermark without going through a real replication attempt. */
+    void setLastKnownAppliedSequenceForTest(long sequence) {
+        lastKnownAppliedSequence = sequence;
     }
 
     public ElectionManager getElectionManager() {

--- a/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
@@ -233,6 +233,15 @@ public class ReplicationManager {
     private final AtomicLong lastWatchResponseTime = new AtomicLong(0);
     private static final long STALENESS_THRESHOLD_MS = 30000; // 30 seconds without response = stale
 
+    // How long isContinued() sleeps before ending the watch while refusingDestructiveResync is
+    // true (2026-08-14 task-3 review fix). Paces the register/teardown cycle that refreshes
+    // lastKnownPrimarySequence - see the pacing comment at that isContinued() check for why this
+    // is load-bearing, not cosmetic. A fixed interval rather than mirroring the initial-sync
+    // thread's own growing 1s->30s backoff: that state lives on a different thread and this is a
+    // different loop (the watch's own getMore cadence, not the sync-decision retry cadence) -
+    // a fixed value in the same 1-5s ballpark is simpler and avoids coupling the two.
+    private static final long REFUSAL_WATCH_PACE_MS = 2000;
+
     // Callback to notify when log index is updated (for election consistency)
     private java.util.function.BiConsumer<Long, Long> onLogIndexUpdate;
 
@@ -1769,14 +1778,30 @@ public class ReplicationManager {
                         // on the primary sequence observed at that one registration forever, never
                         // discovering that the primary has since caught up ("a later caught-up
                         // leader syncs normally" would then require some UNRELATED event, e.g. a
-                        // real disconnect, to ever re-check). Ending this getMore loop here (this
-                        // method is polled every getMore round-trip, whether or not events arrived)
-                        // lets the replication loop's own retry immediately re-establish the watch,
-                        // which re-registers and refreshes the primary-sequence signal the
-                        // destructive-resync guard reads on its next attempt.
+                        // real disconnect, to ever re-check). Ending the watch here lets the
+                        // replication loop's own retry re-establish it, which re-registers and
+                        // refreshes the primary-sequence signal the destructive-resync guard reads
+                        // on its next attempt.
+                        //
+                        // PACING (2026-08-14 task-3 review fix): this is NOT reached only after a
+                        // maxTimeMS getMore wait as the earlier version of this comment assumed -
+                        // isContinued() is also checked immediately after the very first reply that
+                        // establishes the watch cursor (SingleMongoConnection.watch()'s post-
+                        // establishment check, before any getMore is ever issued), and
+                        // replicationLoop() calls watchForChanges() again with no sleep of its own
+                        // once it returns. Without an explicit sleep here those two facts combine
+                        // into an unbounded register/teardown spin against a possibly-troubled
+                        // primary - measured at ~1400 registrations/s in review, not the "~500ms,
+                        // bounded, self-limiting" cadence this comment used to (wrongly) claim. The
+                        // sleep paces every refusal retry, not just conceptually the first.
                         if (refusingDestructiveResync.get()) {
                             log.debug("Watch cycling while refusing a destructive resync, to refresh the "
                                     + "primary-sequence signal");
+                            try {
+                                Thread.sleep(REFUSAL_WATCH_PACE_MS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
                             return false;
                         }
                         return true;
@@ -2279,6 +2304,35 @@ public class ReplicationManager {
      */
     public long getLastAppliedSequence() {
         return lastAppliedSequence.get();
+    }
+
+    /**
+     * Seeds {@link #lastAppliedSequence} from a predecessor {@code ReplicationManager}'s value,
+     * carried across a leader-change instance replacement (2026-08-14 task-3 review fix, D2
+     * defense-in-depth). {@code PoppyDB#startReplicationToLeader} constructs a brand-new
+     * {@code ReplicationManager} on every leader change; a fresh instance's
+     * {@code lastAppliedSequence} starts at 0, and
+     * {@code recordPrimarySequenceAtRegistration()}'s own seed
+     * ({@code compareAndSet(0, primarySeq)}) then unconditionally adopts whatever the new
+     * leader reports - making {@code localSeqBeforeWipe == primarySeqAtRegistration} by
+     * construction and the destructive-resync guard in {@link #startInitialSyncOnce()} vacuously
+     * pass every time on this path (a primary can never be "behind" a local sequence it just
+     * supplied itself). Without carrying the predecessor's real position forward, this path was
+     * protected only by the election-layer empty-vs-data invariant (Tasks 1/2/4), not by this
+     * task's own guard.
+     *
+     * <p>Must be called before {@link #start()}, while {@code lastAppliedSequence} is still its
+     * untouched 0 default - enforced with the same {@code compareAndSet(0, ...)} idiom every
+     * other seed of this field uses (see {@link #recordPrimarySequenceAtRegistration}), so a
+     * second/late call, or one that races an already-started sync, is a safe no-op rather than a
+     * regression. A predecessor sequence of 0 (cold-boot / never-synced predecessor, or no
+     * predecessor at all) is intentionally a no-op - 0 is exactly the legitimate default for a
+     * genuinely fresh node with nothing to protect.
+     */
+    void carryOverLastAppliedSequence(long predecessorSequence) {
+        if (predecessorSequence > 0) {
+            lastAppliedSequence.compareAndSet(0, predecessorSequence);
+        }
     }
 
     /**

--- a/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
@@ -59,6 +59,19 @@ public class ReplicationManager {
     // Number of times the primary signalled "resume window lost" and we fell back to a full re-sync.
     // Exposed for tests/metrics to distinguish a clean resume (0) from a re-sync fallback.
     private final AtomicLong resyncCount = new AtomicLong(0);
+    // True while the initial-sync retry loop is refusing a destructive full re-sync (clear +
+    // snapshot, or a shortcut-driven equivalent) because the primary's reported sequence at the
+    // most recent watch registration is BEHIND the sequence our local data was last known to
+    // reflect - see the guard in startInitialSyncOnce(). Cleared as soon as an attempt's primary
+    // sequence catches back up (>= local), whether that attempt then takes the shortcut or a full
+    // sync. Exposed via getStats() so operators/tests can see a node that is deliberately holding
+    // onto its data rather than idly "still syncing".
+    private final AtomicBoolean refusingDestructiveResync = new AtomicBoolean(false);
+    // Number of times a destructive full re-sync was refused for the reason above. Monotonic
+    // counter, never reset - distinguishes "never needed to refuse" from "refused N times" in
+    // stats/tests, independent of the current (possibly already-cleared) refusingDestructiveResync
+    // flag.
+    private final AtomicLong refusedResyncCount = new AtomicLong(0);
     // Wall-clock time (System.currentTimeMillis()) of the previous resync, used to detect resyncs
     // repeating faster than the buffer can absorb (see triggerResync()). 0 = no resync yet.
     private final AtomicLong lastResyncTimestamp = new AtomicLong(0);
@@ -1023,6 +1036,37 @@ public class ReplicationManager {
                         }
 
                         if (!shortcut) {
+                            // Fail-closed destructive-resync guard (D2, 2026-08-14 empty-node-wipe
+                            // fix): a legitimate primary NEVER regresses its own change-stream
+                            // sequence counter - not even a real, replicated dropDatabase, which is
+                            // itself an event and therefore ADVANCES the counter. A primary whose
+                            // sequence at THIS watch registration is BEHIND the sequence our local
+                            // data was last known to reflect can therefore only be a freshly
+                            // restarted/stale process that reset its counter to 0 (or an older
+                            // build's "resume window lost" chain that lost the original data's
+                            // provenance) - not a trustworthy source of "the real current state".
+                            // Wiping local data to match it would be the exact kill chain this fix
+                            // closes: a restarted, empty node winning re-election (or simply coming
+                            // back up on the same address) and every follower dropping its real
+                            // data to match it. Refuse instead: keep the data, keep retrying with
+                            // backoff - a later, genuinely caught-up primary (sequence >= ours)
+                            // un-sticks this on its own, no manual intervention needed.
+                            long primarySeqAtRegistration = lastKnownPrimarySequence.get();
+                            long localSeqBeforeWipe = lastAppliedSequence.get();
+
+                            if (primarySeqAtRegistration < localSeqBeforeWipe) {
+                                log.error("refusing full re-sync: primary sequence {} is behind local {} - "
+                                        + "possible restarted/stale primary, keeping local data",
+                                        primarySeqAtRegistration, localSeqBeforeWipe);
+                                refusingDestructiveResync.set(true);
+                                refusedResyncCount.incrementAndGet();
+                                Thread.sleep(backoffMs);
+                                backoffMs = Math.min(backoffMs * 2, 30_000);
+                                continue;
+                            }
+
+                            refusingDestructiveResync.set(false);
+
                             // Start each attempt from a clean local slate so a retry after a
                             // partially-successful copy doesn't fail on already-copied documents.
                             // The flag is set BEFORE the clear: even a clear that throws partway
@@ -1056,6 +1100,30 @@ public class ReplicationManager {
                             continue;
                         }
 
+                        // Not (or no longer) refusing: this attempt is about to declare success,
+                        // whether via the shortcut or a full copy, both of which require the guard
+                        // above to have passed (or never triggered - shortcut skips it entirely,
+                        // but a matching dbHash on non-trivial data is itself strong evidence of a
+                        // legitimate, caught-up primary).
+                        refusingDestructiveResync.set(false);
+
+                        // Reseed lastAppliedSequence to this attempt's confirmed primary sequence
+                        // now that we are declaring success. recordPrimarySequenceAtRegistration()'s
+                        // own reseed (compareAndSet(0, primarySeq), fired earlier THIS cycle at
+                        // watch registration) only takes effect when lastAppliedSequence was still
+                        // exactly 0 at that moment - which it deliberately was NOT whenever this
+                        // cycle preserved a pre-existing local sequence for the destructive-resync
+                        // guard above (see triggerResync() - it no longer zeroes this field, so the
+                        // guard can compare the primary's regressed sequence against our real local
+                        // position). Without this, a resynced/shortcut-matched node would keep
+                        // reporting its OLD, pre-resync sequence downstream (the next resumeAfter
+                        // token, the election feed below) instead of its actual, now-current
+                        // position. Math.max rather than a blind set(): monotonic, matching every
+                        // other update to this field, and a safe no-op on the ordinary (never
+                        // regressed) path where the registration-time compareAndSet already applied
+                        // the same value.
+                        lastAppliedSequence.updateAndGet(current -> Math.max(current, lastKnownPrimarySequence.get()));
+
                         // Success: open the gate. The batch processor now drains the events
                         // buffered during the snapshot (idempotent replay) and all subsequent live
                         // events, in order.
@@ -1067,10 +1135,10 @@ public class ReplicationManager {
                         // Seed the election layer's view of our replication position now that we
                         // hold the primary's dataset (either path: full snapshot or consistency
                         // shortcut both land here). lastAppliedSequence is already correct at this
-                        // point - recordPrimarySequenceAtRegistration() seeded it from the
-                        // primary's sequence at watch registration, before this snapshot even
-                        // started copying (see that method's javadoc). Without this call, a
-                        // freshly-synced node that then applies zero LIVE events would never reach
+                        // point (either seeded at registration when it started at 0, or reseeded
+                        // just above when it did not) - see the reseed comment above for the full
+                        // picture. Without this, a freshly-synced node that then applies zero LIVE
+                        // events would never reach
                         // processBatch()'s onLogIndexUpdate call (it only fires when there is
                         // something in eventQueue to drain) and would keep reporting index 0 to
                         // ElectionManager despite actually holding real data - wrongly granting
@@ -1694,6 +1762,23 @@ public class ReplicationManager {
                                     now - lastResponse);
                             return false;
                         }
+                        // While refusing a destructive resync (see the guard in
+                        // startInitialSyncOnce()), recordPrimarySequenceAtRegistration() only ever
+                        // refreshes lastKnownPrimarySequence at watch REGISTRATION - a live watch
+                        // session registers exactly once, so without this, a refusal would freeze
+                        // on the primary sequence observed at that one registration forever, never
+                        // discovering that the primary has since caught up ("a later caught-up
+                        // leader syncs normally" would then require some UNRELATED event, e.g. a
+                        // real disconnect, to ever re-check). Ending this getMore loop here (this
+                        // method is polled every getMore round-trip, whether or not events arrived)
+                        // lets the replication loop's own retry immediately re-establish the watch,
+                        // which re-registers and refreshes the primary-sequence signal the
+                        // destructive-resync guard reads on its next attempt.
+                        if (refusingDestructiveResync.get()) {
+                            log.debug("Watch cycling while refusing a destructive resync, to refresh the "
+                                    + "primary-sequence signal");
+                            return false;
+                        }
                         return true;
                     }
                 });
@@ -1797,10 +1882,25 @@ public class ReplicationManager {
     /**
      * Fall back to a full re-initial-sync after the primary signalled that our resume point is no
      * longer replayable. Rearms the Task 8 initial-sync machinery: closes the apply gate, resets the
-     * sync flags so {@link #startInitialSyncOnce()} launches a fresh snapshot, drops the events left
-     * over from the lost window, and resets the sequence so the next watch starts fresh (no
-     * resumeAfter) instead of re-requesting the same lost window in a loop. The replication loop then
-     * re-runs initial sync + watch on its next iteration.
+     * sync flags so {@link #startInitialSyncOnce()} launches a fresh snapshot, and drops the events
+     * left over from the lost window. The replication loop then re-runs initial sync + watch on its
+     * next iteration.
+     *
+     * <p>Deliberately does NOT reset {@code lastAppliedSequence} to 0 (unlike before the 2026-08-14
+     * empty-node-wipe fix). {@code initialSyncComplete} is already false at this point, which alone
+     * already suppresses the next watch's {@code resumeAfter} (see the {@code initialSyncComplete.get()
+     * && resumeSeq > 0} guard in {@link #watchForChanges()}) - zeroing the sequence was never load-
+     * bearing for that. It WAS, however, load-bearing for a hazard: zeroing it here made
+     * {@code recordPrimarySequenceAtRegistration()}'s reseed ({@code compareAndSet(0, primarySeq)})
+     * fire unconditionally on the very next registration, silently replacing our real local data's
+     * last-known-good sequence with whatever the new/possibly-empty primary reports - which is
+     * exactly what let {@link #startInitialSyncOnce()}'s destructive-resync guard be defeated: by the
+     * time that guard ran, the honest "how far behind is this primary" signal was already gone.
+     * Preserving the value here is what lets that guard compare the primary's regressed sequence
+     * against our data's true position instead of a freshly-overwritten 0. The now-stale value is
+     * reseeded explicitly, and correctly, once a sync attempt actually succeeds (or is legitimately
+     * allowed to proceed) - see the reseed at the "not (or no longer) refusing" point in
+     * {@link #startInitialSyncOnce()}.
      */
     private void triggerResync(long fromSequence) {
         long n = resyncCount.incrementAndGet();
@@ -1817,7 +1917,6 @@ public class ReplicationManager {
         initialSyncComplete.set(false);
         initialSyncStarted.set(false);  // allow startInitialSyncOnce() to launch a new snapshot
         watchLive.set(false);
-        lastAppliedSequence.set(0);     // resume fresh; next watch sends no resumeAfter
         lastReportedSequence.set(0);
         eventQueue.clear();             // discard events buffered for the lost window
     }
@@ -1841,6 +1940,20 @@ public class ReplicationManager {
     /** Number of times replication fell back to a full re-sync because the resume window was lost. */
     long getResyncCount() {
         return resyncCount.get();
+    }
+
+    /**
+     * True while this node is currently refusing a destructive full re-sync because the primary's
+     * sequence regressed below our local data's (see {@link #getStats()}'s
+     * {@code refusingDestructiveResync}).
+     */
+    boolean isRefusingDestructiveResync() {
+        return refusingDestructiveResync.get();
+    }
+
+    /** Lifetime count of destructive-resync refusals (see {@link #isRefusingDestructiveResync()}). */
+    long getRefusedResyncCount() {
+        return refusedResyncCount.get();
     }
 
     /**
@@ -2107,6 +2220,12 @@ public class ReplicationManager {
      * of MongoDB's RECOVERING member: it must not serve data-plane reads or writes. Returns false
      * once the initial sync has completed and the local database is a consistent replica, and false
      * after {@link #stop()} (running == false).
+     *
+     * <p>Also true while {@link #isRefusingDestructiveResync()} holds - a node refusing a
+     * destructive resync has NOT re-completed initial sync against the (currently untrusted) primary,
+     * even though, unlike the ordinary half-cleared case this javadoc otherwise describes, its local
+     * database is fully intact and deliberately left untouched. It is still treated as RECOVERING
+     * here (conservative: correctness over availability) rather than carved out as a distinct state.
      */
     public boolean isSyncing() {
         return running.get() && !initialSyncComplete.get();
@@ -2134,6 +2253,12 @@ public class ReplicationManager {
         stats.put("lastReportedSequence", lastReportedSequence.get());
         stats.put("lastKnownPrimarySequence", lastKnownPrimarySequence.get());
         stats.put("resyncCount", resyncCount.get());
+        // D2 (2026-08-14 empty-node-wipe fix): true while this node is deliberately refusing a
+        // destructive full re-sync because the primary's sequence regressed below our local data's
+        // - see the guard in startInitialSyncOnce(). refusedResyncCount is the monotonic lifetime
+        // count of such refusals, independent of whether the flag is currently set.
+        stats.put("refusingDestructiveResync", refusingDestructiveResync.get());
+        stats.put("refusedResyncCount", refusedResyncCount.get());
         stats.put("primaryHost", primaryHost + ":" + primaryPort);
         stats.put("myAddress", myAddress);
         stats.put("eventQueueSize", eventQueue.size());

--- a/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
@@ -1063,6 +1063,25 @@ public class ReplicationManager {
                         applying.set(true);
                         initialSyncComplete.set(true);
                         initialSyncLatch.countDown();
+
+                        // Seed the election layer's view of our replication position now that we
+                        // hold the primary's dataset (either path: full snapshot or consistency
+                        // shortcut both land here). lastAppliedSequence is already correct at this
+                        // point - recordPrimarySequenceAtRegistration() seeded it from the
+                        // primary's sequence at watch registration, before this snapshot even
+                        // started copying (see that method's javadoc). Without this call, a
+                        // freshly-synced node that then applies zero LIVE events would never reach
+                        // processBatch()'s onLogIndexUpdate call (it only fires when there is
+                        // something in eventQueue to drain) and would keep reporting index 0 to
+                        // ElectionManager despite actually holding real data - wrongly granting
+                        // votes to genuinely empty candidates as voter, and wrongly denied as
+                        // candidate. updateLogIndex()'s monotonic (max) semantics make this safe to
+                        // call unconditionally: it can only raise ElectionManager's view, never
+                        // regress it.
+                        long syncedSeq = lastAppliedSequence.get();
+                        if (onLogIndexUpdate != null && syncedSeq > 0) {
+                            onLogIndexUpdate.accept(syncedSeq, 0L);
+                        }
                         return;
                     } catch (Exception e) {
                         // Snapshot failed while the watch may still be healthy. Retry from within

--- a/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
@@ -1116,22 +1116,47 @@ public class ReplicationManager {
                         // legitimate, caught-up primary).
                         refusingDestructiveResync.set(false);
 
-                        // Reseed lastAppliedSequence to this attempt's confirmed primary sequence
-                        // now that we are declaring success. recordPrimarySequenceAtRegistration()'s
-                        // own reseed (compareAndSet(0, primarySeq), fired earlier THIS cycle at
-                        // watch registration) only takes effect when lastAppliedSequence was still
-                        // exactly 0 at that moment - which it deliberately was NOT whenever this
-                        // cycle preserved a pre-existing local sequence for the destructive-resync
-                        // guard above (see triggerResync() - it no longer zeroes this field, so the
-                        // guard can compare the primary's regressed sequence against our real local
-                        // position). Without this, a resynced/shortcut-matched node would keep
-                        // reporting its OLD, pre-resync sequence downstream (the next resumeAfter
-                        // token, the election feed below) instead of its actual, now-current
-                        // position. Math.max rather than a blind set(): monotonic, matching every
-                        // other update to this field, and a safe no-op on the ordinary (never
-                        // regressed) path where the registration-time compareAndSet already applied
-                        // the same value.
-                        lastAppliedSequence.updateAndGet(current -> Math.max(current, lastKnownPrimarySequence.get()));
+                        // Adopt this attempt's confirmed primary sequence as our new base now that
+                        // we are declaring success (I-1, 2026-08-14 final review fix). A plain
+                        // set(), NOT Math.max(current, ...): change-stream sequences are
+                        // PRIMARY-LOCAL (see tryConsistencyShortcut's own javadoc on this) - the
+                        // OLD lastAppliedSequence (from whatever primary we last successfully
+                        // tracked, possibly a dead one with a much HIGHER counter than this brand
+                        // new/still-quiet primary) lives in a completely different, incomparable
+                        // number space from THIS primary's. Taking the max of two unrelated
+                        // counters is not "the safer of two options", it is meaningless - and
+                        // concretely harmful: it left this node believing it needed to resume
+                        // after a sequence number the new primary's own history could never
+                        // contain, so the very next reconnect always hit "resume window lost" ->
+                        // a dbHash mismatch (as soon as one real write happened) -> the D2 guard
+                        // above comparing the new primary's still-low counter against that stale
+                        // inherited high-water mark -> refusing an entirely LEGITIMATE resync,
+                        // unbounded on a quiet cluster (the new primary would need N more writes
+                        // before its counter ever caught up to the old primary's abandoned one).
+                        // "Having successfully synced against THIS primary, its base is my base."
+                        //
+                        // Two compositions this set() must not break, both verified safe:
+                        //
+                        // (1) The election feed just below must not regress. It doesn't:
+                        // ElectionManager#updateLogIndex is ITSELF monotonic-max internally
+                        // (`if (index >= lastLogIndex.get())`, a lower index is silently a no-op)
+                        // - so adopting a LOWER base here can at most make the value THIS method
+                        // reports go down, never the election's own recorded lastLogIndex. The
+                        // monotonic guarantee Task 1 relies on lives in ElectionManager, by
+                        // design, precisely so a primary-local counter reset on THIS side can
+                        // never regress it - see updateLogIndex's own javadoc.
+                        //
+                        // (2) Events buffered during the sync window are not lost. Every event
+                        // sitting in eventQueue right now was captured by the watch AFTER this
+                        // same registration (recordPrimarySequenceAtRegistration ran, and hence
+                        // lastKnownPrimarySequence was captured, at the START of this sync cycle -
+                        // strictly before any of those events could have arrived), so every
+                        // buffered event's own sequence number is >= lastKnownPrimarySequence.
+                        // Setting lastAppliedSequence to that lower bound now and then draining
+                        // the gate is safe: applyChangeEvent/applyBulkInserts advance it further
+                        // via their own per-event Math.max as each buffered (and all subsequent
+                        // live) event is applied - nothing regresses, nothing is skipped.
+                        lastAppliedSequence.set(lastKnownPrimarySequence.get());
 
                         // Success: open the gate. The batch processor now drains the events
                         // buffered during the snapshot (idempotent replay) and all subsequent live

--- a/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/ReplicationManager.java
@@ -2332,6 +2332,18 @@ public class ReplicationManager {
     }
 
     /**
+     * This instance's own replication target, in {@code "host:port"} form - the identity a
+     * carried sequence must match to be comparable (see the two-arg
+     * {@link #carryOverLastAppliedSequence(long, String)} overload). {@code primaryHost}/
+     * {@code primaryPort} are final, set once at construction and never updated for the life of
+     * this instance (see the field javadocs) - a leader change always replaces the whole
+     * {@code ReplicationManager}, it never repoints an existing one.
+     */
+    String getLeaderAddress() {
+        return primaryHost + ":" + primaryPort;
+    }
+
+    /**
      * Seeds {@link #lastAppliedSequence} from a predecessor {@code ReplicationManager}'s value,
      * carried across a leader-change instance replacement (2026-08-14 task-3 review fix, D2
      * defense-in-depth). {@code PoppyDB#startReplicationToLeader} constructs a brand-new
@@ -2346,6 +2358,15 @@ public class ReplicationManager {
      * protected only by the election-layer empty-vs-data invariant (Tasks 1/2/4), not by this
      * task's own guard.
      *
+     * <p><b>Superseded by the two-arg overload below for production use</b> (2026-08-14
+     * production-CI fix, I-2): calling this single-arg form unconditionally is only correct when
+     * the caller has already established that the carried sequence was earned against THIS SAME
+     * primary - see that overload's javadoc for why blindly carrying a value across a genuine
+     * leader change caused a real incident (82 refusal loops on poppydb.fritz.box). Kept
+     * package-private (not deleted) because it is still exactly right for that one case - the
+     * two-arg overload delegates to it - and because tests exercise it directly to seed a
+     * {@code ReplicationManager} without a live connection.
+     *
      * <p>Must be called before {@link #start()}, while {@code lastAppliedSequence} is still its
      * untouched 0 default - enforced with the same {@code compareAndSet(0, ...)} idiom every
      * other seed of this field uses (see {@link #recordPrimarySequenceAtRegistration}), so a
@@ -2358,6 +2379,56 @@ public class ReplicationManager {
         if (predecessorSequence > 0) {
             lastAppliedSequence.compareAndSet(0, predecessorSequence);
         }
+    }
+
+    /**
+     * Primary-identity-aware carry-over (2026-08-14 production-CI fix, I-2): the single-arg
+     * overload above blindly arms the destructive-resync guard with the predecessor's carried
+     * sequence, which is only sound when that sequence was earned against THIS SAME primary.
+     * Change-stream sequences are PRIMARY-LOCAL (see {@code tryConsistencyShortcut}'s own
+     * javadoc), and a LEADER CHANGE - the very reason a carry-over happens at all - is the NORMAL
+     * case that makes two RMs' sequence spaces incomparable, not a rare edge case. Production
+     * evidence (poppydb.fritz.box CI, branch fix/poppydb-empty-node-wipe): after a real leader
+     * change under messaging load, a follower carried {@code lastAppliedSequence} 227951 from the
+     * old leader's space; the new leader's own (entirely unrelated) counter was 213896. Every
+     * reconnect logged "refusing full re-sync: primary sequence 213896 is behind local 227951"
+     * every 1-2s for 40+ minutes - the node stuck RECOVERING, three messaging test classes timed
+     * out. The commit that made a successful sync ADOPT the synced primary's base
+     * ({@code lastAppliedSequence.set(lastKnownPrimarySequence.get())}, see the reseed comment in
+     * {@link #startInitialSyncOnce()}) could not help: adoption only runs AFTER a successful sync,
+     * and the guard - armed with the foreign 227951 - was exactly what blocked that sync from ever
+     * succeeding. Hen-and-egg.
+     *
+     * <p>{@code predecessorSourceAddress} is the {@code "host:port"} the carried sequence was
+     * actually earned against (see {@link #getLeaderAddress()}), or {@code null} if there was no
+     * live predecessor at all. Two cases:
+     * <ul>
+     *   <li><b>Matches this instance's own {@link #getLeaderAddress()}</b> - the true kill chain:
+     *       the SAME node (address-wise) restarted empty/stale, or - the other route into this
+     *       state - the intra-RM {@code triggerResync()} retry path, where the primary literally
+     *       cannot have changed (one {@code ReplicationManager}'s {@code primaryHost}/
+     *       {@code primaryPort} are final). Arm the guard exactly as before, via
+     *       {@link #carryOverLastAppliedSequence(long)}.</li>
+     *   <li><b>Any other address, including {@code null}</b> - a genuinely different primary (or
+     *       no predecessor at all). The carried sequence must NOT arm the guard - it lives in an
+     *       unrelated number space. Deliberately a no-op here: {@code lastAppliedSequence} is left
+     *       at its 0 default, so {@code recordPrimarySequenceAtRegistration()}'s EXISTING
+     *       {@code compareAndSet(0, primarySeq)} seed (unconditionally live for every instance,
+     *       not something this method needs to duplicate) adopts THIS primary's own base the
+     *       moment it is first learned at watch registration - "let dbHash/the consistency
+     *       shortcut decide whether a resync is actually needed", exactly as a genuinely fresh
+     *       node would. This is a deliberate scope boundary, not a gap: a wrongly-elected empty
+     *       primary that has itself taken on enough fresh writes could still pass a subsequent
+     *       resync decision - the actual barrier against that is the election-layer invariant
+     *       (Tasks 1/2/4, "an empty node must never win against a data-bearing voter"), not this
+     *       guard.</li>
+     * </ul>
+     */
+    void carryOverLastAppliedSequence(long predecessorSequence, String predecessorSourceAddress) {
+        if (getLeaderAddress().equals(predecessorSourceAddress)) {
+            carryOverLastAppliedSequence(predecessorSequence);
+        }
+        // else: different primary (or no predecessor) - see javadoc; intentionally not armed.
     }
 
     /**

--- a/poppydb/src/main/java/de/caluga/poppydb/election/ElectionManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/election/ElectionManager.java
@@ -40,6 +40,13 @@ public class ElectionManager {
     private final AtomicLong lastLogIndex = new AtomicLong(0);
     private final AtomicLong lastLogTerm = new AtomicLong(0);
 
+    // Candidacy restraint (D3, empty-node-wipe fix): highest lastLogIndex this process has ever
+    // observed reported by ANY peer via AppendEntries/heartbeat traffic - the leader's own index
+    // (advertised as prevLogIndex while we are a follower) or a follower's matchIndex (while we
+    // are the leader). Used solely to hold back becomeCandidate() while we are empty; see the
+    // guard there and its javadoc for the full rationale.
+    private final AtomicLong highestPeerLogIndexSeen = new AtomicLong(0);
+
     // Election bookkeeping
     private final Set<String> votesReceived = ConcurrentHashMap.newKeySet();
     private volatile long lastHeartbeatTime = 0;
@@ -258,6 +265,20 @@ public class ElectionManager {
         // Check if blocked from recent stepdown
         if (isElectionBlocked()) {
             log.debug("{} is blocked from election (recent stepdown), waiting...", myAddress);
+            resetElectionTimer();
+            return;
+        }
+
+        // Candidacy restraint (D3, empty-node-wipe fix): we are empty (nothing applied/produced
+        // this process lifetime) but have observed a peer that holds real data. Starting an
+        // election now can only lose - handleVoteRequest's isLogAtLeastAsUpToDate check denies
+        // us on every data-holding voter - while still inflating the term and forcing the
+        // legitimate leader into a pointless step-down. Hold back until either our own index
+        // catches up (sync completes - Task 1's seed makes this prompt) or - cold start, no
+        // data-bearing peer ever observed - there is nothing to defer to.
+        if (lastLogIndex.get() == 0 && highestPeerLogIndexSeen.get() > 0) {
+            log.debug("{} holding back candidacy: empty (index=0) but a peer has reported index {} - waiting for sync",
+                    myAddress, highestPeerLogIndexSeen.get());
             resetElectionTimer();
             return;
         }
@@ -702,6 +723,11 @@ public class ElectionManager {
             lastHeartbeatTime = System.currentTimeMillis();
             currentLeader = request.getLeaderId();
 
+            // Candidacy restraint (D3): the leader's own index, advertised as prevLogIndex on
+            // every heartbeat (see sendHeartbeats), tells us whether the cluster has real data
+            // even while our own lastLogIndex is still 0.
+            recordPeerLogIndex(request.getPrevLogIndex());
+
             // If we were a candidate, step down
             if (state == ElectionState.CANDIDATE) {
                 log.info("{} stepping down from candidate (received heartbeat from leader {})",
@@ -765,6 +791,10 @@ public class ElectionManager {
                 // Extend our lease since we got a response
                 leaseExpiryTime = System.currentTimeMillis() + config.getLeaderLeaseTimeoutMs();
                 peerLastContact.put(peer, System.currentTimeMillis());
+
+                // Candidacy restraint (D3): a follower's matchIndex tells us it holds real data,
+                // relevant if we ever step down and end up empty ourselves (e.g. after a resync).
+                recordPeerLogIndex(response.getMatchIndex());
 
                 // Nodes older than priority takeover omit the field and report -1
                 if (response.getPriority() >= 0) {
@@ -1010,6 +1040,19 @@ public class ElectionManager {
 
     public boolean isRunning() {
         return running;
+    }
+
+    /**
+     * Records the highest lastLogIndex we have observed reported by ANY peer via
+     * AppendEntries/heartbeat traffic (see {@link #highestPeerLogIndexSeen}). Monotonic (max),
+     * same rationale as {@link #updateLogIndex}: this is used purely as a "have we ever seen a
+     * data-bearing peer" signal for the candidacy-restraint guard in {@link #becomeCandidate()},
+     * so a peer's index momentarily appearing lower (e.g. it just restarted itself) must not
+     * make this node newly eligible to race for an election it would still lose against that
+     * same peer once it resyncs.
+     */
+    private void recordPeerLogIndex(long peerIndex) {
+        highestPeerLogIndexSeen.updateAndGet(current -> Math.max(current, peerIndex));
     }
 
     /**

--- a/poppydb/src/main/java/de/caluga/poppydb/election/ElectionManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/election/ElectionManager.java
@@ -1013,17 +1013,25 @@ public class ElectionManager {
     }
 
     /**
-     * Update log index/term. Two production callers keep this fed with the real replication
-     * sequence, one per role:
+     * Update log index/term. Three production callers keep this fed with the real replication
+     * sequence:
      * <ul>
      *   <li><b>Leader:</b> {@link #sendHeartbeats()} calls this every heartbeat with
      *       {@code localSequenceSupplier}'s current value (wired by PoppyDB to
      *       {@code driver::getChangeStreamSequence}) and {@code currentTerm} - the same supplier
      *       already used for priority-takeover catch-up checks.</li>
-     *   <li><b>Follower:</b> {@code ReplicationManager}'s {@code onLogIndexUpdate} hook, wired by
-     *       PoppyDB in {@code startReplicationToLeader}, calls this after every applied batch
-     *       with {@code lastAppliedSequence} and this node's own {@code currentTerm} (substituted
-     *       for the term {@code ReplicationManager} passes, which it has no way to know).</li>
+     *   <li><b>Follower, live events:</b> {@code ReplicationManager}'s {@code onLogIndexUpdate}
+     *       hook, wired by PoppyDB in {@code startReplicationToLeader}, calls this after every
+     *       applied batch with {@code lastAppliedSequence} and this node's own {@code
+     *       currentTerm} (substituted for the term {@code ReplicationManager} passes, which it
+     *       has no way to know).</li>
+     *   <li><b>Follower, initial sync:</b> the same hook is also called once, immediately after
+     *       an initial sync (full snapshot or consistency-shortcut) completes, with the sequence
+     *       seeded at watch registration ({@code recordPrimarySequenceAtRegistration}). Without
+     *       this a freshly-synced node that then applies zero live events would never reach the
+     *       live-event call above and would keep reporting index {@code 0} to this class despite
+     *       holding real data - see that call site's comment in {@code ReplicationManager} for
+     *       the full mechanism.</li>
      * </ul>
      *
      * <p>Term is still passed through as {@code currentTerm} and stored in {@code lastLogTerm}
@@ -1039,12 +1047,23 @@ public class ElectionManager {
      * method exists to close (a once-elected, now-empty node carrying a high stale term at index
      * 0 outranking a real data-holding voter). Index-only comparison side-steps this entirely.
      *
+     * <p><b>Monotonic (max) index:</b> {@code index} is only ever raised, never lowered - a call
+     * with an {@code index} lower than the current value is a no-op. This is required, not just
+     * defensive: the initial-sync seed above can set a real, non-zero index before this node has
+     * applied or produced any live event of its own; the leader-side heartbeat feed
+     * ({@link #sendHeartbeats()}) reads the LOCAL driver's change-stream sequence, which initial
+     * sync deliberately runs under {@code suppressChangeStreamEvents()} and therefore never
+     * advances for synced data. Without monotonic semantics, the very next heartbeat after
+     * becoming leader (or the next call from either feed racing the other) would silently
+     * overwrite the seeded value back down to {@code 0}, reopening the empty-node-wipe bug for
+     * exactly the freshly-synced node the seed exists to protect.
+     *
      * <p>Thread-safety: called from two independent, unsynchronized threads - the leader's
      * heartbeat scheduler ({@link #sendHeartbeats()}) and the follower's replication batch
      * processor (via the {@code onLogIndexUpdate} hook wired in PoppyDB). Takes {@code
-     * stateLock} for the duration of the two writes so they can never interleave with each other
-     * or with {@link #handleVoteRequest}'s read of both fields (which already runs under the
-     * same lock).
+     * stateLock} for the duration of the read-compare-write so it can never interleave with
+     * itself or with {@link #handleVoteRequest}'s read of both fields (which already runs under
+     * the same lock).
      *
      * <p>Because both process state and this in-memory field reset to {@code 0} on restart, a
      * node whose local database was just cleared for a resync (e.g. mid-{@code
@@ -1056,8 +1075,10 @@ public class ElectionManager {
     public void updateLogIndex(long index, long term) {
         stateLock.lock();
         try {
-            lastLogIndex.set(index);
-            lastLogTerm.set(term);
+            if (index >= lastLogIndex.get()) {
+                lastLogIndex.set(index);
+                lastLogTerm.set(term);
+            }
         } finally {
             stateLock.unlock();
         }

--- a/poppydb/src/main/java/de/caluga/poppydb/election/ElectionManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/election/ElectionManager.java
@@ -488,6 +488,14 @@ public class ElectionManager {
             // Check if candidate's log is at least as up-to-date as ours
             boolean logOk = isLogAtLeastAsUpToDate(request.getLastLogTerm(), request.getLastLogIndex());
 
+            if (!logOk) {
+                // Operator-visible at INFO: this is the exact line that must show up when a
+                // freshly restarted (empty) node tries to win an election against a node that
+                // still holds data - see the empty-node-wipe bug this check exists to prevent.
+                log.info("{} denied vote to {} (candidate log behind: candidateIndex={} < myIndex={})",
+                        myAddress, request.getCandidateId(), request.getLastLogIndex(), lastLogIndex.get());
+            }
+
             // Priority-based voting decision:
             // If we're a higher priority node that can become leader and haven't voted yet,
             // we should not vote for a lower priority candidate (give ourselves a chance first)
@@ -584,10 +592,10 @@ public class ElectionManager {
      * Check if candidate's log is at least as up-to-date as ours.
      * Per Raft: compare by (lastLogTerm, lastLogIndex) - term is more important.
      *
-     * <p><b>Currently always true in practice:</b> {@code lastLogIndex}/{@code lastLogTerm} are
-     * never updated by any production caller (see {@link #updateLogIndex}), so both sides of
-     * every comparison are {@code 0}. This check is dead weight until that is wired up - do not
-     * rely on it to reject a behind-on-data candidate.
+     * <p>{@code lastLogIndex}/{@code lastLogTerm} are fed from the real replication sequence
+     * (see {@link #updateLogIndex}'s javadoc for the leader/follower call sites), so a node that
+     * just started with an empty local database (both still {@code 0}) is correctly rejected in
+     * favor of a candidate that has actually replicated data.
      */
     private boolean isLogAtLeastAsUpToDate(long candidateLastTerm, long candidateLastIndex) {
         long myLastTerm = lastLogTerm.get();
@@ -626,6 +634,14 @@ public class ElectionManager {
         if (!running || state != ElectionState.LEADER) {
             return;
         }
+
+        // Keep our own log index fed from real replication progress while we lead - this is
+        // the leader-side half of the log-recency check's data source (the follower half is
+        // ReplicationManager's onLogIndexUpdate, wired in PoppyDB). Piggybacked on the existing
+        // heartbeat cadence rather than a new timer; currentTerm is used as the log term because
+        // by the time any peer compares it (in isLogAtLeastAsUpToDate) terms are already
+        // Raft-synced across the cluster - see updateLogIndex's javadoc.
+        updateLogIndex(localSequenceSupplier.getAsLong(), currentTerm.get());
 
         AppendEntriesRequest heartbeat = AppendEntriesRequest.heartbeat(
                 currentTerm.get(),
@@ -995,24 +1011,35 @@ public class ElectionManager {
     }
 
     /**
-     * Update log index/term (called after writes on leader).
+     * Update log index/term. Two production callers keep this fed with the real replication
+     * sequence, one per role:
+     * <ul>
+     *   <li><b>Leader:</b> {@link #sendHeartbeats()} calls this every heartbeat with
+     *       {@code localSequenceSupplier}'s current value (wired by PoppyDB to
+     *       {@code driver::getChangeStreamSequence}) and {@code currentTerm} - the same supplier
+     *       already used for priority-takeover catch-up checks.</li>
+     *   <li><b>Follower:</b> {@code ReplicationManager}'s {@code onLogIndexUpdate} hook, wired by
+     *       PoppyDB in {@code startReplicationToLeader}, calls this after every applied batch
+     *       with {@code lastAppliedSequence} and this node's own {@code currentTerm} (substituted
+     *       for the term {@code ReplicationManager} passes, which it has no way to know).</li>
+     * </ul>
      *
-     * <p><b>Known limitation - currently dead code:</b> no production caller ever invokes this.
-     * {@code ReplicationManager} does report replication progress via its own
-     * {@code onLogIndexUpdate} hook, but nothing wires that hook to this method, so
-     * {@code lastLogIndex}/{@code lastLogTerm} stay {@code 0} on every node for the node's
-     * entire lifetime. The consequence is in {@link #isLogAtLeastAsUpToDate}: every vote
-     * request's log comparison is {@code 0 == 0}, i.e. vacuously "at least as up to date" -
-     * the log check in {@link #handleVoteRequest} can never deny a vote for being behind. A
-     * node whose local state was just cleared for a resync (e.g. mid-{@code clearLocalDatabases})
-     * is therefore exactly as electable as a fully caught-up peer; this is the mechanism behind
-     * the users-file version gate's documented mid-resync caveat (see
-     * {@code docs/poppydb.md#bootstrapping-users---users-file}). Pre-existing, not something
-     * this change fixes - wiring real log tracking through election would need an actual
-     * replicated log (indices that mean the same thing across a leader change), which
-     * {@code ReplicationManager}'s per-node change-stream sequence numbers do not provide (see
-     * {@code ReplicationManager#tryConsistencyShortcut}'s javadoc on why sequences are
-     * primary-local). Tracked as a follow-up, not silently relied upon.
+     * <p>Term is deliberately {@code currentTerm}, not a genuine per-log-entry term:
+     * {@code ReplicationManager}'s change-stream sequence numbers are primary-local (see
+     * {@code ReplicationManager#tryConsistencyShortcut}'s javadoc), so there is no real
+     * replicated log with indices that mean the same thing across a leader change to draw a
+     * proper log term from. Using {@code currentTerm} works because {@link #handleVoteRequest}
+     * only reaches {@link #isLogAtLeastAsUpToDate} once the request's Raft term already matches
+     * ours (an older request term is denied earlier, a newer one is adopted first) - so both
+     * sides of the comparison use the same term basis by construction, and the index comparison
+     * (the part that matters for the empty-node-wipe bug) is not distorted by the simplification.
+     *
+     * <p>Because both process state and this in-memory field reset to {@code 0} on restart, a
+     * node whose local database was just cleared for a resync (e.g. mid-{@code
+     * clearLocalDatabases}) still starts back at {@code 0} - that is intentional (see the
+     * users-file version gate's documented mid-resync caveat,
+     * {@code docs/poppydb.md#bootstrapping-users---users-file}); it is exactly why {@link
+     * #isLogAtLeastAsUpToDate} now has real values on the other side to compare against.
      */
     public void updateLogIndex(long index, long term) {
         lastLogIndex.set(index);

--- a/poppydb/src/main/java/de/caluga/poppydb/election/ElectionManager.java
+++ b/poppydb/src/main/java/de/caluga/poppydb/election/ElectionManager.java
@@ -589,22 +589,24 @@ public class ElectionManager {
     }
 
     /**
-     * Check if candidate's log is at least as up-to-date as ours.
-     * Per Raft: compare by (lastLogTerm, lastLogIndex) - term is more important.
+     * Deliberately NOT a Raft &sect;5.4.1 log comparison: {@code ReplicationManager}'s change
+     * stream sequences are primary-local, and {@code lastLogTerm} is a stand-in fed from
+     * {@code currentTerm} at uncorrelated moments (leader heartbeat vs. follower batch-apply,
+     * on different nodes, with no synchronization between the two feeds' timing) - so ordering
+     * nodes by {@code (term, index)} the way Raft does is not meaningful here: a node that was
+     * elected once while still empty can carry a high, stale {@code lastLogTerm} at {@code
+     * index 0}, which a naive term-first comparison would prefer over a real data-holding voter.
      *
-     * <p>{@code lastLogIndex}/{@code lastLogTerm} are fed from the real replication sequence
-     * (see {@link #updateLogIndex}'s javadoc for the leader/follower call sites), so a node that
-     * just started with an empty local database (both still {@code 0}) is correctly rejected in
-     * favor of a candidate that has actually replicated data.
+     * <p>The one invariant this can honestly enforce: a node that has applied/produced no data
+     * since process start ({@code index 0}) must never win against a voter that has ({@code
+     * index > 0}) - directly closes the empty-node-wipe bug this method exists for. A stale but
+     * non-empty candidate (index &gt; 0 but behind) is intentionally NOT denied here; that case
+     * is handled elsewhere (fail-closed resync refusing sequence regression, and candidacy
+     * restraint keeping behind nodes from campaigning in the first place - see the other D-tasks
+     * in this bug's task list).
      */
     private boolean isLogAtLeastAsUpToDate(long candidateLastTerm, long candidateLastIndex) {
-        long myLastTerm = lastLogTerm.get();
-        long myLastIndex = lastLogIndex.get();
-
-        if (candidateLastTerm != myLastTerm) {
-            return candidateLastTerm > myLastTerm;
-        }
-        return candidateLastIndex >= myLastIndex;
+        return !(candidateLastIndex == 0 && lastLogIndex.get() > 0);
     }
 
     // ==================== Heartbeat Handling ====================
@@ -638,9 +640,9 @@ public class ElectionManager {
         // Keep our own log index fed from real replication progress while we lead - this is
         // the leader-side half of the log-recency check's data source (the follower half is
         // ReplicationManager's onLogIndexUpdate, wired in PoppyDB). Piggybacked on the existing
-        // heartbeat cadence rather than a new timer; currentTerm is used as the log term because
-        // by the time any peer compares it (in isLogAtLeastAsUpToDate) terms are already
-        // Raft-synced across the cluster - see updateLogIndex's javadoc.
+        // heartbeat cadence rather than a new timer. currentTerm is still passed through as the
+        // log term for bookkeeping/future use, but isLogAtLeastAsUpToDate no longer reads it -
+        // see that method's javadoc for why term ordering across nodes isn't meaningful here.
         updateLogIndex(localSequenceSupplier.getAsLong(), currentTerm.get());
 
         AppendEntriesRequest heartbeat = AppendEntriesRequest.heartbeat(
@@ -1024,26 +1026,41 @@ public class ElectionManager {
      *       for the term {@code ReplicationManager} passes, which it has no way to know).</li>
      * </ul>
      *
-     * <p>Term is deliberately {@code currentTerm}, not a genuine per-log-entry term:
-     * {@code ReplicationManager}'s change-stream sequence numbers are primary-local (see
-     * {@code ReplicationManager#tryConsistencyShortcut}'s javadoc), so there is no real
-     * replicated log with indices that mean the same thing across a leader change to draw a
-     * proper log term from. Using {@code currentTerm} works because {@link #handleVoteRequest}
-     * only reaches {@link #isLogAtLeastAsUpToDate} once the request's Raft term already matches
-     * ours (an older request term is denied earlier, a newer one is adopted first) - so both
-     * sides of the comparison use the same term basis by construction, and the index comparison
-     * (the part that matters for the empty-node-wipe bug) is not distorted by the simplification.
+     * <p>Term is still passed through as {@code currentTerm} and stored in {@code lastLogTerm}
+     * (harmless bookkeeping, and may serve a genuine per-log-entry term if PoppyDB ever gets a
+     * real replicated log), but {@link #isLogAtLeastAsUpToDate} deliberately does NOT read it
+     * for the vote decision any more - see that method's javadoc. An earlier version of this
+     * comment argued the two nodes' terms were "the same basis by construction" at comparison
+     * time; that argument does not hold across the actual comparison, which reads whatever
+     * {@code lastLogTerm} was last written by this node's own feed (possibly stale, from a term
+     * this node held before a later election it did not participate in) against the candidate's
+     * {@code lastLogTerm} (same staleness problem on their side) - i.e. two independently stale
+     * snapshots, not a fresh pair. Relying on term ordering there reopened the exact bug this
+     * method exists to close (a once-elected, now-empty node carrying a high stale term at index
+     * 0 outranking a real data-holding voter). Index-only comparison side-steps this entirely.
+     *
+     * <p>Thread-safety: called from two independent, unsynchronized threads - the leader's
+     * heartbeat scheduler ({@link #sendHeartbeats()}) and the follower's replication batch
+     * processor (via the {@code onLogIndexUpdate} hook wired in PoppyDB). Takes {@code
+     * stateLock} for the duration of the two writes so they can never interleave with each other
+     * or with {@link #handleVoteRequest}'s read of both fields (which already runs under the
+     * same lock).
      *
      * <p>Because both process state and this in-memory field reset to {@code 0} on restart, a
      * node whose local database was just cleared for a resync (e.g. mid-{@code
      * clearLocalDatabases}) still starts back at {@code 0} - that is intentional (see the
      * users-file version gate's documented mid-resync caveat,
      * {@code docs/poppydb.md#bootstrapping-users---users-file}); it is exactly why {@link
-     * #isLogAtLeastAsUpToDate} now has real values on the other side to compare against.
+     * #isLogAtLeastAsUpToDate} now has a real value on the other side to compare against.
      */
     public void updateLogIndex(long index, long term) {
-        lastLogIndex.set(index);
-        lastLogTerm.set(term);
+        stateLock.lock();
+        try {
+            lastLogIndex.set(index);
+            lastLogTerm.set(term);
+        } finally {
+            stateLock.unlock();
+        }
     }
 
     /**

--- a/poppydb/src/test/java/de/caluga/poppydb/EmptyNodeRestartWipeTest.java
+++ b/poppydb/src/test/java/de/caluga/poppydb/EmptyNodeRestartWipeTest.java
@@ -1,0 +1,368 @@
+package de.caluga.poppydb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.MorphiumConfig;
+import de.caluga.morphium.driver.Doc;
+import de.caluga.poppydb.election.ElectionConfig;
+import de.caluga.test.mongo.suite.data.UncachedObject;
+
+/**
+ * E2E regression test for the empty-node-restart cluster-wide data-loss bug
+ * (2026-08-14-poppydb-empty-node-wipe) - pins down the exact real-world repro forever, at the
+ * full multi-node in-process replica-set level (election + replication wired together, unlike
+ * {@link ReplicationFailClosedTest} which exercises the replication-only D2 guard in isolation).
+ *
+ * <p><b>The bug, as it happened in production:</b> a 3-node replica set (distinct priorities),
+ * fully replicated. The highest-priority node was killed and restarted EMPTY (fresh process, no
+ * on-disk/in-memory state, same address). Before the fixes on this branch:
+ * <ol>
+ *   <li>the empty, freshly-restarted node won the election on priority alone, despite having
+ *       zero data (its {@code lastLogIndex} started at 0, but nothing stopped it campaigning or
+ *       being granted votes purely on priority/term);</li>
+ *   <li>the data-bearing followers, reconnecting to what was now "the primary", found their
+ *       replicated namespace set didn't match the empty leader's and fell back to a full
+ *       resync - which meant dropping their own (real, correct) databases first: "Falling back
+ *       to full sync: replicated namespace sets differ (primary: {}, local: {...})".</li>
+ * </ol>
+ * Net effect: an operational restart of a single, already-caught-up node wiped the entire
+ * cluster's data.
+ *
+ * <p><b>The fixes under test</b> (all already on this branch): vote safety + candidacy restraint
+ * so an empty node cannot win an election while data-bearing peers exist (commits
+ * d6735e0ee/c8a5cb669, 2ee1848bf), freshly-synced nodes reporting their true replication position
+ * to the election instead of a stale 0 (47877ad18), and a fail-closed guard on the replication
+ * side that refuses a destructive resync from a primary whose sequence has regressed relative to
+ * local state (49633aba6). This test does not target any one of those commits individually - it
+ * pins the OUTCOME: no matter which layer is doing the protecting, the cluster must survive this
+ * kill chain with zero data loss.
+ *
+ * <p><b>Design notes:</b>
+ * <ul>
+ *   <li>"Restart empty" is reproduced literally: the node is hard {@link PoppyDB#shutdown()}, and
+ *       a brand-new {@code PoppyDB} instance - fresh in-memory driver, fresh election state - is
+ *       started on the exact same port, exactly like a process manager restarting a crashed
+ *       server (modeled on {@link ReplicationFailClosedTest}'s "kill primary, start fresh empty
+ *       PoppyDB on the same port" trick, here at the full RS/election level instead of a
+ *       manually-wired {@link ReplicationManager}).</li>
+ *   <li>Every count is read via {@link PoppyDB#getDriver()} directly against each node's own
+ *       in-memory driver, never over the wire - secondaries reject unqualified wire reads by
+ *       design (see {@code b15c28704}), so a wire-level count would silently only ever prove the
+ *       primary's view, not each node's own local state, which is exactly what a wipe would
+ *       corrupt.</li>
+ *   <li>{@link #watchConvergence} is an ACTIVE watch, not a single condition-poll: on every tick
+ *       (150ms) it re-asserts that the still-data-bearing nodes have not lost anything, and that
+ *       the restarted node - if it currently claims leadership - already has the full data set.
+ *       This catches a transient wipe-then-recover as reliably as a permanent one, and catches a
+ *       "won leadership while still empty" violation the instant it happens rather than only if
+ *       it happens to still be true whenever a single poll happens to sample it.</li>
+ *   <li>Priority takeover timers are shortened ({@link #fastTakeoverConfig()}) purely to keep the
+ *       "restarted highest-priority node may reclaim leadership, but only once synced" leg of
+ *       Test A actually exercised within the test's timeout, rather than leaving it as a
+ *       might-or-might-not-happen possibility under the 30s default stability window.</li>
+ * </ul>
+ */
+@Tag("server")
+public class EmptyNodeRestartWipeTest {
+
+    private static final Logger log = LoggerFactory.getLogger(EmptyNodeRestartWipeTest.class);
+
+    private static final String DB = "emptynodewipe";
+    private static final String COLL = "objs";
+    private static final int DOCS = 100;
+
+    /** Started nodes, shut down in reverse start order on teardown. */
+    private final List<PoppyDB> nodes = new ArrayList<>();
+
+    @AfterEach
+    public void tearDown() {
+        for (int i = nodes.size() - 1; i >= 0; i--) {
+            try {
+                nodes.get(i).shutdown();
+            } catch (Exception ignored) {
+            }
+        }
+        nodes.clear();
+    }
+
+    // ---- RS bootstrap helpers (pattern of UserFailoverTest / StepdownReplicationTest) -------
+
+    private int nextPort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private void startServer(PoppyDB srv, int port) throws Exception {
+        nodes.add(srv);
+        srv.start();
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (true) {
+            try (Socket s = new Socket()) {
+                s.connect(new InetSocketAddress("localhost", port), 250);
+                return;
+            } catch (Exception e) {
+                if (System.currentTimeMillis() > deadline) {
+                    throw e;
+                }
+                Thread.sleep(50);
+            }
+        }
+    }
+
+    private void waitForPrimary(PoppyDB node) throws Exception {
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (!node.isPrimary() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(node.isPrimary(), "node must become primary");
+    }
+
+    /** Poll a condition with generous timeout - replication/election is asynchronous, never fixed-sleep. */
+    private boolean poll(long timeoutMs, Callable<Boolean> condition) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (Boolean.TRUE.equals(condition.call())) {
+                return true;
+            }
+            Thread.sleep(100);
+        }
+        return Boolean.TRUE.equals(condition.call());
+    }
+
+    /**
+     * A fresh {@link ElectionConfig} instance per call (never share one instance across nodes -
+     * {@code PoppyDB#configureReplicaSet} mutates its config's priority in place, which would
+     * silently cross-contaminate every node handed the same object) with shortened priority
+     * takeover timers, so a caught-up higher-priority node reclaiming leadership is something
+     * this test can actually observe within its timeout instead of only maybe happening within
+     * the 30s production default.
+     */
+    private ElectionConfig fastTakeoverConfig() {
+        return new ElectionConfig()
+            .setPriorityTakeoverMinStabilityMs(3000)
+            .setPriorityTakeoverCheckIntervalMs(1000)
+            .setPriorityTakeoverStepDownSecs(3);
+    }
+
+    // ---- data helpers ------------------------------------------------------------------------
+
+    /** Reads the doc count directly off the node's OWN local driver - never over the wire. */
+    private long countOn(PoppyDB node) {
+        return node.getDriver().count(DB, COLL, Doc.of(), null, null);
+    }
+
+    private Morphium writerFor(int port, String db) {
+        MorphiumConfig cfg = new MorphiumConfig();
+        cfg.clusterSettings().setHostSeed("localhost:" + port);
+        cfg.connectionSettings().setDatabase(db);
+        cfg.connectionSettings().setMaxConnections(10);
+        cfg.cacheSettings().setBufferedWritesEnabled(false);
+        return new Morphium(cfg);
+    }
+
+    private void writeDocs(Morphium writer, int count, String prefix) {
+        List<UncachedObject> batch = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            batch.add(new UncachedObject(prefix + "-" + i, i));
+        }
+        writer.storeList(batch, COLL);
+    }
+
+    /**
+     * Actively watches convergence after an empty-node restart, for up to {@code timeoutMs}:
+     * <ul>
+     *   <li>on EVERY tick, every node in {@code mustNeverLoseData} must still report exactly
+     *       {@code expectedCount} - a real wipe, even a transient one, fails the test the moment
+     *       it is observed, not just if it happens to still be visible at the end;</li>
+     *   <li>on EVERY tick, if {@code restarted} currently claims leadership
+     *       ({@link PoppyDB#isPrimary()}), it must already report {@code expectedCount} locally -
+     *       leadership while still behind/empty is exactly the bug this test pins;</li>
+     *   <li>returns as soon as {@code restarted} itself reaches {@code expectedCount} (legitimate
+     *       convergence via initial sync); fails with a descriptive message if that never happens
+     *       within {@code timeoutMs}.</li>
+     * </ul>
+     */
+    private void watchConvergence(PoppyDB restarted, List<PoppyDB> mustNeverLoseData,
+            long expectedCount, long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (true) {
+            for (PoppyDB n : mustNeverLoseData) {
+                long c = countOn(n);
+                assertEquals(expectedCount, c,
+                    "a data-bearing node must never lose data while the empty node restarts/resyncs "
+                        + "(got " + c + ", want " + expectedCount + ")");
+            }
+            if (restarted.isPrimary()) {
+                long c = countOn(restarted);
+                assertEquals(expectedCount, c,
+                    "the restarted node must never hold/claim leadership before its own data has "
+                        + "fully caught up via legitimate initial sync (local count=" + c
+                        + ", want " + expectedCount + ")");
+            }
+            long restartedCount = countOn(restarted);
+            if (restartedCount == expectedCount) {
+                return; // converged: restarted node has legitimately caught up
+            }
+            if (System.currentTimeMillis() > deadline) {
+                fail("restarted node never reached the full document count via initial sync "
+                    + "(got " + restartedCount + ", want " + expectedCount + ") within " + timeoutMs + "ms");
+            }
+            Thread.sleep(150);
+        }
+    }
+
+    // ---- Test A: restart the HIGHEST-priority node empty ------------------------------------
+
+    @Test
+    public void restartingHighestPriorityNodeEmptyMustNotWipeTheCluster() throws Exception {
+        int port1 = nextPort();
+        int port2 = nextPort();
+        int port3 = nextPort();
+        PoppyDB node1 = new PoppyDB(port1, "localhost", 20, 5);
+        PoppyDB node2 = new PoppyDB(port2, "localhost", 20, 5);
+        PoppyDB node3 = new PoppyDB(port3, "localhost", 20, 5);
+        List<String> hosts = List.of("localhost:" + port1, "localhost:" + port2, "localhost:" + port3);
+        Map<String, Integer> prio = Map.of(
+                "localhost:" + port1, 100,
+                "localhost:" + port2, 90,
+                "localhost:" + port3, 80);
+        node1.configureReplicaSet("rsEmptyWipeA", hosts, prio, true, fastTakeoverConfig());
+        node2.configureReplicaSet("rsEmptyWipeA", hosts, prio, true, fastTakeoverConfig());
+        node3.configureReplicaSet("rsEmptyWipeA", hosts, prio, true, fastTakeoverConfig());
+
+        startServer(node1, port1);
+        startServer(node2, port2);
+        startServer(node3, port3);
+        waitForPrimary(node1); // priority 100 wins the initial election deterministically
+
+        Morphium writer = writerFor(port1, DB);
+        try {
+            writeDocs(writer, DOCS, "pre");
+        } finally {
+            writer.close();
+        }
+
+        // Replicated everywhere BEFORE we touch anything - isolates the restart-empty scenario
+        // below from an ordinary steady-state replication bug.
+        assertTrue(poll(30_000, () -> countOn(node1) == DOCS && countOn(node2) == DOCS && countOn(node3) == DOCS),
+                "all " + DOCS + " docs must replicate to every node before the kill (node1=" + countOn(node1)
+                        + ", node2=" + countOn(node2) + ", node3=" + countOn(node3) + ")");
+
+        log.info("Test A: pre-kill state converged, {} docs on all 3 nodes; killing node1 (highest priority)", DOCS);
+
+        // ---- the exact repro: hard-kill the highest-priority node, restart it EMPTY on the same port ----
+        node1.shutdown();
+        nodes.remove(node1);
+
+        PoppyDB restarted = new PoppyDB(port1, "localhost", 20, 5);
+        restarted.configureReplicaSet("rsEmptyWipeA", hosts, prio, true, fastTakeoverConfig());
+        startServer(restarted, port1);
+
+        // The heart of the regression: while the cluster converges, node2/node3's real data must
+        // never be wiped, and the restarted node may only ever claim leadership once it has
+        // genuinely caught up via initial sync - never while it is still empty/behind.
+        watchConvergence(restarted, List.of(node2, node3), DOCS, 90_000);
+
+        // Final full-cluster assertion, each read directly off the node's own local driver state.
+        assertEquals(DOCS, countOn(restarted), "restarted node must have fully synced");
+        assertEquals(DOCS, countOn(node2), "node2 must still have all data after convergence");
+        assertEquals(DOCS, countOn(node3), "node3 must still have all data after convergence");
+
+        // Best-effort confirmation that the restarted node reached that count via a legitimate
+        // initial sync (not e.g. having become primary itself and thus having no ReplicationManager
+        // to ask - that path is already independently proven correct by watchConvergence above,
+        // since it could only have claimed leadership once already fully synced).
+        ReplicationManager restartedRm = restarted.getReplicationManagerForTest();
+        if (restartedRm != null) {
+            assertTrue(restartedRm.isInitialSyncComplete(),
+                    "the restarted node's ReplicationManager must report a COMPLETED initial sync");
+        }
+
+        log.info("Test A converged: restarted node reached {} docs, cluster primary is now {}",
+                countOn(restarted), node2.isPrimary() ? "node2" : (node3.isPrimary() ? "node3" : "restarted"));
+    }
+
+    // ---- Test B: restart the LOWEST-priority node empty --------------------------------------
+
+    @Test
+    public void restartingLowestPriorityNodeEmptyMustNotWipeTheCluster() throws Exception {
+        int port1 = nextPort();
+        int port2 = nextPort();
+        int port3 = nextPort();
+        PoppyDB node1 = new PoppyDB(port1, "localhost", 20, 5);
+        PoppyDB node2 = new PoppyDB(port2, "localhost", 20, 5);
+        PoppyDB node3 = new PoppyDB(port3, "localhost", 20, 5);
+        List<String> hosts = List.of("localhost:" + port1, "localhost:" + port2, "localhost:" + port3);
+        Map<String, Integer> prio = Map.of(
+                "localhost:" + port1, 100,
+                "localhost:" + port2, 90,
+                "localhost:" + port3, 80);
+        node1.configureReplicaSet("rsEmptyWipeB", hosts, prio, true, fastTakeoverConfig());
+        node2.configureReplicaSet("rsEmptyWipeB", hosts, prio, true, fastTakeoverConfig());
+        node3.configureReplicaSet("rsEmptyWipeB", hosts, prio, true, fastTakeoverConfig());
+
+        startServer(node1, port1);
+        startServer(node2, port2);
+        startServer(node3, port3);
+        waitForPrimary(node1); // priority 100 wins the initial election deterministically
+
+        Morphium writer = writerFor(port1, DB);
+        try {
+            writeDocs(writer, DOCS, "pre");
+        } finally {
+            writer.close();
+        }
+
+        assertTrue(poll(30_000, () -> countOn(node1) == DOCS && countOn(node2) == DOCS && countOn(node3) == DOCS),
+                "all " + DOCS + " docs must replicate to every node before the kill (node1=" + countOn(node1)
+                        + ", node2=" + countOn(node2) + ", node3=" + countOn(node3) + ")");
+
+        log.info("Test B: pre-kill state converged, {} docs on all 3 nodes; killing node3 (lowest priority)", DOCS);
+
+        // ---- restart the LOWEST-priority node empty: node1 stays primary throughout, no ----
+        // ---- re-election is even needed - this isolates the wipe-on-resync half of the bug ----
+        // ---- from the vote/candidacy half that Test A exercises. ----
+        node3.shutdown();
+        nodes.remove(node3);
+
+        PoppyDB restarted = new PoppyDB(port3, "localhost", 20, 5);
+        restarted.configureReplicaSet("rsEmptyWipeB", hosts, prio, true, fastTakeoverConfig());
+        startServer(restarted, port3);
+
+        // node1 (still primary, highest priority, never touched) and node2 must never lose data;
+        // the restarted lowest-priority node must never claim leadership before catching up
+        // (trivially true here since node1 never yields it, but the same watch applies uniformly).
+        watchConvergence(restarted, List.of(node1, node2), DOCS, 90_000);
+
+        assertEquals(DOCS, countOn(restarted), "restarted node must have fully synced");
+        assertEquals(DOCS, countOn(node1), "node1 (primary throughout) must still have all data");
+        assertEquals(DOCS, countOn(node2), "node2 must still have all data after convergence");
+        assertTrue(node1.isPrimary(), "node1 must have remained primary the whole time - no failover was needed");
+
+        ReplicationManager restartedRm = restarted.getReplicationManagerForTest();
+        if (restartedRm != null) {
+            assertTrue(restartedRm.isInitialSyncComplete(),
+                    "the restarted node's ReplicationManager must report a COMPLETED initial sync");
+        }
+
+        log.info("Test B converged: restarted node reached {} docs, node1 remained primary throughout", countOn(restarted));
+    }
+}

--- a/poppydb/src/test/java/de/caluga/poppydb/InitialSyncElectionSeedTest.java
+++ b/poppydb/src/test/java/de/caluga/poppydb/InitialSyncElectionSeedTest.java
@@ -1,0 +1,131 @@
+package de.caluga.poppydb;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import de.caluga.morphium.driver.Doc;
+import de.caluga.morphium.driver.commands.InsertMongoCommand;
+import de.caluga.morphium.driver.inmem.InMemoryDriver;
+import de.caluga.poppydb.election.ElectionManager;
+import de.caluga.poppydb.election.ElectionConfig;
+
+/**
+ * Integration-level regression test for the "freshly-synced but silent" leg of the
+ * empty-node-wipe bug: a node that just completed an initial sync (full snapshot or consistency
+ * shortcut - both converge on the same "success: open the gate" block in the replication loop,
+ * see that block's comment in {@link ReplicationManager}) must report its real, non-zero
+ * replication position to {@link ElectionManager} immediately, even if it goes on to apply ZERO
+ * live events afterward (a quiet primary). Before this fix, only {@code processBatch()}'s
+ * per-applied-batch call fed {@code onLogIndexUpdate}, so a freshly-synced-then-silent node kept
+ * reporting index 0 - wrongly granting votes to genuinely empty candidates as voter (reopening
+ * the wipe), and wrongly getting denied as candidate.
+ *
+ * <p>Uses the same lightweight harness as {@link InitialSyncChangeStreamSilenceTest}: a real
+ * standalone {@link PoppyDB} primary plus a bare {@link ReplicationManager} pointed directly at
+ * it (no multi-node election machinery, no {@code @Disabled} - this stays fast and always-on).
+ * The {@code ElectionManager} here is not attached to a live election (no peers, never
+ * started/stopped) - it exists purely as the production wiring target for
+ * {@code setOnLogIndexUpdate}, exactly as {@link PoppyDB#startReplicationToLeader} wires it.
+ */
+@Tag("server")
+public class InitialSyncElectionSeedTest {
+
+    private PoppyDB leader;
+    private ReplicationManager rm;
+    private InMemoryDriver local;
+
+    @AfterEach
+    public void tearDown() {
+        if (rm != null) {
+            try {
+                rm.stop();
+            } catch (Exception ignored) {
+            }
+        }
+        if (local != null) {
+            try {
+                local.close();
+            } catch (Exception ignored) {
+            }
+        }
+        if (leader != null) {
+            try {
+                leader.shutdown();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private int nextPort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private void startServer(PoppyDB srv, int port) throws Exception {
+        srv.start();
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (true) {
+            try (Socket s = new Socket()) {
+                s.connect(new InetSocketAddress("localhost", port), 250);
+                return;
+            } catch (Exception e) {
+                if (System.currentTimeMillis() > deadline) {
+                    throw e;
+                }
+                Thread.sleep(50);
+            }
+        }
+    }
+
+    @Test
+    public void freshlySyncedNodeReportsNonZeroIndexWithoutAnyLiveEvent() throws Exception {
+        int port = nextPort();
+        leader = new PoppyDB(port, "localhost", 20, 5);
+        startServer(leader, port);
+        assertTrue(leader.isPrimary(), "standalone PoppyDB must act as primary");
+
+        // Give the primary real, pre-existing data BEFORE the secondary ever connects, so its
+        // change-stream sequence is genuinely non-zero and the secondary's initial-sync seed
+        // (recordPrimarySequenceAtRegistration) has something real to seed from.
+        new InsertMongoCommand(leader.getDriver()).setDb("datadb").setColl("docs")
+            .setDocuments(List.of(Doc.of("_id", 1, "v", "fresh")))
+            .execute();
+
+        local = new InMemoryDriver();
+        local.connect();
+
+        ElectionConfig config = new ElectionConfig()
+                .setElectionTimeoutMinMs(60_000)
+                .setElectionTimeoutMaxMs(60_000);
+        ElectionManager electionManager = new ElectionManager(
+                "localhost:test-secondary", List.of("localhost:test-secondary"), config);
+        // Not started: this test only exercises updateLogIndex() as a wiring target, not the
+        // election protocol itself (that's ElectionLogRecencyTest's job).
+
+        rm = new ReplicationManager(local, "localhost", port);
+        rm.setMyAddress("localhost:test-secondary");
+        // Exactly the wiring PoppyDB#startReplicationToLeader installs in production.
+        rm.setOnLogIndexUpdate((index, term) ->
+                electionManager.updateLogIndex(index, electionManager.getCurrentTerm()));
+        rm.start();
+        assertTrue(rm.waitForInitialSync(30, TimeUnit.SECONDS), "initial sync must complete within 30s");
+
+        // No write happens on the primary after this point in this test - the secondary applies
+        // zero live events. Before this fix, ElectionManager's lastLogIndex would still be 0 here.
+        assertTrue(electionManager.getLastLogIndex() > 0,
+                "a freshly-synced node must report a non-zero replication position to "
+                        + "ElectionManager even without applying any live event afterward "
+                        + "(got lastLogIndex=" + electionManager.getLastLogIndex() + ", "
+                        + "ReplicationManager lastAppliedSequence=" + rm.getLastAppliedSequence() + ")");
+    }
+}

--- a/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
+++ b/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
@@ -513,4 +513,58 @@ public class ReplicationFailClosedTest {
         log.info("carry-over regressed case converged: predecessorSeq={}, refusedResyncCount={}",
             predecessorSeq, rm.getRefusedResyncCount());
     }
+
+    // ---- issue 1 (2nd review pass): carry-over must survive a failed replication start --------
+    //
+    // PoppyDB#startReplicationToLeader(String, long) is private and tightly coupled to the
+    // election/leader-discovery machinery (primary/leaderId guards, the retry-scheduler chain),
+    // and reproducing a genuine SYNCHRONOUS throw from newReplicationManager.start() realistically
+    // needs an auth/TLS connect mismatch (a plain unreachable port is documented elsewhere in this
+    // class as SWALLOWED by PooledDriver.connect(), not thrown - see
+    // scheduleReplicationLivenessProbe's javadoc). Driving that end-to-end through a real 3-node
+    // election, on a schedule precise enough to fail exactly the FIRST attempt and succeed the
+    // retry, would be disproportionate machinery for covering one fallback decision. Per the
+    // review's own escape hatch, these two tests instead exercise PoppyDB#carryOverSequenceFor -
+    // the pure decision function startReplicationToLeader delegates to - directly and in
+    // isolation: no network, no election, no started server at all.
+
+    @Test
+    public void carryOverSequenceFallsBackToPersistedWatermarkWhenNoPredecessor() {
+        PoppyDB node = new PoppyDB();
+        nodes.add(node); // shutdown() on a never-started instance is a safe no-op
+
+        // The exact bug scenario: a PREVIOUS attempt persisted a real predecessor's position into
+        // the durable watermark, then (in production) newReplicationManager.start() threw, so
+        // replicationManager is null going into the retry - predecessor == null here mirrors that.
+        node.setLastKnownAppliedSequenceForTest(777);
+
+        assertEquals(777, node.carryOverSequenceFor(null),
+            "a failed-start retry (predecessor == null) must fall back to the persisted "
+                + "watermark, not silently reset to 0");
+    }
+
+    @Test
+    public void carryOverSequenceReadsLivePredecessorWhenPresent() throws Exception {
+        PoppyDB node = new PoppyDB();
+        nodes.add(node);
+
+        // A stale watermark from an even earlier attempt must NOT shadow a real, live
+        // predecessor - the live value always wins when one is available.
+        node.setLastKnownAppliedSequenceForTest(1);
+
+        InMemoryDriver drv = new InMemoryDriver();
+        drv.connect();
+        try {
+            ReplicationManager predecessor = new ReplicationManager(drv, "localhost", 1);
+            // Seeds lastAppliedSequence without ever calling start()/connecting anywhere - the
+            // decision function only reads getLastAppliedSequence(), so no live connection is
+            // needed to exercise it.
+            predecessor.carryOverLastAppliedSequence(500);
+
+            assertEquals(500, node.carryOverSequenceFor(predecessor),
+                "a live predecessor's own position must be used, not the stale watermark");
+        } finally {
+            drv.close();
+        }
+    }
 }

--- a/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
+++ b/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
@@ -76,6 +76,8 @@ public class ReplicationFailClosedTest {
 
     /** Started nodes, shut down in reverse start order on teardown. */
     private final List<PoppyDB> nodes = new ArrayList<>();
+    /** Extra ReplicationManager instances (RM-replacement tests use more than one) to stop on teardown. */
+    private final List<ReplicationManager> extraReplicationManagers = new ArrayList<>();
     private ReplicationManager rm;
     private InMemoryDriver local;
 
@@ -87,6 +89,13 @@ public class ReplicationFailClosedTest {
             } catch (Exception ignored) {
             }
         }
+        for (int i = extraReplicationManagers.size() - 1; i >= 0; i--) {
+            try {
+                extraReplicationManagers.get(i).stop();
+            } catch (Exception ignored) {
+            }
+        }
+        extraReplicationManagers.clear();
         if (local != null) {
             try {
                 local.close();
@@ -142,6 +151,13 @@ public class ReplicationFailClosedTest {
 
     private long localCount() throws Exception {
         return local.count(DB, COLL, Doc.of(), null, null);
+    }
+
+    /** Count of "Starting change stream watch on primary..." lines captured so far - one per watch registration. */
+    private long registrationLogCount(ListAppender<ILoggingEvent> appender) {
+        return appender.list.stream()
+            .filter(ev -> ev.getFormattedMessage().contains("Starting change stream watch on primary"))
+            .count();
     }
 
     private void writeDocs(Morphium writer, int count, String prefix) {
@@ -247,6 +263,21 @@ public class ReplicationFailClosedTest {
                 "getStats() must surface the active refusal");
             assertTrue((Long) stats.get("refusedResyncCount") >= 1,
                 "getStats() must surface the refusal count");
+
+            // Pacing sanity check (task-3 review, issue 1): while refusing, the watch
+            // register/teardown cycle must be paced (REFUSAL_WATCH_PACE_MS), not spinning hot.
+            // A ~6s window at the 2s pace should see roughly 3 registrations; assert well under a
+            // spin's ~1400/s rate (thousands in this window) without pinning to an exact count.
+            long registrationsBefore = registrationLogCount(appender);
+            long windowStart = System.currentTimeMillis();
+            Thread.sleep(6_000);
+            long registrationsDuringWindow = registrationLogCount(appender) - registrationsBefore;
+            long windowMs = System.currentTimeMillis() - windowStart;
+            assertTrue(registrationsDuringWindow < 20,
+                "watch registrations while refusing must be paced, not spinning (got "
+                    + registrationsDuringWindow + " registrations in " + windowMs + "ms)");
+            assertTrue(rm.isRefusingDestructiveResync(),
+                "still refusing after the pacing-measurement window (primary was never caught up)");
 
             // Recoverability (the brief's explicit requirement): once the SAME reconnected
             // process genuinely catches up - its own sequence overtakes the follower's local
@@ -370,5 +401,116 @@ public class ReplicationFailClosedTest {
             "the local-only extra namespace must be wiped by the (legitimate) full resync");
 
         log.info("case (c) converged: local sequence was {}", s);
+    }
+
+    // ---- issue 2 (task-3 review): sequence carry-over across RM replacement (leader change) --
+    //
+    // PoppyDB#startReplicationToLeader constructs a brand-new ReplicationManager on every leader
+    // change, reusing the SAME persistent local driver (only the RM wrapper is replaced - the
+    // production analogue of what these two tests build by hand: rm1 against primary A is
+    // stop()ped, and a fresh rm is built against a different primary, sharing the same `local`
+    // driver). A fresh instance's own lastAppliedSequence starts at 0, which - absent the carry-
+    // over - would make the destructive-resync guard vacuously pass on every leader change; these
+    // tests exercise ReplicationManager#carryOverLastAppliedSequence directly, the same call
+    // PoppyDB now makes before starting the replacement.
+
+    @Test
+    public void carryOverAllowsNormalSyncWhenReplacementLeaderIsCaughtUp() throws Exception {
+        int portA = nextPort();
+        int portB = nextPort();
+        startStandalonePrimary(portA);
+
+        local = new InMemoryDriver();
+        local.connect();
+        ReplicationManager rm1 = new ReplicationManager(local, "localhost", portA);
+        extraReplicationManagers.add(rm1);
+        rm1.start();
+        assertTrue(poll(30_000, rm1::isInitialSyncComplete), "rm1 initial sync must complete");
+
+        Morphium writerA = writerFor(portA, DB);
+        try {
+            writeDocs(writerA, DOCS, "pre");
+            assertTrue(poll(30_000, () -> localCount() == DOCS),
+                "rm1 must live-replicate the batch (got " + localCount() + ")");
+        } finally {
+            writerA.close();
+        }
+        assertTrue(poll(5_000, () -> rm1.getLastAppliedSequence() > 0),
+            "rm1 lastAppliedSequence must have advanced past 0");
+        long predecessorSeq = rm1.getLastAppliedSequence();
+
+        // Simulate PoppyDB#startReplicationToLeader tearing down the old RM on a leader change.
+        rm1.stop();
+
+        // The "new leader": a DIFFERENT standalone primary, fed enough writes that its own
+        // sequence is comfortably >= predecessorSeq - a legitimate, caught-up new leader.
+        startStandalonePrimary(portB);
+        Morphium writerB = writerFor(portB, DB);
+        try {
+            writeDocs(writerB, (int) predecessorSeq + 50, "leaderb");
+        } finally {
+            writerB.close();
+        }
+
+        // Replacement RM, same local driver, carrying the predecessor's sequence forward exactly
+        // as PoppyDB#startReplicationToLeader now does.
+        rm = new ReplicationManager(local, "localhost", portB);
+        rm.carryOverLastAppliedSequence(predecessorSeq);
+        rm.start();
+
+        assertTrue(poll(30_000, rm::isInitialSyncComplete),
+            "a caught-up replacement leader must sync normally despite the carried-over sequence");
+        assertEquals(0, rm.getRefusedResyncCount(),
+            "a caught-up replacement leader must never trigger the destructive-resync refusal");
+        assertFalse(rm.isRefusingDestructiveResync());
+
+        log.info("carry-over caught-up case converged: predecessorSeq={}, final local count={}",
+            predecessorSeq, localCount());
+    }
+
+    @Test
+    public void carryOverRefusesWhenReplacementLeaderIsRegressed() throws Exception {
+        int portA = nextPort();
+        int portC = nextPort();
+        startStandalonePrimary(portA);
+
+        local = new InMemoryDriver();
+        local.connect();
+        ReplicationManager rm1 = new ReplicationManager(local, "localhost", portA);
+        extraReplicationManagers.add(rm1);
+        rm1.start();
+        assertTrue(poll(30_000, rm1::isInitialSyncComplete), "rm1 initial sync must complete");
+
+        Morphium writerA = writerFor(portA, DB);
+        try {
+            writeDocs(writerA, DOCS, "pre");
+            assertTrue(poll(30_000, () -> localCount() == DOCS),
+                "rm1 must live-replicate the batch (got " + localCount() + ")");
+        } finally {
+            writerA.close();
+        }
+        assertTrue(poll(5_000, () -> rm1.getLastAppliedSequence() > 0),
+            "rm1 lastAppliedSequence must have advanced past 0");
+        long predecessorSeq = rm1.getLastAppliedSequence();
+
+        rm1.stop();
+
+        // The "new leader": a FRESH, EMPTY standalone primary - a regressed/stale leader
+        // (sequence starts near 0, necessarily behind predecessorSeq).
+        startStandalonePrimary(portC);
+
+        rm = new ReplicationManager(local, "localhost", portC);
+        rm.carryOverLastAppliedSequence(predecessorSeq);
+        rm.start();
+
+        assertTrue(poll(30_000, () -> rm.getRefusedResyncCount() >= 1),
+            "a regressed replacement leader must be refused (refusedResyncCount="
+                + rm.getRefusedResyncCount() + ")");
+        assertFalse(rm.isInitialSyncComplete(), "a refused replacement must not report a completed sync");
+        assertEquals(DOCS, localCount(),
+            "local data carried over from the predecessor RM must survive a refused replacement resync");
+
+        log.info("carry-over regressed case converged: predecessorSeq={}, refusedResyncCount={}",
+            predecessorSeq, rm.getRefusedResyncCount());
     }
 }

--- a/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
+++ b/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
@@ -1,0 +1,374 @@
+package de.caluga.poppydb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.MorphiumConfig;
+import de.caluga.morphium.driver.Doc;
+import de.caluga.morphium.driver.commands.GenericCommand;
+import de.caluga.morphium.driver.inmem.InMemoryDriver;
+import de.caluga.test.mongo.suite.data.UncachedObject;
+
+/**
+ * Fail-closed destructive resync (D2) + shortcut namespace union (D4) - 2026-08-14
+ * empty-node-wipe fix, task 3.
+ *
+ * <p>Reproduces, at the {@link ReplicationManager} level (no election/RS machinery needed - a
+ * ReplicationManager talks to a fixed {@code primaryHost:primaryPort} regardless of RS/leader
+ * state), the exact kill chain from the bug report: a follower holding real data reconnects to
+ * whatever now answers at that address, and if that "primary" turns out to be a freshly
+ * restarted, empty process, its change-stream sequence counter necessarily starts fresh (0-ish) -
+ * behind the sequence our local data was last known to reflect. Before the fix, the follower
+ * would trust that empty state and wipe its own data to match it. The fix refuses instead.
+ *
+ * <p>The "primary restarted empty" step is reproduced literally: a standalone primary is fed data
+ * and live-replicates it to a manually-wired {@link ReplicationManager}; the connection is then
+ * severed ({@link ReplicationManager#pauseReplicationForTest()}), the primary process is shut
+ * down (destroying its in-memory state), and a brand-new, empty {@code PoppyDB} is started on the
+ * SAME port before the connection is healed again ({@link ReplicationManager#resumeReplicationForTest()}).
+ * The follower's next reconnect necessarily hits the primary's shrunk replay buffer ("resume
+ * window lost"), which is exactly the fallback branch the bug report's log lines show.
+ *
+ * <ul>
+ *   <li>{@link #refusesWhenReconnectedPrimaryIsBehind()} - case (a): the freshly-restarted primary
+ *       is empty AND behind (sequence 0-ish) - the follower must refuse, keep its data, log an
+ *       ERROR, and surface the refusal in stats.</li>
+ *   <li>{@link #proceedsWhenReconnectedPrimaryIsEmptyButCaughtUp()} - case (b): the
+ *       freshly-restarted primary is also empty, but its sequence has been advanced (by other
+ *       writes then a drop) past the follower's local sequence - a legitimate post-dropDatabase
+ *       shape. The resync must proceed exactly as before this fix.</li>
+ *   <li>{@link #shortcutNotTakenWhenLocalHasExtraNamespace()} - case (c) / D4: a follower whose
+ *       local state has an extra namespace the (still fully caught-up, never-restarted) primary
+ *       does not must NOT take the consistency shortcut - the namespace comparison must be a
+ *       union (local-only namespaces count as mismatch), not an intersection that could miss
+ *       this and leave the extra namespace behind forever.</li>
+ * </ul>
+ */
+@Tag("server")
+public class ReplicationFailClosedTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ReplicationFailClosedTest.class);
+
+    private static final String DB = "failclosedtest";
+    private static final String COLL = "objs";
+    private static final int DOCS = 20;
+
+    /** Started nodes, shut down in reverse start order on teardown. */
+    private final List<PoppyDB> nodes = new ArrayList<>();
+    private ReplicationManager rm;
+    private InMemoryDriver local;
+
+    @AfterEach
+    public void tearDown() {
+        if (rm != null) {
+            try {
+                rm.stop();
+            } catch (Exception ignored) {
+            }
+        }
+        if (local != null) {
+            try {
+                local.close();
+            } catch (Exception ignored) {
+            }
+        }
+        for (int i = nodes.size() - 1; i >= 0; i--) {
+            try {
+                nodes.get(i).shutdown();
+            } catch (Exception ignored) {
+            }
+        }
+        nodes.clear();
+    }
+
+    // ---- bootstrap helpers (pattern of ReplicationResumeTest / FastResyncTest) --------------
+
+    private int nextPort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    /** Starts a standalone (no RS config -> immediately primary) PoppyDB node, tracked for teardown. */
+    private PoppyDB startStandalonePrimary(int port) throws Exception {
+        PoppyDB srv = new PoppyDB(port, "localhost", 20, 5);
+        nodes.add(srv);
+        srv.start();
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (true) {
+            try (Socket s = new Socket()) {
+                s.connect(new InetSocketAddress("localhost", port), 250);
+                return srv;
+            } catch (Exception e) {
+                if (System.currentTimeMillis() > deadline) {
+                    throw e;
+                }
+                Thread.sleep(50);
+            }
+        }
+    }
+
+    private boolean poll(long timeoutMs, Callable<Boolean> condition) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (Boolean.TRUE.equals(condition.call())) {
+                return true;
+            }
+            Thread.sleep(100);
+        }
+        return Boolean.TRUE.equals(condition.call());
+    }
+
+    private long localCount() throws Exception {
+        return local.count(DB, COLL, Doc.of(), null, null);
+    }
+
+    private void writeDocs(Morphium writer, int count, String prefix) {
+        List<UncachedObject> batch = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            batch.add(new UncachedObject(prefix + "-" + i, i));
+        }
+        writer.storeList(batch, COLL);
+    }
+
+    private Morphium writerFor(int port, String db) {
+        MorphiumConfig cfg = new MorphiumConfig();
+        cfg.clusterSettings().setHostSeed("localhost:" + port);
+        cfg.connectionSettings().setDatabase(db);
+        cfg.connectionSettings().setMaxConnections(10);
+        cfg.cacheSettings().setBufferedWritesEnabled(false);
+        return new Morphium(cfg);
+    }
+
+    /**
+     * Common setup for cases (a) and (b): a standalone primary fed {@link #DOCS} documents,
+     * live-replicated to a manually-wired {@link ReplicationManager}, its replay buffer then
+     * shrunk so a subsequent gap cannot be resumed from the buffer (forcing the primary to
+     * answer "resume window lost" rather than silently truncating - the same trick
+     * {@code ReplicationResumeTest#bufferMissTriggersResync} uses).
+     *
+     * @return the follower's lastAppliedSequence right after live replication converged (S in
+     *         the class javadoc / bug report).
+     */
+    private long bootstrapFollowerWithData(int port1) throws Exception {
+        PoppyDB primary = startStandalonePrimary(port1);
+
+        local = new InMemoryDriver();
+        local.connect();
+        rm = new ReplicationManager(local, "localhost", port1);
+        rm.start();
+        assertTrue(poll(30_000, rm::isInitialSyncComplete), "initial (trivially empty) sync must complete");
+
+        Morphium writer = writerFor(port1, DB);
+        try {
+            writeDocs(writer, DOCS, "pre");
+            assertTrue(poll(30_000, () -> localCount() == DOCS),
+                "follower must live-replicate the batch (got " + localCount() + ")");
+        } finally {
+            writer.close();
+        }
+        assertTrue(poll(5_000, () -> rm.getLastAppliedSequence() > 0),
+            "lastAppliedSequence must have advanced past 0 via live replication");
+        long s = rm.getLastAppliedSequence();
+
+        // Shrink the buffer so the upcoming gap cannot be resumed from it.
+        primary.getDriver().setChangeStreamHistoryLimit(2);
+        return s;
+    }
+
+    // ---- case (a): reconnected primary is behind -> refuse -----------------------------------
+
+    @Test
+    public void refusesWhenReconnectedPrimaryIsBehind() throws Exception {
+        int port1 = nextPort();
+        long s = bootstrapFollowerWithData(port1);
+        assertEquals(0, rm.getRefusedResyncCount(), "no refusal should have happened yet");
+
+        ch.qos.logback.classic.Logger rmLogger =
+            (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(ReplicationManager.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        rmLogger.addAppender(appender);
+
+        try {
+            // Sever, kill the primary (destroying its state), and put a brand-new EMPTY PoppyDB
+            // on the SAME port - "a freshly restarted node" the follower will reconnect to.
+            rm.pauseReplicationForTest();
+            Thread.sleep(500);
+            nodes.get(0).shutdown();
+            nodes.remove(0);
+            startStandalonePrimary(port1); // fresh, empty, sequence starts near 0
+
+            rm.resumeReplicationForTest();
+
+            assertTrue(poll(30_000, () -> rm.getRefusedResyncCount() >= 1),
+                "reconnecting to a behind/empty primary must be refused (refusedResyncCount="
+                    + rm.getRefusedResyncCount() + ")");
+            assertTrue(poll(5_000, rm::isRefusingDestructiveResync),
+                "the refusal state must be currently active");
+
+            // Data must be untouched - the whole point of the fix.
+            assertEquals(DOCS, localCount(),
+                "local data must survive a refused resync against a regressed primary");
+            assertFalse(rm.isInitialSyncComplete(),
+                "a refused resync must not be reported as a completed sync");
+
+            List<ILoggingEvent> errors = appender.list.stream()
+                .filter(ev -> ev.getLevel() == Level.ERROR)
+                .collect(Collectors.toList());
+            assertTrue(errors.stream().anyMatch(ev -> ev.getFormattedMessage().contains("refusing full re-sync")
+                    && ev.getFormattedMessage().contains("possible restarted/stale primary")),
+                "an ERROR log must document the refusal: " + errors.stream()
+                    .map(ILoggingEvent::getFormattedMessage).collect(Collectors.toList()));
+
+            Map<String, Object> stats = rm.getStats();
+            assertEquals(Boolean.TRUE, stats.get("refusingDestructiveResync"),
+                "getStats() must surface the active refusal");
+            assertTrue((Long) stats.get("refusedResyncCount") >= 1,
+                "getStats() must surface the refusal count");
+
+            // Recoverability (the brief's explicit requirement): once the SAME reconnected
+            // process genuinely catches up - its own sequence overtakes the follower's local
+            // sequence via real writes - the refusal must lift on its own and the follower must
+            // resync normally, with no operator intervention beyond writes actually happening.
+            PoppyDB caughtUpPrimary = nodes.get(0);
+            Morphium catchUpWriter = writerFor(port1, DB);
+            try {
+                writeDocs(catchUpWriter, (int) s + 50, "catchup");
+            } finally {
+                catchUpWriter.close();
+            }
+
+            assertTrue(poll(60_000, () -> rm.isInitialSyncComplete() && !rm.isRefusingDestructiveResync()),
+                "the follower must eventually resync once the primary genuinely caught up "
+                    + "(isInitialSyncComplete=" + rm.isInitialSyncComplete()
+                    + ", refusing=" + rm.isRefusingDestructiveResync() + ")");
+            assertTrue(poll(30_000, () -> localCount() == caughtUpPrimary.getDriver()
+                    .count(DB, COLL, Doc.of(), null, null)),
+                "the recovered follower must converge to the caught-up primary's data (local="
+                    + localCount() + ")");
+
+            log.info("case (a) converged: local sequence was {}, refusedResyncCount={}",
+                s, rm.getRefusedResyncCount());
+        } finally {
+            rmLogger.detachAppender(appender);
+        }
+    }
+
+    // ---- case (b): reconnected primary is empty but caught up -> resync proceeds ------------
+
+    @Test
+    public void proceedsWhenReconnectedPrimaryIsEmptyButCaughtUp() throws Exception {
+        int port1 = nextPort();
+        long s = bootstrapFollowerWithData(port1);
+
+        rm.pauseReplicationForTest();
+        Thread.sleep(500);
+        nodes.get(0).shutdown();
+        nodes.remove(0);
+        PoppyDB freshPrimary = startStandalonePrimary(port1);
+
+        // Legitimate post-dropDatabase shape: advance the fresh primary's own sequence counter
+        // well past the follower's local sequence (via unrelated writes), then drop that data -
+        // final state is empty, but the sequence keeps counting up, unlike a genuinely-behind
+        // primary.
+        Morphium bumpWriter = writerFor(port1, "bumpdb");
+        try {
+            writeDocs(bumpWriter, (int) Math.max(50, s + 100), "bump");
+        } finally {
+            bumpWriter.close();
+        }
+        GenericCommand dropBump = new GenericCommand(freshPrimary.getDriver());
+        dropBump.setDb("bumpdb");
+        dropBump.setCmdData(Doc.of("dropDatabase", 1, "$db", "bumpdb"));
+        freshPrimary.getDriver().runCommand(dropBump);
+
+        rm.resumeReplicationForTest();
+
+        assertTrue(poll(30_000, () -> rm.isInitialSyncComplete() && localCount() == 0),
+            "a legitimately caught-up (even if empty) primary must sync normally (got count="
+                + localCount() + ", initialSyncComplete=" + rm.isInitialSyncComplete() + ")");
+        assertEquals(0, rm.getRefusedResyncCount(),
+            "a caught-up primary must never trigger the destructive-resync refusal");
+        assertFalse(rm.isRefusingDestructiveResync(), "must not be left in a refusing state");
+        assertFalse(rm.wasLastSyncShortcut(),
+            "namespaces genuinely differed (primary emptied, local still had data) - must be a full sync");
+
+        log.info("case (b) converged: local sequence was {}", s);
+    }
+
+    // ---- case (c) / D4: shortcut must not be taken when local has an extra namespace ---------
+
+    @Test
+    public void shortcutNotTakenWhenLocalHasExtraNamespace() throws Exception {
+        int port1 = nextPort();
+        long s = bootstrapFollowerWithData(port1);
+        PoppyDB primary = nodes.get(0);
+
+        // Test-only backdoor: write straight into the follower's InMemoryDriver, bypassing
+        // replication, to create a namespace the (still perfectly healthy, never-restarted)
+        // primary does not have (same technique as FastResyncTest#fallbackOnDivergence, but a
+        // whole extra NAMESPACE rather than an extra document in an existing one).
+        GenericCommand inject = new GenericCommand(local);
+        inject.setDb("extradb");
+        inject.setColl("extracoll");
+        inject.setCmdData(Doc.of(
+            "insert", "extracoll", "$db", "extradb",
+            "documents", List.of(Doc.of("_id", "extra-doc", "note", "local-only"))));
+        local.runCommand(inject);
+        assertEquals(1, local.count("extradb", "extracoll", Doc.of(), null, null),
+            "the injected extra namespace must be present before the forced resync");
+
+        // Force a fresh sync cycle against the SAME still-alive primary (never restarted, so its
+        // sequence only ever increases - the D2 guard must never fire here, isolating this test
+        // to the shortcut's namespace comparison alone): sever, write a gap the shrunk buffer
+        // cannot cover, heal.
+        rm.pauseReplicationForTest();
+        Thread.sleep(500);
+        Morphium writer = writerFor(port1, DB);
+        try {
+            writeDocs(writer, DOCS, "gap");
+        } finally {
+            writer.close();
+        }
+        Thread.sleep(300);
+        rm.resumeReplicationForTest();
+
+        assertTrue(poll(30_000, () -> rm.isInitialSyncComplete() && localCount() == 2 * DOCS),
+            "follower must converge to both batches after the forced resync (got count="
+                + localCount() + ")");
+        assertEquals(0, rm.getRefusedResyncCount(),
+            "the still-live, never-restarted primary must never trigger the D2 refusal");
+        assertFalse(rm.wasLastSyncShortcut(),
+            "a follower with a local-only extra namespace must NOT take the consistency shortcut "
+                + "(union comparison, not intersection)");
+
+        // The extra namespace must be gone - proof the mismatch was actually detected and acted
+        // on, not silently waved through by an intersection-only comparison.
+        assertTrue(poll(15_000, () -> local.count("extradb", "extracoll", Doc.of(), null, null) == 0),
+            "the local-only extra namespace must be wiped by the (legitimate) full resync");
+
+        log.info("case (c) converged: local sequence was {}", s);
+    }
+}

--- a/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
+++ b/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
@@ -178,6 +178,42 @@ public class ReplicationFailClosedTest {
     }
 
     /**
+     * Copies the follower's CURRENT {@code DB.COLL} documents, verbatim, into a target node's
+     * driver - the same doc {@code Map}s {@link InMemoryDriver#find} returns, re-inserted as-is.
+     * Unlike two independent inserts built from scratch (which do not reliably dbHash-match -
+     * apparently not just field content but some internal representation detail differs), this
+     * guarantees a genuine dbHash match: it is a literal copy of the exact bytes replication
+     * already produced, the same technique {@code performInitialSync}'s own {@code syncCollection}
+     * uses to seed a follower from a primary.
+     */
+    private void copyLocalDataInto(PoppyDB target) throws Exception {
+        List<Map<String, Object>> docs = local.find(DB, COLL, Doc.of(), null, null, 0, 1000);
+        GenericCommand cmd = new GenericCommand(target.getDriver());
+        cmd.setDb(DB);
+        cmd.setColl(COLL);
+        cmd.setCmdData(Doc.of("insert", COLL, "$db", DB, "documents", docs));
+        target.getDriver().runCommand(cmd);
+    }
+
+    /**
+     * Inserts {@code count} documents with DETERMINISTIC {@code _id}s (unlike {@link #writeDocs},
+     * whose {@link UncachedObject}s get a fresh random {@code MorphiumId} on every call) directly
+     * into a target node's driver - bypassing Morphium/the wire protocol, same pattern as the
+     * dbHash-comparison tests elsewhere in this file.
+     */
+    private void insertFixedDocs(PoppyDB target, int count, String prefix) throws Exception {
+        List<Map<String, Object>> docs = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            docs.add(Doc.of("_id", prefix + "-" + i, "value", i));
+        }
+        GenericCommand cmd = new GenericCommand(target.getDriver());
+        cmd.setDb(DB);
+        cmd.setColl(COLL);
+        cmd.setCmdData(Doc.of("insert", COLL, "$db", DB, "documents", docs));
+        target.getDriver().runCommand(cmd);
+    }
+
+    /**
      * Common setup for cases (a) and (b): a standalone primary fed {@link #DOCS} documents,
      * live-replicated to a manually-wired {@link ReplicationManager}, its replay buffer then
      * shrunk so a subsequent gap cannot be resumed from the buffer (forcing the primary to
@@ -566,5 +602,130 @@ public class ReplicationFailClosedTest {
         } finally {
             drv.close();
         }
+    }
+
+    // ---- I-1 (final review): adopt the synced primary's own base, don't max() with a stale one -
+
+    /**
+     * Sequences are PRIMARY-LOCAL (see {@code tryConsistencyShortcut}'s own javadoc). Before this
+     * fix, a successful sync/shortcut reseeded {@code lastAppliedSequence} via
+     * {@code Math.max(current, lastKnownPrimarySequence)} - so a follower that had accumulated a
+     * HIGH sequence N against an old primary kept N even after successfully converging against a
+     * brand-new primary whose own counter is comfortably below N (only reachable via the
+     * consistency SHORTCUT: the D2 guard would otherwise refuse a full sync against a primary
+     * whose counter is behind local - so "successful sync with a lower primary counter" and
+     * "guard-gated full sync" are mutually exclusive by construction; the shortcut is the only
+     * path that bypasses the guard entirely). Every later reconnect then sent
+     * {@code resumeAfter=N}, which the new (low-counter) primary could never satisfy -> "resume
+     * window lost" -> a dbHash mismatch as soon as one real write happened (breaking the
+     * shortcut) -> the D2 guard comparing the new primary's still-low counter against the STALE
+     * inherited N -> refusing an entirely legitimate resync, unbounded on a quiet cluster.
+     *
+     * <p>Reproduced here by CHURNING the original primary (delete + re-insert the same content)
+     * so its own counter inflates well past what recreating that exact content needs, then
+     * replacing it with a brand-new primary fed the identical content in a single write (same
+     * deterministic {@code _id}s via {@link #insertFixedDocs} - the dbHash comparison, unlike
+     * {@link #writeDocs}'s random {@code MorphiumId}s, needs byte-for-byte identical documents to
+     * match). Verified red against the reverted {@code Math.max(...)} before landing the
+     * {@code set(...)} fix (manual step, not committed - the assertion on
+     * {@code getLastAppliedSequence() < n} failed, and the final legitimate-resync poll timed out
+     * with the follower stuck refusing).
+     */
+    @Test
+    public void adoptsNewPrimaryBaseAfterSuccessfulShortcutSoLaterResyncsAreNotRefused() throws Exception {
+        int port1 = nextPort();
+        PoppyDB primaryA = startStandalonePrimary(port1);
+
+        local = new InMemoryDriver();
+        local.connect();
+        rm = new ReplicationManager(local, "localhost", port1);
+        rm.start();
+        assertTrue(poll(30_000, rm::isInitialSyncComplete), "initial (trivially empty) sync must complete");
+
+        insertFixedDocs(primaryA, DOCS, "chk");
+        assertTrue(poll(30_000, () -> localCount() == DOCS),
+            "follower must live-replicate the batch (got " + localCount() + ")");
+
+        // Churn: delete and re-insert the SAME content so primaryA's own counter advances well
+        // past what a single write needs, while the final DATA (all dbHash compares) is
+        // unchanged.
+        GenericCommand delAll = new GenericCommand(primaryA.getDriver());
+        delAll.setDb(DB);
+        delAll.setColl(COLL);
+        delAll.setCmdData(Doc.of("delete", COLL, "$db", DB,
+            "deletes", List.of(Doc.of("q", Doc.of(), "limit", 0))));
+        primaryA.getDriver().runCommand(delAll);
+        assertTrue(poll(10_000, () -> primaryA.getDriver().count(DB, COLL, Doc.of(), null, null) == 0),
+            "churn delete must land on the primary");
+        insertFixedDocs(primaryA, DOCS, "chk");
+
+        assertTrue(poll(30_000, () -> localCount() == DOCS),
+            "follower must reconverge to the re-inserted batch (got " + localCount() + ")");
+        assertTrue(poll(5_000, () -> rm.getLastAppliedSequence() > 0),
+            "lastAppliedSequence must have advanced past 0");
+        long n = rm.getLastAppliedSequence(); // the OLD primary's high, churn-inflated counter
+
+        primaryA.getDriver().setChangeStreamHistoryLimit(2);
+        rm.pauseReplicationForTest();
+        Thread.sleep(500);
+        nodes.get(0).shutdown();
+        nodes.remove(0);
+
+        // A brand-new primary whose own counter starts near 0, fed the EXACT SAME final content
+        // in one write (no churn), copied verbatim from the follower's current data (see
+        // copyLocalDataInto's javadoc for why a verbatim copy, not an independently-reconstructed
+        // insert, is what reliably dbHash-matches) - comfortably below N either way.
+        PoppyDB primaryB = startStandalonePrimary(port1);
+        copyLocalDataInto(primaryB);
+
+        // isInitialSyncComplete() is ALREADY true at this point (stale from the trivial bootstrap
+        // sync at the very top of this test, never reset) - polling it directly would pass
+        // instantly without waiting for a real cycle against primaryB at all. Wait for the
+        // MONOTONIC shortcut-attempt counter to advance instead - the only reliable "a genuinely
+        // NEW sync decision cycle has run" signal (a boolean flip false->true here is real but
+        // racy: the whole reconnect+resume-window-lost+shortcut cycle can complete faster than a
+        // 100ms poll interval, so a poll might only ever observe the post-cycle `true`, identical
+        // to the pre-cycle stale `true`).
+        int shortcutAttemptsBeforeResume = rm.getConsistencyShortcutAttemptsForTest();
+        rm.resumeReplicationForTest();
+
+        assertTrue(poll(30_000, () -> rm.getConsistencyShortcutAttemptsForTest() > shortcutAttemptsBeforeResume
+                && rm.isInitialSyncComplete()),
+            "a genuinely new sync cycle must run and complete against primaryB (shortcut attempts "
+                + "before=" + shortcutAttemptsBeforeResume + ", now=" + rm.getConsistencyShortcutAttemptsForTest()
+                + ", isInitialSyncComplete=" + rm.isInitialSyncComplete() + ")");
+        assertTrue(rm.wasLastSyncShortcut(),
+            "test setup: this sync must take the consistency shortcut (identical data, D2 guard "
+                + "bypassed) to reproduce a successful sync while the new primary's own counter "
+                + "is far below N=" + n);
+        assertEquals(0, rm.getRefusedResyncCount(), "the initial shortcut sync itself must never be refused");
+
+        // The core I-1 assertion: lastAppliedSequence must have been ADOPTED from the new
+        // primary's own (low) base, not left at the old primary's inflated N via Math.max.
+        assertTrue(rm.getLastAppliedSequence() < n,
+            "lastAppliedSequence must adopt the new primary's own (lower) base after a successful "
+                + "sync, not stay pinned at the old primary's unrelated, inflated sequence space "
+                + "(N=" + n + ", got " + rm.getLastAppliedSequence() + ")");
+
+        // The actual regression: force a SECOND, entirely legitimate resync against the SAME
+        // still-alive (never regressed) primary B - a real gap it cannot buffer from. Before the
+        // fix this refused forever, because lastAppliedSequence (still pinned at N) could never
+        // be <= primary B's real, much lower counter.
+        primaryB.getDriver().setChangeStreamHistoryLimit(2);
+        rm.pauseReplicationForTest();
+        Thread.sleep(500);
+        insertFixedDocs(primaryB, DOCS, "gap2");
+        Thread.sleep(300);
+        rm.resumeReplicationForTest();
+
+        assertTrue(poll(30_000, () -> rm.isInitialSyncComplete() && localCount() == 2 * DOCS),
+            "a legitimate resync against the SAME (never-regressed) primary must proceed, not be "
+                + "refused forever due to a stale, unrelated old-primary sequence (got count="
+                + localCount() + ", refusedResyncCount=" + rm.getRefusedResyncCount() + ")");
+        assertEquals(0, rm.getRefusedResyncCount(),
+            "a legitimate resync must never trip the D2 guard once the base has been correctly adopted");
+
+        log.info("I-1 regression converged: N={}, final lastAppliedSequence={}",
+            n, rm.getLastAppliedSequence());
     }
 }

--- a/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
+++ b/poppydb/src/test/java/de/caluga/poppydb/ReplicationFailClosedTest.java
@@ -449,6 +449,12 @@ public class ReplicationFailClosedTest {
     // over - would make the destructive-resync guard vacuously pass on every leader change; these
     // tests exercise ReplicationManager#carryOverLastAppliedSequence directly, the same call
     // PoppyDB now makes before starting the replacement.
+    //
+    // 2026-08-14 production-CI fix (I-2): both tests below now use the two-arg,
+    // primary-identity-aware carryOverLastAppliedSequence(seq, sourceAddress) - portA/portB/portC
+    // are all DIFFERENT addresses, exactly the shape a real leader change has in production. See
+    // carryOverRefusesOnlyWhenReplacementLeaderIsTheSameAddressRegressed below for the mirror that
+    // covers the SAME-address case (the actual kill chain).
 
     @Test
     public void carryOverAllowsNormalSyncWhenReplacementLeaderIsCaughtUp() throws Exception {
@@ -474,6 +480,7 @@ public class ReplicationFailClosedTest {
         assertTrue(poll(5_000, () -> rm1.getLastAppliedSequence() > 0),
             "rm1 lastAppliedSequence must have advanced past 0");
         long predecessorSeq = rm1.getLastAppliedSequence();
+        String predecessorAddress = rm1.getLeaderAddress();
 
         // Simulate PoppyDB#startReplicationToLeader tearing down the old RM on a leader change.
         rm1.stop();
@@ -488,10 +495,14 @@ public class ReplicationFailClosedTest {
             writerB.close();
         }
 
-        // Replacement RM, same local driver, carrying the predecessor's sequence forward exactly
-        // as PoppyDB#startReplicationToLeader now does.
+        // Replacement RM, same local driver, carrying the predecessor's (sequence, source
+        // address) forward exactly as PoppyDB#startReplicationToLeader now does. Different
+        // address (portA vs portB) - per the identity-aware overload, this does NOT arm the
+        // guard; the outcome (sync succeeds) is unchanged from before I-2 either way here since
+        // the new leader is caught up regardless, but the MECHANISM is now adopt-at-registration,
+        // not a guard pass.
         rm = new ReplicationManager(local, "localhost", portB);
-        rm.carryOverLastAppliedSequence(predecessorSeq);
+        rm.carryOverLastAppliedSequence(predecessorSeq, predecessorAddress);
         rm.start();
 
         assertTrue(poll(30_000, rm::isInitialSyncComplete),
@@ -504,8 +515,23 @@ public class ReplicationFailClosedTest {
             predecessorSeq, localCount());
     }
 
+    /**
+     * I-2 (production-CI fix, superseding the old {@code carryOverRefusesWhenReplacementLeaderIsRegressed}):
+     * a genuine leader change to a DIFFERENT primary, even one whose own counter is far below the
+     * predecessor's, must NOT be refused - the carried sequence lives in an unrelated, foreign
+     * number space and must not arm the guard at all. This is exactly the CI incident: node1
+     * carried 227951 from its old leader; the new leader's own counter was 213896 (lower, but a
+     * completely different and entirely legitimate primary) - the old code refused for 40+
+     * minutes; the fix adopts the new primary's own base at registration and lets dbHash/the
+     * consistency shortcut decide. Here that means a full resync legitimately proceeds (the new,
+     * near-empty primary's data does not match local's) and local converges to ITS (near-empty)
+     * state - the wipe is correct in this case, because a genuinely different, currently-elected
+     * leader's state is exactly what a follower is supposed to converge to. Protecting against a
+     * WRONGLY-elected empty leader is the election layer's job (Tasks 1/2/4), not this guard's -
+     * see the class-level javadoc on {@code ReplicationManager#carryOverLastAppliedSequence(long, String)}.
+     */
     @Test
-    public void carryOverRefusesWhenReplacementLeaderIsRegressed() throws Exception {
+    public void carryOverAdoptsFreshBaseWhenReplacementLeaderIsDifferentEvenIfItsCounterIsLower() throws Exception {
         int portA = nextPort();
         int portC = nextPort();
         startStandalonePrimary(portA);
@@ -528,25 +554,87 @@ public class ReplicationFailClosedTest {
         assertTrue(poll(5_000, () -> rm1.getLastAppliedSequence() > 0),
             "rm1 lastAppliedSequence must have advanced past 0");
         long predecessorSeq = rm1.getLastAppliedSequence();
+        String predecessorAddress = rm1.getLeaderAddress();
 
         rm1.stop();
 
-        // The "new leader": a FRESH, EMPTY standalone primary - a regressed/stale leader
-        // (sequence starts near 0, necessarily behind predecessorSeq).
+        // The "new leader": a genuinely DIFFERENT (different port/address) standalone primary,
+        // fresh and empty - its own counter is near 0, far below predecessorSeq. In production
+        // this is an ordinary leader change to a new, currently-quiet leader, not a restart of
+        // the same node.
         startStandalonePrimary(portC);
 
         rm = new ReplicationManager(local, "localhost", portC);
-        rm.carryOverLastAppliedSequence(predecessorSeq);
+        rm.carryOverLastAppliedSequence(predecessorSeq, predecessorAddress);
+        rm.start();
+
+        assertTrue(poll(30_000, rm::isInitialSyncComplete),
+            "a genuinely different replacement leader must sync normally - never blocked by a "
+                + "carried sequence earned against a different primary");
+        assertEquals(0, rm.getRefusedResyncCount(),
+            "a different replacement leader must never trip the destructive-resync guard, "
+                + "regardless of its own counter being lower than the predecessor's");
+        assertFalse(rm.isRefusingDestructiveResync());
+        assertTrue(poll(10_000, () -> localCount() == 0),
+            "local must legitimately converge to the new (empty) leader's real state - this guard "
+                + "is not the barrier against a wrongly-elected leader, the election layer is");
+
+        log.info("I-2 different-leader-lower-counter case converged: predecessorSeq={}", predecessorSeq);
+    }
+
+    /**
+     * I-2's mirror: the SAME leader address restarting empty/stale, reached via the
+     * RM-REPLACEMENT path (not the intra-RM {@code triggerResync()} path already covered by
+     * {@link #refusesWhenReconnectedPrimaryIsBehind()}) - this is the true kill chain
+     * {@code EmptyNodeRestartWipeTest} guards end-to-end, and must still refuse after I-2.
+     */
+    @Test
+    public void carryOverRefusesOnlyWhenReplacementLeaderIsTheSameAddressRegressed() throws Exception {
+        int portA = nextPort();
+        startStandalonePrimary(portA);
+
+        local = new InMemoryDriver();
+        local.connect();
+        ReplicationManager rm1 = new ReplicationManager(local, "localhost", portA);
+        extraReplicationManagers.add(rm1);
+        rm1.start();
+        assertTrue(poll(30_000, rm1::isInitialSyncComplete), "rm1 initial sync must complete");
+
+        Morphium writerA = writerFor(portA, DB);
+        try {
+            writeDocs(writerA, DOCS, "pre");
+            assertTrue(poll(30_000, () -> localCount() == DOCS),
+                "rm1 must live-replicate the batch (got " + localCount() + ")");
+        } finally {
+            writerA.close();
+        }
+        assertTrue(poll(5_000, () -> rm1.getLastAppliedSequence() > 0),
+            "rm1 lastAppliedSequence must have advanced past 0");
+        long predecessorSeq = rm1.getLastAppliedSequence();
+        String predecessorAddress = rm1.getLeaderAddress();
+
+        rm1.stop();
+        nodes.get(0).shutdown(); // kill the SAME node's process (destroying its in-memory state)
+        nodes.remove(0);
+        // ... and put a brand-new, empty PoppyDB back on the EXACT SAME port - "the same node
+        // restarted empty", reached this time via a fresh ReplicationManager (RM replacement),
+        // not via the original RM's own reconnect/triggerResync loop.
+        startStandalonePrimary(portA);
+
+        rm = new ReplicationManager(local, "localhost", portA);
+        assertEquals(predecessorAddress, rm.getLeaderAddress(),
+            "test setup: the replacement RM must target the exact same address as the predecessor");
+        rm.carryOverLastAppliedSequence(predecessorSeq, predecessorAddress);
         rm.start();
 
         assertTrue(poll(30_000, () -> rm.getRefusedResyncCount() >= 1),
-            "a regressed replacement leader must be refused (refusedResyncCount="
+            "a same-address regressed replacement leader must still be refused (refusedResyncCount="
                 + rm.getRefusedResyncCount() + ")");
         assertFalse(rm.isInitialSyncComplete(), "a refused replacement must not report a completed sync");
         assertEquals(DOCS, localCount(),
             "local data carried over from the predecessor RM must survive a refused replacement resync");
 
-        log.info("carry-over regressed case converged: predecessorSeq={}, refusedResyncCount={}",
+        log.info("I-2 same-address-regressed case converged: predecessorSeq={}, refusedResyncCount={}",
             predecessorSeq, rm.getRefusedResyncCount());
     }
 
@@ -599,6 +687,40 @@ public class ReplicationFailClosedTest {
 
             assertEquals(500, node.carryOverSequenceFor(predecessor),
                 "a live predecessor's own position must be used, not the stale watermark");
+        } finally {
+            drv.close();
+        }
+    }
+
+    // ---- I-2 (production-CI fix): PoppyDB#carryOverSourceFor, the companion to
+    // carryOverSequenceFor - same pure/isolated/no-network shape as the two tests above.
+
+    @Test
+    public void carryOverSourceFallsBackToPersistedWatermarkWhenNoPredecessor() {
+        PoppyDB node = new PoppyDB();
+        nodes.add(node);
+
+        node.setLastKnownAppliedSequenceSourceForTest("localhost:9999");
+
+        assertEquals("localhost:9999", node.carryOverSourceFor(null),
+            "a failed-start retry (predecessor == null) must fall back to the persisted source "
+                + "watermark, exactly mirroring carryOverSequenceFor's own fallback");
+    }
+
+    @Test
+    public void carryOverSourceReadsLivePredecessorWhenPresent() throws Exception {
+        PoppyDB node = new PoppyDB();
+        nodes.add(node);
+
+        node.setLastKnownAppliedSequenceSourceForTest("localhost:1111"); // stale, must not shadow
+
+        InMemoryDriver drv = new InMemoryDriver();
+        drv.connect();
+        try {
+            ReplicationManager predecessor = new ReplicationManager(drv, "localhost", 2222);
+
+            assertEquals("localhost:2222", node.carryOverSourceFor(predecessor),
+                "a live predecessor's own leader address must be used, not the stale watermark");
         } finally {
             drv.close();
         }

--- a/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionLogRecencyTest.java
+++ b/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionLogRecencyTest.java
@@ -21,11 +21,17 @@ import static org.junit.jupiter.api.Assertions.*;
  * node winning an election against nodes still holding data because {@code lastLogIndex} was
  * never updated by any production caller.
  *
- * <p>The deny-case test deliberately sets up the voter's data via the same production
+ * <p>The deny-case tests deliberately set up the voter's data via the same production
  * mechanism (leader-side {@code localSequenceSupplier} synced while heartbeating) rather than
  * poking {@link ElectionManager#updateLogIndex} directly - that method already worked correctly
  * before this fix (see {@code ElectionManagerTest#testVoteRequestLogComparison}); the bug was
  * that nothing production ever called it.
+ *
+ * <p>{@link #deniesVoteFromEmptyCandidateWithHigherStaleTermThanVoter} covers a second-round
+ * review finding: {@code isLogAtLeastAsUpToDate} must NOT fall back to comparing {@code
+ * lastLogTerm} when indices differ, because that term is only a {@code currentTerm} stand-in
+ * fed independently on each node - a once-elected, now-empty candidate can carry a higher stale
+ * term than a data-holding voter, and a term-first comparison would wrongly grant it the vote.
  */
 public class ElectionLogRecencyTest {
 
@@ -99,6 +105,24 @@ public class ElectionLogRecencyTest {
 
         assertFalse(response.isVoteGranted(),
                 "must deny vote to an empty candidate (log behind) when the voter holds real replicated data");
+    }
+
+    @Test
+    void deniesVoteFromEmptyCandidateWithHigherStaleTermThanVoter() throws Exception {
+        ElectionManager voter = singleNodeLeaderWithSequence("voter-with-data:27020", 500);
+
+        // Adversarial case from review: an empty candidate (index 0) whose lastLogTerm happens
+        // to be HIGHER than the voter's currentTerm - e.g. it was elected once before while
+        // still empty, or simply raced its own currentTerm up through repeated candidacy
+        // retries. A term-first Raft-style comparison would grant this vote (candidateLastTerm >
+        // myLastTerm), reopening the exact empty-node-wipe bug. Must still be denied on index
+        // alone.
+        VoteRequest staleHighTermEmptyCandidateRequest = new VoteRequest(
+                voter.getCurrentTerm() + 1, "empty-candidate-high-term:27020", 0, voter.getCurrentTerm() + 100);
+        VoteResponse response = voter.handleVoteRequest(staleHighTermEmptyCandidateRequest);
+
+        assertFalse(response.isVoteGranted(),
+                "must deny an empty candidate even when its (stand-in) lastLogTerm is higher than the voter's");
     }
 
     @Test

--- a/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionLogRecencyTest.java
+++ b/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionLogRecencyTest.java
@@ -32,6 +32,14 @@ import static org.junit.jupiter.api.Assertions.*;
  * lastLogTerm} when indices differ, because that term is only a {@code currentTerm} stand-in
  * fed independently on each node - a once-elected, now-empty candidate can carry a higher stale
  * term than a data-holding voter, and a term-first comparison would wrongly grant it the vote.
+ *
+ * <p>{@link #updateLogIndexNeverLowersTheIndex} covers a third-round review finding:
+ * {@link ElectionManager#updateLogIndex} must use max (monotonic) semantics. Without it, a
+ * freshly-synced-then-silent node's seeded index (see {@code ReplicationManager}'s
+ * initial-sync-completion call site, and the dedicated integration test {@code
+ * InitialSyncElectionSeedTest}) would be silently regressed back to {@code 0} by the very next
+ * leader-side heartbeat tick (which reads the LOCAL driver's change-stream sequence - unrelated
+ * to, and possibly lower than, the synced position - see updateLogIndex's javadoc).
  */
 public class ElectionLogRecencyTest {
 
@@ -140,6 +148,51 @@ public class ElectionLogRecencyTest {
 
         assertTrue(response.isVoteGranted(),
                 "must grant vote to a candidate that is at least as up to date, even from an empty voter");
+    }
+
+    @Test
+    void voterSeededViaUpdateLogIndexDeniesEmptyCandidate() throws Exception {
+        // Direct-call variant (as opposed to deniesVoteFromEmptyCandidateWhenVoterHoldsData's
+        // production-wiring variant): confirms the seed-then-deny path also works when fed the
+        // way ReplicationManager's initial-sync-completion call site feeds it - a single
+        // updateLogIndex() call with no further live events.
+        ElectionConfig config = new ElectionConfig()
+                .setElectionTimeoutMinMs(60_000)
+                .setElectionTimeoutMaxMs(60_000);
+        ElectionManager voter = new ElectionManager("seeded-voter:27021", List.of("seeded-voter:27021", "candidate:27021"), config);
+        managers.add(voter);
+        voter.updateLogIndex(500, 0);
+        voter.start();
+
+        VoteRequest emptyCandidateRequest = new VoteRequest(
+                voter.getCurrentTerm() + 1, "empty-candidate:27021", 0, 0);
+        VoteResponse response = voter.handleVoteRequest(emptyCandidateRequest);
+
+        assertFalse(response.isVoteGranted(),
+                "a voter seeded via updateLogIndex (e.g. after an initial sync) must deny an empty candidate");
+    }
+
+    @Test
+    void updateLogIndexNeverLowersTheIndex() throws Exception {
+        ElectionConfig config = new ElectionConfig()
+                .setElectionTimeoutMinMs(60_000)
+                .setElectionTimeoutMaxMs(60_000);
+        ElectionManager manager = new ElectionManager("monotonic:27022", List.of("monotonic:27022"), config);
+        managers.add(manager);
+
+        manager.updateLogIndex(500, 3);
+        assertEquals(500, manager.getLastLogIndex(), "index must be set on the first call");
+
+        // Simulates the leader-side heartbeat feed reading the local driver's change-stream
+        // sequence (0, since initial sync runs under suppressChangeStreamEvents) right after the
+        // seed above - must not regress the already-known, higher index.
+        manager.updateLogIndex(0, 3);
+        assertEquals(500, manager.getLastLogIndex(),
+                "a lower index must never overwrite a higher one already recorded");
+
+        // A genuinely higher index must still win.
+        manager.updateLogIndex(600, 3);
+        assertEquals(600, manager.getLastLogIndex(), "a higher index must still advance the value");
     }
 
     @Test

--- a/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionLogRecencyTest.java
+++ b/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionLogRecencyTest.java
@@ -1,0 +1,139 @@
+package de.caluga.test.poppydb.election;
+
+import de.caluga.poppydb.election.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * D1: the election log-recency check ({@link ElectionManager#handleVoteRequest}'s
+ * isLogAtLeastAsUpToDate comparison) must be fed by the real replication sequence instead of
+ * staying vacuously 0/0 on every node - see the bug this closes: a freshly restarted, empty
+ * node winning an election against nodes still holding data because {@code lastLogIndex} was
+ * never updated by any production caller.
+ *
+ * <p>The deny-case test deliberately sets up the voter's data via the same production
+ * mechanism (leader-side {@code localSequenceSupplier} synced while heartbeating) rather than
+ * poking {@link ElectionManager#updateLogIndex} directly - that method already worked correctly
+ * before this fix (see {@code ElectionManagerTest#testVoteRequestLogComparison}); the bug was
+ * that nothing production ever called it.
+ */
+public class ElectionLogRecencyTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ElectionLogRecencyTest.class);
+
+    private final List<ElectionManager> managers = new ArrayList<>();
+
+    @AfterEach
+    void cleanup() {
+        for (ElectionManager manager : managers) {
+            try {
+                manager.stop();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+        managers.clear();
+    }
+
+    /** Poll-based wait (no sleep+assert) matching the pattern used across the election suite. */
+    private static void awaitCondition(String description, long timeoutMs, BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        assertTrue(condition.getAsBoolean(), "Timed out waiting for: " + description);
+    }
+
+    /**
+     * Single-node cluster that auto-elects itself leader, with its localSequenceSupplier wired
+     * to a fixed "real replication sequence" - exactly the supplier PoppyDB wires to
+     * {@code driver::getChangeStreamSequence} in production. Waits for that sequence to actually
+     * show up in {@link ElectionManager#getLastLogIndex()} through whatever production feeds it.
+     */
+    private ElectionManager singleNodeLeaderWithSequence(String address, long sequence) throws InterruptedException {
+        ElectionConfig config = new ElectionConfig()
+                .setElectionTimeoutMinMs(50)
+                .setElectionTimeoutMaxMs(100);
+        ElectionManager manager = new ElectionManager(address, List.of(address), config);
+        managers.add(manager);
+        manager.setLocalSequenceSupplier(() -> sequence);
+
+        CountDownLatch leaderLatch = new CountDownLatch(1);
+        manager.setOnLeadershipChange(isLeader -> {
+            if (isLeader) {
+                leaderLatch.countDown();
+            }
+        });
+        manager.start();
+        assertTrue(leaderLatch.await(2, TimeUnit.SECONDS), address + " should have become leader (single node)");
+
+        awaitCondition(address + " lastLogIndex synced to real sequence " + sequence, 2000,
+                () -> manager.getLastLogIndex() == sequence);
+        return manager;
+    }
+
+    @Test
+    void deniesVoteFromEmptyCandidateWhenVoterHoldsData() throws Exception {
+        ElectionManager voter = singleNodeLeaderWithSequence("voter-with-data:27017", 500);
+
+        // An empty (freshly restarted) candidate: log index/term both 0, but a higher election
+        // term than the voter - this is exactly how the real bug won: the empty node out-races
+        // the data-holding node's term through repeated candidacy retries, forcing the voter to
+        // adopt the higher term before the log check runs.
+        VoteRequest emptyCandidateRequest = new VoteRequest(
+                voter.getCurrentTerm() + 1, "empty-candidate:27017", 0, 0);
+        VoteResponse response = voter.handleVoteRequest(emptyCandidateRequest);
+
+        assertFalse(response.isVoteGranted(),
+                "must deny vote to an empty candidate (log behind) when the voter holds real replicated data");
+    }
+
+    @Test
+    void grantsVoteFromCaughtUpCandidateEvenWhenVoterIsEmpty() throws Exception {
+        ElectionConfig config = new ElectionConfig()
+                .setElectionTimeoutMinMs(1000)
+                .setElectionTimeoutMaxMs(2000);
+        ElectionManager voter = new ElectionManager("empty-voter:27018", List.of("empty-voter:27018", "candidate:27018"), config);
+        managers.add(voter);
+        voter.start();
+
+        VoteRequest caughtUpCandidateRequest = new VoteRequest(
+                voter.getCurrentTerm() + 1, "candidate:27018", 500, 0);
+        VoteResponse response = voter.handleVoteRequest(caughtUpCandidateRequest);
+
+        assertTrue(response.isVoteGranted(),
+                "must grant vote to a candidate that is at least as up to date, even from an empty voter");
+    }
+
+    @Test
+    void coldStartGrantsVoteWhenBothSidesAreEmpty() throws Exception {
+        // Cold-start invariant: three freshly started nodes, all at log index 0, must still be
+        // able to elect a leader - equal (0 == 0) indices must GRANT, not deadlock forever.
+        ElectionConfig config = new ElectionConfig()
+                .setElectionTimeoutMinMs(1000)
+                .setElectionTimeoutMaxMs(2000);
+        ElectionManager voter = new ElectionManager("cold-voter:27019", List.of("cold-voter:27019", "cold-candidate:27019"), config);
+        managers.add(voter);
+        voter.start();
+
+        VoteRequest emptyCandidateRequest = new VoteRequest(
+                voter.getCurrentTerm() + 1, "cold-candidate:27019", 0, 0);
+        VoteResponse response = voter.handleVoteRequest(emptyCandidateRequest);
+
+        assertTrue(response.isVoteGranted(),
+                "three empty nodes at cold start must still be able to elect a leader");
+    }
+}

--- a/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionLogRecencyTest.java
+++ b/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionLogRecencyTest.java
@@ -196,6 +196,40 @@ public class ElectionLogRecencyTest {
     }
 
     @Test
+    void emptyNodeWithDataBearingPeerDelaysCandidacyUntilSyncedOrPeerNeverSeen() throws Exception {
+        // D3: candidacy restraint. Short timeouts so several election-timeout cycles fit into
+        // the sleep window below - if the guard did not hold, at least one of them would flip
+        // this node to CANDIDATE.
+        ElectionConfig config = new ElectionConfig()
+                .setElectionTimeoutMinMs(50)
+                .setElectionTimeoutMaxMs(100);
+        ElectionManager restrained = new ElectionManager("restrained:27023",
+                List.of("restrained:27023", "data-peer:27023"), config);
+        managers.add(restrained);
+        restrained.start();
+
+        // Simulate this node observing AppendEntries traffic from a leader that reports a real,
+        // non-zero log index - exactly what handleAppendEntries sees in production heartbeats.
+        AppendEntriesRequest fromDataPeer = AppendEntriesRequest.heartbeat(
+                restrained.getCurrentTerm(), "data-peer:27023", 500, 0, 500);
+        restrained.handleAppendEntries(fromDataPeer);
+
+        // Own index is still 0 (nothing applied/produced this process lifetime). Despite
+        // repeated election timeouts, this node must never transition to CANDIDATE while a
+        // data-bearing peer is known - it can only lose that election and would just inflate
+        // the term, forcing the legitimate leader into a pointless step-down.
+        Thread.sleep(600);
+        assertEquals(ElectionState.FOLLOWER, restrained.getState(),
+                "empty node must hold back candidacy while a data-bearing peer is known, not race to CANDIDATE");
+
+        // Once its own index catches up (sync completed - Task 1's seed makes this prompt), the
+        // guard must no longer apply and candidacy becomes eligible again on the very next timeout.
+        restrained.updateLogIndex(10, restrained.getCurrentTerm());
+        awaitCondition("restrained becomes CANDIDATE once its own index is no longer 0", 1000,
+                () -> restrained.getState() == ElectionState.CANDIDATE);
+    }
+
+    @Test
     void coldStartGrantsVoteWhenBothSidesAreEmpty() throws Exception {
         // Cold-start invariant: three freshly started nodes, all at log index 0, must still be
         // able to elect a leader - equal (0 == 0) indices must GRANT, not deadlock forever.

--- a/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionManagerTest.java
+++ b/poppydb/src/test/java/de/caluga/test/poppydb/election/ElectionManagerTest.java
@@ -404,21 +404,26 @@ public class ElectionManagerTest {
         ElectionManager manager = new ElectionManager("localhost:27017", hosts, config);
         managers.add(manager);
 
-        // Set our log state to be ahead
+        // Set our log state to reflect real (non-empty) replication progress.
         manager.updateLogIndex(10, 2);
 
         manager.start();
         Thread.sleep(50);
 
-        // Request from candidate with older log (lower term)
-        VoteRequest oldLogRequest = new VoteRequest(3, "localhost:27018", 5, 1);
-        VoteResponse response1 = manager.handleVoteRequest(oldLogRequest);
-        assertFalse(response1.isVoteGranted(), "Should deny vote to candidate with older log (lower term)");
+        // isLogAtLeastAsUpToDate is deliberately NOT a Raft term/index comparison (see its
+        // javadoc): replication sequences are primary-local and lastLogTerm is only a
+        // currentTerm stand-in, so term ordering across nodes isn't meaningful here. The one
+        // invariant it enforces: an empty candidate (index 0) must never win against a voter
+        // that holds data (index > 0) - a stale-but-non-empty candidate is intentionally NOT
+        // denied by this check (handled elsewhere: fail-closed resync + candidacy restraint).
+        VoteRequest emptyCandidateRequest = new VoteRequest(3, "localhost:27018", 0, 0);
+        VoteResponse response1 = manager.handleVoteRequest(emptyCandidateRequest);
+        assertFalse(response1.isVoteGranted(), "Should deny vote to an empty candidate (index 0) when we hold data");
 
-        // Request from candidate with up-to-date log
-        VoteRequest upToDateRequest = new VoteRequest(4, "localhost:27019", 10, 2);
-        VoteResponse response2 = manager.handleVoteRequest(upToDateRequest);
-        assertTrue(response2.isVoteGranted(), "Should grant vote to candidate with up-to-date log");
+        // Any non-zero index is granted, even if numerically behind our own index.
+        VoteRequest nonEmptyCandidateRequest = new VoteRequest(4, "localhost:27019", 5, 1);
+        VoteResponse response2 = manager.handleVoteRequest(nonEmptyCandidateRequest);
+        assertTrue(response2.isVoteGranted(), "Should grant vote to any non-empty candidate");
     }
 
     @Test


### PR DESCRIPTION
## Der Bug (reproduziert, 2026-08-14)

Lokales 3-Knoten-RS mit Daten, ein Knoten (höchste Priorität) wird neu gestartet → **alle drei Knoten leer**. Kill-Chain: Die Raft-Log-Recency-Prüfung der Wahl war vakuos (lastLogIndex blieb überall 0), der leere Knoten gewann per Priorität — und der Follower-Resync-Fallback droppte lokale Daten, um dem leeren Primary zu gleichen („replicated namespace sets differ (primary: {}, local: {…})" → dropDatabase). Betrifft auch Setups mit Persistenz (stale statt leer).

## Die Verteidigungsschichten (12 Commits, jede einzeln reviewt)

1. **Vote-Safety:** Die Wahl erzwingt die ehrlich haltbare Invariante — ein Knoten ohne Daten seit Prozessstart (Index 0) verliert gegen jeden Voter mit Daten. Bewusst kein Pseudo-Raft-Vergleich (der Term-Standin war beweisbar lückenhaft). Gefüttert aus echten Quellen: Leader-Heartbeat, Follower-Batch-Apply, Seed nach Initial-Sync; monotoner Feed.
2. **Candidacy-Restraint:** Leere Knoten kandidieren nicht, solange sie datentragende Peers beobachtet haben — verhindert Term-Inflation. Rolling-Restart-Lockup nachweislich unmöglich; Ops-Hinweis: stirbt der letzte Daten-Knoten permanent, löst der Neustart EINES Knotens die Zurückhaltung.
3. **Fail-closed-Resync, primary-identitätsbewusst:** Ein Follower droppt nie Daten für einen Primary, dessen Sequence hinter seiner eigenen liegt — aber nur im Sequenzraum DESSELBEN Primary verglichen (Adresse im Carry-over). Leaderwechsel → Basis-Adoption statt False-Refusal (das hat CI-Run 2 live bewiesen: 82 Refusals in Schleife, Follower 40 min RECOVERING, drei Messaging-Klassen im Timeout — gefixt in 9ca9945e1). Refusals sind paced, geloggt, in Stats sichtbar, recoverable.
4. **Shortcut-/Sync-Härtung:** Namespace-Union-Vergleich, Sequence-Carry-over über Leaderwechsel und fehlgeschlagene Starts, Adoption der Primary-Basis nach erfolgreichem Sync.

## Verifikation

- E2E-Regressionstest `EmptyNodeRestartWipeTest` (echtes 3-Knoten-RS in-process, Kill+Empty-Restart, Daten-Assertions pro Knoten, aktiver Konvergenz-Watch) — hätte den Pre-Fix-Code deterministisch gerissen
- Drei CI-Volläufe auf dem Testrunner; der finale (9ca9945e1): **alle 5 Phasen 0 flaky, 0 broken** (1152 Tests), poppydb.fritz.box-Telemetrie: 0 Refusals, Leaderwechsel unter Last folgenlos
- Volle poppydb-Modul-Suite lokal grün (läuft in den CI-Phasen strukturell nicht mit — bekanntes runtests.sh-Follow-up)

## Offen / Follow-ups

- #297 Election-Churn unter Last (jetzt folgenlos, aber Hygiene)
- runtests.sh kann keine poppydb-Modul-Tests (TEST_MODULE hardcoded) — die neuen Regressionstests laufen nur via `mvn -pl poppydb test` und im Full-Install
- Known-Limitation (CHANGELOG, dokumentiert): Restarten mehrere Knoten *gleichzeitig* leer, schützt die Election-Schicht nur noch per Mehrheitsverhältnis; der Resync-Guard schützt dann die lokalen Daten der Überlebenden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQg1hfjtiPsM8G1dRiMs3f