### PR TITLE
feat: add spring-boot-morphium as optional module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -500,6 +500,51 @@ package renames, no API changes, only the Maven coordinates move. The code origi
 being archived now that its content has moved into the main Morphium repository. See
 [Quarkus Extension](docs/quarkus-extension.md).
 
+#### `spring-boot-morphium` — optional Spring Boot integration module
+A new optional module, `spring-boot-morphium`, integrates Morphium into
+[Spring Boot](https://spring.io/projects/spring-boot) applications: `MorphiumAutoConfiguration`
+creates the application's `Morphium` bean from `morphium.*` properties (type-safe
+`@ConfigurationProperties`, with `spring-boot-configuration-processor`-generated metadata for
+IDE autocompletion), connection retry with linear backoff on transient failures, and a
+best-effort classpath pre-scan for `@Entity`/`@Embedded` classes. Jakarta Data `@Repository`
+interfaces (`CrudRepository`/`MorphiumRepository` from `morphium-jakarta-data`) are wired via
+`MorphiumRepositoryRegistrar` at Spring context-startup time, backed by a JDK dynamic proxy
+(`java.lang.reflect.Proxy`) per repository interface — in contrast to `quarkus-morphium`, which
+generates repository implementations as Gizmo bytecode at build time; here everything is
+runtime reflection, no annotation processor or build-time codegen involved. Declarative
+`@MorphiumTransactional` transactions wrap the annotated method body in
+`startTransaction()`/`commitTransaction()`/`abortTransaction()` via an AspectJ `@Around` advice,
+active only when `spring-boot-starter-aop` is on the classpath. An Actuator `HealthIndicator`
+reports live MongoDB connection status (database, driver, replica-set state) under
+`/actuator/health`, active only when `spring-boot-actuator` is present and a `Morphium` bean
+already exists; a user-defined bean named `morphiumHealthIndicator` correctly overrides the
+auto-configured one. The module publishes three artifacts — `morphium-spring-boot-starter`,
+`morphium-spring-boot-autoconfigure`, and `morphium-spring-boot-test` (a `@MorphiumTest`
+composite annotation that wires `InMemDriver` into a `@SpringBootTest`, so repository tests run
+without a MongoDB instance or container) — and, unlike `quarkus-morphium/integration-tests`,
+`morphium-spring-boot-test` is a genuine end-user artifact, not an internal test suite, and is
+published to Central like the other two. Like `morphium-jakarta-data` and `quarkus-morphium`,
+the core has zero compile- or runtime dependency on this module; building the reactor with
+`-DskipExtensions` produces an unchanged core-only build. No Docker/Testcontainers dependency
+anywhere in the module — all tests run against Morphium's `InMemDriver`, unlike
+`quarkus-morphium`'s integration tests, which need a running Docker daemon.
+**Two coordinate/naming corrections made during the pre-integration conversion:** the three
+modules were renamed from `spring-boot-morphium-*` to `morphium-spring-boot-*`, following the
+Spring Boot starter naming convention (the `spring-boot-` prefix is reserved for Spring's own
+starters); and the configuration property prefix was renamed from `spring.morphium.*` to
+`morphium.*`, since the `spring.*` namespace is reserved for Spring Boot's own configuration
+keys. Both renames happened before any Maven Central release of this module existed, so they
+carry zero breaking-change cost. **Existing users of the pre-integration
+`de.caluga:spring-boot-morphium-starter:1.0.0-SNAPSHOT`** must update their dependency's
+artifactId to `morphium-spring-boot-starter`, its version to the Morphium version they adopt
+(currently `6.3.x`), and rename every `spring.morphium.*` key in their
+`application.properties`/`.yml` to `morphium.*` (e.g. `spring.morphium.database` →
+`morphium.database`) — no Java API changes; `MorphiumProperties`, `@EnableMorphiumRepositories`,
+`@MorphiumTransactional`, and all other public types are unaffected. The code originates from
+[Bardioc1977/spring-boot-morphium](https://github.com/Bardioc1977/spring-boot-morphium), which
+is being archived now that its content has moved into the main Morphium repository. See
+[Spring Boot](docs/spring-boot.md).
+
 #### PoppyDB: `--users-file` — declarative user provisioning (bootstrap, upsert, version-gated)
 Builds on user replication: `--rootUser`/`--rootPassword` only ever provisioned one admin user,
 so any real application user set still had to be created by hand (a shell script running

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -505,8 +505,8 @@ A new optional module, `spring-boot-morphium`, integrates Morphium into
 [Spring Boot](https://spring.io/projects/spring-boot) applications: `MorphiumAutoConfiguration`
 creates the application's `Morphium` bean from `morphium.*` properties (type-safe
 `@ConfigurationProperties`, with `spring-boot-configuration-processor`-generated metadata for
-IDE autocompletion), connection retry with linear backoff on transient failures, and a
-best-effort classpath pre-scan for `@Entity`/`@Embedded` classes. Jakarta Data `@Repository`
+IDE autocompletion), and connection retry with linear backoff on transient failures.
+Jakarta Data `@Repository`
 interfaces (`CrudRepository`/`MorphiumRepository` from `morphium-jakarta-data`) are wired via
 `MorphiumRepositoryRegistrar` at Spring context-startup time, backed by a JDK dynamic proxy
 (`java.lang.reflect.Proxy`) per repository interface — in contrast to `quarkus-morphium`, which

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,14 @@ any of the following. These are additional, opt-in modules built on top of the c
   checks, Dev Services, Dev UI, and build-time Jakarta Data repository generation via Gizmo
   - GraalVM native-image support and `MorphiumId` JSON (de)serialization out of the box
   - Zero dependency from the core: build with `-DskipExtensions` for a core-only artifact
+- **[Spring Boot](./spring-boot.md)** - Optional module integrating Morphium into
+  [Spring Boot](https://spring.io/projects/spring-boot) applications via auto-configuration,
+  type-safe `@ConfigurationProperties` (`morphium.*`), `@MorphiumTransactional` via AspectJ, an
+  Actuator health indicator, and Jakarta Data `@Repository` interfaces backed by JDK dynamic
+  proxies at runtime (no build-time bytecode generation, unlike `quarkus-morphium`'s Gizmo
+  approach)
+  - No Docker/Testcontainers needed — all tests run against Morphium's `InMemDriver`
+  - Zero dependency from the core: build with `-DskipExtensions` for a core-only artifact
 
 Minimum requirements
 - Java 21+

--- a/docs/spring-boot.md
+++ b/docs/spring-boot.md
@@ -54,7 +54,7 @@ pagination runtime.
 </dependency>
 ```
 
-In the Morphium reactor, `${project.version}` currently resolves to `6.3.0-SNAPSHOT`.
+In the Morphium reactor, `${project.version}` currently resolves to `6.3.2-SNAPSHOT`.
 This module follows Morphium's regular release versioning — it is versioned and
 released in lockstep with Morphium; there is no separate version line to track.
 
@@ -270,7 +270,7 @@ class ProductRepositoryTest {
 `InMemDriver` is Morphium's in-memory MongoDB emulation — tests run against it with no
 container and no external MongoDB, exactly like the core Morphium test suite.
 
-## Abgrenzung zu Spring Data MongoDB
+## Distinction from Spring Data MongoDB
 
 This module is **not** a replacement for, or a re-implementation of, Spring Data
 MongoDB, and does not aim to be API-compatible with it:
@@ -301,7 +301,7 @@ This page is an overview. The complete module documentation — installation, th
 property reference, repository usage, transactions, testing, and the detailed
 architecture comparison with Quarkus — lives in the module's own README:
 
-[`morphium-spring-boot-starter/README.md`](https://github.com/sboesebeck/morphium/tree/develop/morphium-spring-boot-starter/README.md)
+[`spring-boot-morphium/README.md`](https://github.com/sboesebeck/morphium/blob/develop/spring-boot-morphium/README.md)
 
 See also [Jakarta Data](jakarta-data.md) for the framework-agnostic repository runtime
 this module builds on, and [Quarkus Extension](quarkus-extension.md) for the

--- a/docs/spring-boot.md
+++ b/docs/spring-boot.md
@@ -1,0 +1,308 @@
+# Spring Boot Starter: Auto-Configuration for Morphium
+
+`morphium-spring-boot-*` is an **optional Morphium module** that integrates Morphium
+into [Spring Boot](https://spring.io/projects/spring-boot) applications via
+auto-configuration, type-safe `@ConfigurationProperties`, declarative transactions,
+an Actuator health indicator, and Jakarta Data `@Repository` interfaces backed by JDK
+dynamic proxies at runtime — no build-time bytecode generation, no annotation
+processor for the repositories themselves. It pulls in
+[`morphium-jakarta-data`](jakarta-data.md) for the entire query-derivation, JDQL, and
+pagination runtime.
+
+!!! note "Optional module — the Morphium core does not depend on it"
+    `de.caluga:morphium` has zero compile- or runtime dependency on this module, on
+    Spring, or on `jakarta.data-api`. You only need `morphium-spring-boot-starter` if
+    you are building a Spring Boot application against MongoDB via Morphium.
+
+## What it provides
+
+- **Auto-configuration** — `MorphiumAutoConfiguration` creates the application's
+  single `Morphium` bean from `morphium.*` properties, with connection retry on
+  transient failures (linear backoff) and a best-effort classpath pre-scan for
+  `@Entity`/`@Embedded` classes so Morphium can skip its own internal scan at startup.
+- **Type-safe configuration** — every setting lives under `morphium.*` as
+  `@ConfigurationProperties`, with `spring-boot-configuration-processor`-generated
+  metadata for IDE autocompletion.
+- **Jakarta Data repositories** — declare a `@Repository` interface extending
+  `CrudRepository`/`MorphiumRepository` from `morphium-jakarta-data`; at Spring
+  context-startup time, `MorphiumRepositoryRegistrar` scans for such interfaces and
+  registers a `MorphiumRepositoryFactoryBean` for each, which creates a
+  `java.lang.reflect.Proxy` implementing the interface — see
+  [Proxy mechanism vs. Quarkus](#proxy-mechanism-vs-quarkus) below. See
+  [Jakarta Data](jakarta-data.md) for the full query-derivation, JDQL, and pagination
+  feature set — everything documented there works identically once wired through this
+  module's proxies.
+- **Declarative transactions** — `@MorphiumTransactional` on a Spring bean method
+  wraps the method body in `startTransaction()`/`commitTransaction()`/
+  `abortTransaction()` via an AspectJ `@Around` advice, active only when
+  `spring-boot-starter-aop` is on the classpath.
+- **Actuator health** — a `HealthIndicator` reporting live MongoDB connection status
+  (database, driver, replica-set state) under `/actuator/health`, active only when
+  `spring-boot-actuator` is present and a `Morphium` bean already exists.
+- **Test support** — the companion `morphium-spring-boot-test` module provides
+  `@MorphiumTest`, a composite annotation that wires `InMemDriver` (Morphium's
+  in-memory MongoDB emulation) into a `@SpringBootTest`, so repository tests run
+  without a MongoDB instance or container.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>de.caluga</groupId>
+  <artifactId>morphium-spring-boot-starter</artifactId>
+  <version>${project.version}</version>
+</dependency>
+```
+
+In the Morphium reactor, `${project.version}` currently resolves to `6.3.0-SNAPSHOT`.
+This module follows Morphium's regular release versioning — it is versioned and
+released in lockstep with Morphium; there is no separate version line to track.
+
+## Configuration Reference
+
+All properties live under `morphium.*` (not `spring.morphium.*` — the `spring.*`
+namespace is reserved for Spring Boot's own configuration keys). Every entry below is
+verified directly against `MorphiumProperties.java` in the
+`morphium-spring-boot-autoconfigure` module.
+
+| Property | Default | Description | Source |
+|---|---|---|---|
+| `morphium.database` | *(required)* | MongoDB database name | `MorphiumProperties.java:46` |
+| `morphium.hosts` | `localhost:27017` | Comma-separated `host:port` list; ignored if `morphium.atlas-url` is set | `MorphiumProperties.java:39` |
+| `morphium.username` / `.password` | -- | Optional credentials, applied only when both are set | `MorphiumProperties.java:52,57` |
+| `morphium.auth-database` | `admin` | Authentication database (`authSource`) | `MorphiumProperties.java:64` |
+| `morphium.driver-name` | `PooledDriver` | `PooledDriver` (production) or `InMemDriver` (tests, no MongoDB needed) | `MorphiumProperties.java:71` |
+| `morphium.read-preference` | `primary` | MongoDB read preference | `MorphiumProperties.java:77` |
+| `morphium.max-connections` | `250` | Connection pool size | `MorphiumProperties.java:82` |
+| `morphium.atlas-url` | -- | MongoDB Atlas SRV connection string (overrides `morphium.hosts` when set) | `MorphiumProperties.java:89` |
+| `morphium.replica-set-name` | -- | Replica set name (required for transactions) | `MorphiumProperties.java:97` |
+| `morphium.connect-retries` | `5` | Connection attempts before giving up on transient failures, linear backoff `attempt * 2000`ms | `MorphiumProperties.java:106` |
+| `morphium.index-check` | `CREATE_ON_STARTUP` | `CREATE_ON_STARTUP`, `WARN_ON_STARTUP`, `CREATE_ON_WRITE_NEW_COL`, `NO_CHECK` | `MorphiumProperties.java:115` |
+| `morphium.cache.global-valid-time` | `5000` | Cache TTL in milliseconds | `MorphiumProperties.java:361` |
+| `morphium.cache.read-cache-enabled` | `true` | Enable query result cache | `MorphiumProperties.java:368` |
+| `morphium.ssl.enabled` | `false` | Enable TLS | `MorphiumProperties.java:418` |
+| `morphium.ssl.keystore-path` / `.keystore-password` | -- | Keystore (JKS/PKCS12) for client-certificate TLS | `MorphiumProperties.java:426,431` |
+
+If `spring-boot-configuration-processor` is on the classpath (declared as an optional
+dependency of `morphium-spring-boot-autoconfigure`), every property above also appears
+in `META-INF/spring-configuration-metadata.json`, giving IDEs autocompletion and
+validation for `morphium.*` keys.
+
+## Quick Example
+
+```java
+@Entity(collectionName = "products")
+public class Product {
+    @Id private MorphiumId id;
+    private String name;
+    private double price;
+    private String category;
+    // getters/setters omitted
+}
+
+@Repository
+public interface ProductRepository extends MorphiumRepository<Product, MorphiumId> {
+    List<Product> findByCategory(String category);
+
+    List<Product> findByPriceGreaterThan(double minPrice);
+}
+
+@SpringBootApplication
+@EnableMorphiumRepositories
+public class MyApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MyApplication.class, args);
+    }
+}
+
+@Service
+public class ProductService {
+    @Autowired ProductRepository products;
+
+    public List<Product> findExpensive(double minPrice) {
+        return products.findByPriceGreaterThan(minPrice);
+    }
+}
+```
+
+```properties
+morphium.database=my-app-db
+morphium.hosts=localhost:27017
+```
+
+## Repository Usage
+
+Annotate a `@SpringBootApplication` (or any `@Configuration` class) with
+`@EnableMorphiumRepositories` to enable scanning. By default the scan covers the
+annotated class's package and sub-packages; pass explicit packages via `value()`/
+`basePackages()` to scan elsewhere.
+
+Repository interfaces extend either `jakarta.data.repository.CrudRepository<T, K>`
+(the plain Jakarta Data interface) or `de.caluga.morphium.data.MorphiumRepository<T,
+K>`, which adds Morphium-specific escape hatches with no Jakarta Data equivalent:
+
+```java
+// Distinct values for a field
+List<Object> categories = products.distinct("category");
+
+// Direct access to the Morphium API
+products.morphium().inc(product, "stock", 5);
+
+// A typed Morphium Query, for anything beyond derived queries/JDQL/@Find
+Query<Product> q = products.query();
+q.f("price").gt(100).f("category").eq("electronics");
+```
+
+### Proxy mechanism vs. Quarkus
+
+This module uses **JDK dynamic proxies at runtime** — the standard Spring Data
+pattern — in contrast to the [Quarkus extension](quarkus-extension.md), which uses
+**Gizmo bytecode generation at build time**.
+
+Concretely: at Spring context-startup time, `MorphiumRepositoryRegistrar` (imported by
+`@EnableMorphiumRepositories`) scans the configured base packages for `@Repository`
+interfaces and registers a `MorphiumRepositoryFactoryBean` bean definition for each
+one found. Each factory bean creates a `java.lang.reflect.Proxy` implementing the
+repository interface, backed by a `MorphiumRepositoryInvocationHandler` that
+dispatches every method call — derived queries, JDQL, `@Find`/`@Delete`, plain CRUD —
+to the shared `morphium-jakarta-data` runtime. No implementation class is ever
+generated or compiled; the proxy is synthesized by the JVM itself, once per repository
+interface, the first time the bean is requested.
+
+Quarkus's `quarkus-morphium` extension instead runs a build-time processor that emits
+a real, compiled implementation class via Gizmo bytecode generation before the
+application ever starts — no proxy or reflective dispatch exists at runtime there at
+all. The trade-off is the classic one: this module's proxies need zero build-time
+tooling and work with plain `javac`, at the cost of a small amount of per-call
+reflective dispatch overhead and no build-time validation of query derivation;
+Quarkus's build-time generation avoids that runtime cost and validates earlier, at the
+cost of requiring its build-time augmentation phase. Both mechanisms delegate to the
+exact same `morphium-jakarta-data` query engine — only *how* a repository interface is
+wired to that engine differs.
+
+## Transactions
+
+Requires a MongoDB replica set or Atlas cluster (`morphium.replica-set-name`) — a
+standalone MongoDB node rejects multi-document transactions.
+
+```java
+@Service
+public class OrderService {
+    @Autowired Morphium morphium;
+
+    @MorphiumTransactional
+    public void placeOrder(Order order, Payment payment) {
+        morphium.store(order);
+        morphium.store(payment);
+        // committed automatically on return, rolled back automatically on exception
+    }
+}
+```
+
+`@MorphiumTransactional` is picked up by an AspectJ `@Around` advice
+(`MorphiumTransactionAspect`) that is only active when `spring-boot-starter-aop` is on
+the classpath and a `Morphium` bean exists in the context. It starts a transaction
+before the advised method runs, commits on normal return, and aborts (rethrowing the
+original exception unchanged) if the method throws.
+
+## Health / Actuator
+
+When `spring-boot-actuator` is on the classpath and a `Morphium` bean already exists,
+`MorphiumHealthAutoConfiguration` registers a `HealthIndicator` under
+`/actuator/health`:
+
+```json
+{
+  "components": {
+    "morphium": {
+      "status": "UP",
+      "details": {
+        "database": "my-app-db",
+        "driver": "PooledDriver",
+        "replicaSet": true,
+        "replicaSetName": "rs0"
+      }
+    }
+  }
+}
+```
+
+Disable it with `management.health.morphium.enabled=false`, or override it entirely
+by defining your own `@Bean(name = "morphiumHealthIndicator") HealthIndicator` — the
+auto-configured bean backs off via `@ConditionalOnMissingBean(name =
+"morphiumHealthIndicator")`.
+
+## Testing without a MongoDB instance
+
+```properties
+# src/test/resources/application-test.properties
+morphium.database=test
+morphium.driver-name=InMemDriver
+```
+
+```java
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableMorphiumRepositories
+class ProductRepositoryTest {
+    @Autowired ProductRepository repository;
+
+    @Test
+    void shouldFindByCategory() {
+        repository.save(new Product("Widget", 9.99, "tools"));
+        assertThat(repository.findByCategory("tools")).hasSize(1);
+    }
+}
+```
+
+The companion `morphium-spring-boot-test` module wraps the same properties into a
+composite `@MorphiumTest` annotation:
+
+```java
+@MorphiumTest
+@EnableMorphiumRepositories
+class ProductRepositoryTest {
+    @Autowired ProductRepository repository;
+    // InMemDriver is auto-configured — no MongoDB instance or container needed
+}
+```
+
+`InMemDriver` is Morphium's in-memory MongoDB emulation — tests run against it with no
+container and no external MongoDB, exactly like the core Morphium test suite.
+
+## Abgrenzung zu Spring Data MongoDB
+
+This module is **not** a replacement for, or a re-implementation of, Spring Data
+MongoDB, and does not aim to be API-compatible with it:
+
+- It implements the **Jakarta Data 1.0** specification (`@Repository`,
+  `CrudRepository`, `@Find`, `@Query`/JDQL, `Page`/`CursoredPage`, `Sort`/`Order`) — a
+  vendor-neutral Jakarta EE specification — not Spring Data's own repository
+  interfaces or query-method conventions.
+- The underlying data access is always **Morphium**, not Spring Data MongoDB's
+  `MongoTemplate`/`MongoOperations`. There is no `MongoTemplate` bean and no Spring
+  Data MongoDB entity mapping; entities use Morphium's own annotations (`@Entity`,
+  `@Id`, `@Reference`, etc.).
+- Transactions are Morphium transactions wrapped by a small AOP aspect, not Spring's
+  `PlatformTransactionManager`/`@Transactional` infrastructure.
+- Query derivation, JDQL, and pagination/sorting behavior come from
+  `morphium-jakarta-data`; the keyword set and grammar differ in detail from Spring
+  Data's query-method conventions, even though simple method names
+  (`findByCategory`, `countByStatus`, ...) often look similar.
+
+If your application already uses Spring Data MongoDB and does not use Morphium, this
+module has nothing to offer you. If you are building on Morphium and want a
+Spring-managed, dependency-injected repository layer with Jakarta Data semantics, this
+is the module for that.
+
+## Full Documentation
+
+This page is an overview. The complete module documentation — installation, the full
+property reference, repository usage, transactions, testing, and the detailed
+architecture comparison with Quarkus — lives in the module's own README:
+
+[`morphium-spring-boot-starter/README.md`](https://github.com/sboesebeck/morphium/tree/develop/morphium-spring-boot-starter/README.md)
+
+See also [Jakarta Data](jakarta-data.md) for the framework-agnostic repository runtime
+this module builds on, and [Quarkus Extension](quarkus-extension.md) for the
+build-time-bytecode alternative to this module's runtime JDK proxies.

--- a/docs/spring-boot.md
+++ b/docs/spring-boot.md
@@ -18,8 +18,7 @@ pagination runtime.
 
 - **Auto-configuration** — `MorphiumAutoConfiguration` creates the application's
   single `Morphium` bean from `morphium.*` properties, with connection retry on
-  transient failures (linear backoff) and a best-effort classpath pre-scan for
-  `@Entity`/`@Embedded` classes so Morphium can skip its own internal scan at startup.
+  transient failures (linear backoff).
 - **Type-safe configuration** — every setting lives under `morphium.*` as
   `@ConfigurationProperties`, with `spring-boot-configuration-processor`-generated
   metadata for IDE autocompletion.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,9 +109,9 @@ nav:
     - SSL/TLS Connections: ssl-tls.md
     - Developer Guide: developer-guide.md
   - Extensions:
-    # Placeholder: Spring-Boot-Integrationsseite folgt in einer späteren Welle (M5).
     - Jakarta Data: jakarta-data.md
     - Quarkus Extension: quarkus-extension.md
+    - Spring Boot: spring-boot.md
   - Reference:
     - API Reference: api-reference.md
     - Configuration: configuration-reference.md

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,14 @@
          dependencyManagement comment below); only the version property is
          centralized. -->
     <quarkus.version>3.32.3</quarkus.version>
+    <!-- Extension module property for spring-boot-morphium (M5-T5, moved
+         here from spring-boot-morphium/pom.xml per D1/B6, analogous to the
+         quarkus.version pattern above): a Spring Boot upgrade is a
+         single-line change here. The spring-boot-dependencies BOM *import*
+         itself stays in spring-boot-morphium/pom.xml (see I4 and the
+         dependencyManagement comment below); only the version property is
+         centralized. -->
+    <spring-boot.version>3.4.13</spring-boot.version>
   </properties>
   <build>
     <pluginManagement>
@@ -493,6 +501,7 @@
       <modules>
         <module>morphium-jakarta-data</module>
         <module>quarkus-morphium</module>
+        <module>spring-boot-morphium</module>
       </modules>
     </profile>
   </profiles>

--- a/release.sh
+++ b/release.sh
@@ -155,9 +155,9 @@ done
 # (e.g. quarkus-morphium/integration-tests) should still list modules
 # explicitly here rather than glob-discovering directories, so such submodules
 # are simply never added to the arrays.
-MODULE_DIRS=(morphium-core poppydb morphium-jakarta-data quarkus-morphium/runtime quarkus-morphium/deployment quarkus-morphium/testing)
-MODULE_ARTIFACT_IDS=(morphium poppydb morphium-jakarta-data quarkus-morphium quarkus-morphium-deployment quarkus-morphium-testing)
-MODULE_EXTRA_CLASSIFIERS=("" "cli" "" "" "" "")
+MODULE_DIRS=(morphium-core poppydb morphium-jakarta-data quarkus-morphium/runtime quarkus-morphium/deployment quarkus-morphium/testing spring-boot-morphium/morphium-spring-boot-autoconfigure spring-boot-morphium/morphium-spring-boot-starter spring-boot-morphium/morphium-spring-boot-test)
+MODULE_ARTIFACT_IDS=(morphium poppydb morphium-jakarta-data quarkus-morphium quarkus-morphium-deployment quarkus-morphium-testing morphium-spring-boot-autoconfigure morphium-spring-boot-starter morphium-spring-boot-test)
+MODULE_EXTRA_CLASSIFIERS=("" "cli" "" "" "" "" "" "" "")
 
 # All module pom.xml paths plus the root pom.xml, for git add/commit calls.
 # Note: MODULE_DIRS only lists directories that hold a *published* artifact
@@ -174,7 +174,7 @@ MODULE_EXTRA_CLASSIFIERS=("" "cli" "" "" "" "")
 # it is listed here, so any pom missing from this array would silently be
 # version-bumped by Maven but NOT staged by the `git add "${ALL_POM_FILES[@]}"`
 # calls below — leaving it out of sync with the commit.
-ALL_POM_FILES=(pom.xml quarkus-morphium/pom.xml quarkus-morphium/integration-tests/pom.xml)
+ALL_POM_FILES=(pom.xml quarkus-morphium/pom.xml quarkus-morphium/integration-tests/pom.xml spring-boot-morphium/pom.xml)
 for _module_dir in "${MODULE_DIRS[@]}"; do
   ALL_POM_FILES+=("${_module_dir}/pom.xml")
 done
@@ -913,7 +913,7 @@ module_list=""
 for module_dir in "${MODULE_DIRS[@]}"; do
   module_list="${module_list:+$module_list, }$module_dir"
 done
-log_success "Multi-module structure: morphium-parent, quarkus-morphium-parent, ${module_list}"
+log_success "Multi-module structure: morphium-parent, quarkus-morphium-parent, morphium-spring-boot-parent, ${module_list}"
 fi
 
 # -----------------------------------------------------------------------------
@@ -972,6 +972,13 @@ if [ "$DRY_RUN" = true ]; then
   sign_file "${quarkus_parent_repo}/quarkus-morphium-parent-${version}.pom"
   checksum_file "${quarkus_parent_repo}/quarkus-morphium-parent-${version}.pom"
 
+  log_info "Adding morphium-spring-boot-parent..."
+  spring_parent_repo="${BUNDLE_DIR}/de/caluga/morphium-spring-boot-parent/${version}"
+  mkdir -p "$spring_parent_repo"
+  cp spring-boot-morphium/pom.xml "${spring_parent_repo}/morphium-spring-boot-parent-${version}.pom"
+  sign_file "${spring_parent_repo}/morphium-spring-boot-parent-${version}.pom"
+  checksum_file "${spring_parent_repo}/morphium-spring-boot-parent-${version}.pom"
+
   for i in "${!MODULE_DIRS[@]}"; do
     add_module_to_bundle \
       "${MODULE_DIRS[$i]}" \
@@ -988,7 +995,7 @@ if [ "$DRY_RUN" = true ]; then
   log_step "Dry run complete"
   echo ""
   echo "Would release version: $release_version"
-  echo "  Modules: morphium-parent, quarkus-morphium-parent, ${MODULE_ARTIFACT_IDS[*]}"
+  echo "  Modules: morphium-parent, quarkus-morphium-parent, morphium-spring-boot-parent, ${MODULE_ARTIFACT_IDS[*]}"
   echo "  From branch: $branch"
   echo ""
   echo "Bundle contents:"
@@ -1011,7 +1018,7 @@ if [ "$SKIP_TO_UPLOAD" != true ]; then
   echo "  Last release: $last_tag"
   echo "  Release version: $release_version (--${BUMP_TYPE})"
   echo "  Next development: $next_snapshot"
-  echo "  Modules: morphium-parent, quarkus-morphium-parent, ${MODULE_ARTIFACT_IDS[*]}"
+  echo "  Modules: morphium-parent, quarkus-morphium-parent, morphium-spring-boot-parent, ${MODULE_ARTIFACT_IDS[*]}"
   echo "  Branch: $branch"
   echo "  Auto-publish: $AUTO_PUBLISH"
   echo ""
@@ -1136,6 +1143,16 @@ if [ "$SKIP_TO_UPLOAD" != true ]; then
   sign_file "${quarkus_parent_repo}/quarkus-morphium-parent-${version}.pom"
   checksum_file "${quarkus_parent_repo}/quarkus-morphium-parent-${version}.pom"
 
+  # --- morphium-spring-boot-parent (POM-only, same special case as
+  # morphium-parent/quarkus-morphium-parent above) ---
+  log_info "Adding morphium-spring-boot-parent..."
+  spring_parent_repo="${BUNDLE_DIR}/de/caluga/morphium-spring-boot-parent/${version}"
+  mkdir -p "$spring_parent_repo"
+
+  cp spring-boot-morphium/pom.xml "${spring_parent_repo}/morphium-spring-boot-parent-${version}.pom"
+  sign_file "${spring_parent_repo}/morphium-spring-boot-parent-${version}.pom"
+  checksum_file "${spring_parent_repo}/morphium-spring-boot-parent-${version}.pom"
+
   # --- one block per registered module (see MODULE_DIRS/MODULE_ARTIFACT_IDS
   # /MODULE_EXTRA_CLASSIFIERS above); analogous to the former morphium/poppydb
   # copy-paste blocks, now driven by add_module_to_bundle() so a future module
@@ -1168,7 +1185,7 @@ if [ "$SKIP_TO_UPLOAD" != true ]; then
   (cd "$BUNDLE_DIR" && zip -q -r "$(pwd)/../bundle-${version}.jar" de/)
 
   log_success "Combined bundle: $bundle_file ($(du -h "$bundle_file" | cut -f1))"
-  log_info "  Contents: morphium-parent (pom), quarkus-morphium-parent (pom), ${MODULE_ARTIFACT_IDS[*]} (jar+sources+javadoc, plus extra classifiers where applicable)"
+  log_info "  Contents: morphium-parent (pom), quarkus-morphium-parent (pom), morphium-spring-boot-parent (pom), ${MODULE_ARTIFACT_IDS[*]} (jar+sources+javadoc, plus extra classifiers where applicable)"
 fi
 
 # -----------------------------------------------------------------------------

--- a/spring-boot-morphium/CHANGELOG.md
+++ b/spring-boot-morphium/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased] - 1.0.0-SNAPSHOT
+
+### Added
+- Spring Boot 3.4.13 auto-configuration for Morphium (`morphium.*` properties)
+- Jakarta Data 1.0 repository support via JDK dynamic proxies
+  - `CrudRepository<T,K>` and `MorphiumRepository<T,K>`
+  - Query derivation: `findBy*`, `countBy*`, `existsBy*`, `deleteBy*`
+  - JDQL via `@Query` annotation
+  - `@Find` / `@Delete` with `@By` parameter binding
+  - Pagination (`Page<T>`, `CursoredPage<T>`, `PageRequest`)
+  - Sorting (`Sort<T>`, `Order<T>`, `@OrderBy`)
+  - Stream and async (`Stream<T>`, `CompletionStage<T>`) return types
+- `@EnableMorphiumRepositories` annotation for repository scanning
+- `@MorphiumTransactional` AOP aspect for declarative transactions
+- Actuator health indicator (`/actuator/health` with Morphium connection details)
+- `@MorphiumTest` composite test annotation (InMemDriver, no MongoDB required)
+- Connection retry logic with linear backoff for transient failures
+- SSL/TLS support via `morphium.ssl.*` properties
+
+### Changed
+- Renamed Maven artifacts to follow the Spring Boot starter naming convention
+  (`<project>-spring-boot-*`, the `spring-boot-` prefix being reserved for Spring's
+  own starters): `spring-boot-morphium-parent` → `morphium-spring-boot-parent`,
+  `spring-boot-morphium-autoconfigure` → `morphium-spring-boot-autoconfigure`,
+  `spring-boot-morphium-starter` → `morphium-spring-boot-starter`,
+  `spring-boot-morphium-test` → `morphium-spring-boot-test`. `groupId` (`de.caluga`)
+  and Java package names (`de.caluga.morphium.spring.*`) are unchanged.
+- Renamed the `@ConfigurationProperties` prefix from `spring.morphium.*` to
+  `morphium.*` -- the `spring.*` namespace is reserved for Spring Boot's own
+  configuration keys.
+

--- a/spring-boot-morphium/README.md
+++ b/spring-boot-morphium/README.md
@@ -55,11 +55,11 @@ Add the starter to your `pom.xml`:
 <dependency>
     <groupId>de.caluga</groupId>
     <artifactId>morphium-spring-boot-starter</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>6.3.2-SNAPSHOT</version>
 </dependency>
 ```
 
-In the Morphium reactor, `${project.version}` currently resolves to `6.3.0-SNAPSHOT`.
+In the Morphium reactor, `${project.version}` currently resolves to `6.3.2-SNAPSHOT`.
 This module follows Morphium's regular release versioning -- there is no independent
 version to pin beyond the reactor version.
 
@@ -279,7 +279,7 @@ The `morphium-spring-boot-test` module provides a composite annotation:
 <dependency>
     <groupId>de.caluga</groupId>
     <artifactId>morphium-spring-boot-test</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>6.3.2-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -349,7 +349,7 @@ aspect, and the actuator health indicator. Every Jakarta Data feature documented
 return-type handling) applies unchanged once wired through this module -- there is no
 separate, Spring-specific feature set to learn.
 
-### Abgrenzung zu Spring Data MongoDB
+### Distinction from Spring Data MongoDB
 
 This module is **not** a replacement for or a re-implementation of Spring Data
 MongoDB, and does not aim to be API-compatible with it:

--- a/spring-boot-morphium/README.md
+++ b/spring-boot-morphium/README.md
@@ -1,0 +1,408 @@
+# Morphium Spring Boot Starter
+
+[![Build](https://github.com/Bardioc1977/spring-boot-morphium/actions/workflows/build.yml/badge.svg)](https://github.com/Bardioc1977/spring-boot-morphium/actions/workflows/build.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.4.13-brightgreen)](https://spring.io/projects/spring-boot)
+[![Java](https://img.shields.io/badge/Java-21%2B-orange)](https://adoptium.net)
+[![Jakarta Data](https://img.shields.io/badge/Jakarta%20Data-1.0-green)](https://jakarta.ee/specifications/data/1.0/)
+
+A [Spring Boot](https://spring.io/projects/spring-boot) auto-configuration for
+[Morphium](https://github.com/sboesebeck/morphium), an actively maintained MongoDB ORM
+for Java -- with full **Jakarta Data 1.0** repository support.
+
+> **Part of the Morphium project.** This module is being integrated into the main
+> [Morphium](https://github.com/sboesebeck/morphium) reactor and is versioned and
+> released **in lockstep with Morphium** -- there is no separate release cadence or
+> version line to track. Building the Morphium reactor builds this module against the
+> exact Morphium core version in the same build. Maven coordinates are
+> `morphium-spring-boot-starter` / `morphium-spring-boot-autoconfigure` /
+> `morphium-spring-boot-test` (not `spring-boot-morphium-*` -- that naming was used
+> before integration; see [MIGRATION-NOTES.md](MIGRATION-NOTES.md) for the full
+> rename history).
+
+> **Companion project:** See [quarkus-morphium](https://github.com/Bardioc1977/quarkus-morphium)
+> for Quarkus integration with the same Jakarta Data feature set.
+
+---
+
+## Features
+
+- **Auto-configuration** -- `Morphium` bean created from `morphium.*` properties
+- **Jakarta Data repositories** -- `@Repository` interfaces with JDK dynamic proxies (runtime)
+- **Query derivation** -- `findBy*`, `countBy*`, `existsBy*`, `deleteBy*` with And/Or, Between, In, Like, etc.
+- **JDQL** -- `@Query("WHERE status = :s ORDER BY name")` Jakarta Data Query Language
+- **@Find / @Delete** -- explicit field binding via `@By` parameters
+- **Transactions** -- `@MorphiumTransactional` with AOP-based commit/rollback
+- **Actuator health** -- Morphium connection status in `/actuator/health`
+- **Test support** -- `@MorphiumTest` composite annotation with InMemDriver (no MongoDB needed)
+- **MorphiumRepository** -- escape hatch for `distinct()`, `query()`, `morphium()` access
+
+---
+
+## Prerequisites
+
+| Dependency | Minimum version |
+|---|---|
+| Java | 21 |
+| Spring Boot | 3.4.x |
+| Morphium | 6.2.2 ([sboesebeck/morphium](https://github.com/sboesebeck/morphium)) |
+
+## Installation
+
+Add the starter to your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>de.caluga</groupId>
+    <artifactId>morphium-spring-boot-starter</artifactId>
+    <version>6.3.0-SNAPSHOT</version>
+</dependency>
+```
+
+In the Morphium reactor, `${project.version}` currently resolves to `6.3.0-SNAPSHOT`.
+This module follows Morphium's regular release versioning -- there is no independent
+version to pin beyond the reactor version.
+
+> **Note:** Until published to Maven Central, build the reactor locally:
+> ```bash
+> git clone https://github.com/sboesebeck/morphium.git
+> cd morphium
+> mvn install -DskipTests
+> ```
+
+## Quick Start
+
+### 1. Configure
+
+```properties
+# application.properties
+morphium.database=my-database
+morphium.hosts=localhost:27017
+```
+
+### 2. Define an entity
+
+```java
+@Entity(collectionName = "products")
+public class Product {
+    @Id private MorphiumId id;
+    private String name;
+    private double price;
+    private String category;
+
+    // getters, setters, constructors
+}
+```
+
+### 3. Create a repository
+
+```java
+@Repository
+public interface ProductRepository extends MorphiumRepository<Product, MorphiumId> {
+
+    List<Product> findByCategory(String category);
+
+    List<Product> findByPriceGreaterThan(double minPrice);
+
+    long countByCategory(String category);
+
+    @Query("WHERE category = :cat AND price > :minPrice ORDER BY price")
+    List<Product> findExpensive(@Param("cat") String category,
+                                @Param("minPrice") double minPrice);
+}
+```
+
+### 4. Enable and inject
+
+```java
+@SpringBootApplication
+@EnableMorphiumRepositories
+public class MyApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MyApplication.class, args);
+    }
+}
+```
+
+```java
+@Service
+public class ProductService {
+
+    @Autowired ProductRepository products;
+
+    public List<Product> findExpensive(double minPrice) {
+        return products.findByPriceGreaterThan(minPrice);
+    }
+}
+```
+
+---
+
+## Jakarta Data Repository Support
+
+| Feature | Details |
+|---------|---------|
+| **CRUD** | `CrudRepository<T,K>`, `MorphiumRepository<T,K>` -- save, insert, update, delete, findById, findAll |
+| **Query derivation** | `findBy`, `countBy`, `existsBy`, `deleteBy` with operators: Equals, Not, GreaterThan, LessThan, Between, In, NotIn, Like, StartsWith, EndsWith, Null, NotNull, True, False -- combined with And/Or |
+| **@Find + @By** | Explicit field binding via parameter annotations |
+| **@Query (JDQL)** | Jakarta Data Query Language with WHERE, ORDER BY, named parameters, BETWEEN, IN, LIKE, IS NULL, NOT, GROUP BY, HAVING, aggregates |
+| **@OrderBy** | Static sort annotation on query methods |
+| **Pagination** | `Page<T>`, `PageRequest`, `CursoredPage<T>` (keyset pagination) |
+| **Sorting** | `Sort<T>`, `Order<T>` as method parameters |
+| **Stream** | `Stream<T>` return type for large result sets |
+| **Async** | `CompletionStage<T>` return type for non-blocking operations |
+
+### MorphiumRepository -- The Escape Hatch
+
+`MorphiumRepository<T,K>` extends `CrudRepository` with Morphium-specific operations:
+
+```java
+// Distinct values for a field
+List<Object> categories = products.distinct("category");
+
+// Direct access to the Morphium API
+products.morphium().inc(product, "stock", 5);
+
+// Create a typed Morphium Query
+Query<Product> q = products.query();
+q.f("price").gt(100).f("category").eq("electronics");
+```
+
+---
+
+## Configuration Reference
+
+Property prefix is `morphium` (not `spring.morphium`) -- the `spring.*` namespace is
+reserved for Spring Boot's own configuration keys. Every property below is verified
+directly against `MorphiumProperties.java`.
+
+| Property | Default | Description | Source |
+|---|---|---|---|
+| `morphium.database` | *(required)* | MongoDB database name | `MorphiumProperties.java:46` |
+| `morphium.hosts` | `localhost:27017` | Comma-separated `host:port` list; ignored if `morphium.atlas-url` is set | `MorphiumProperties.java:39` |
+| `morphium.username` | -- | MongoDB username; only applied together with `morphium.password` | `MorphiumProperties.java:52` |
+| `morphium.password` | -- | MongoDB password | `MorphiumProperties.java:57` |
+| `morphium.auth-database` | `admin` | Authentication database (`authSource`) | `MorphiumProperties.java:64` |
+| `morphium.driver-name` | `PooledDriver` | `PooledDriver` (production) or `InMemDriver` (tests, no MongoDB needed) | `MorphiumProperties.java:71` |
+| `morphium.read-preference` | `primary` | MongoDB read preference | `MorphiumProperties.java:77` |
+| `morphium.max-connections` | `250` | Connection pool size | `MorphiumProperties.java:82` |
+| `morphium.atlas-url` | -- | MongoDB Atlas SRV URL (overrides `morphium.hosts` when set) | `MorphiumProperties.java:89` |
+| `morphium.replica-set-name` | -- | Replica set name (required for transactions) | `MorphiumProperties.java:97` |
+| `morphium.connect-retries` | `5` | Connection attempts before giving up on transient failures (linear backoff, `attempt * 2000`ms) | `MorphiumProperties.java:106` |
+| `morphium.index-check` | `CREATE_ON_STARTUP` | `CREATE_ON_STARTUP`, `WARN_ON_STARTUP`, `CREATE_ON_WRITE_NEW_COL`, `NO_CHECK` | `MorphiumProperties.java:115` |
+| `morphium.cache.global-valid-time` | `5000` | Cache TTL in milliseconds | `MorphiumProperties.java:361` |
+| `morphium.cache.read-cache-enabled` | `true` | Enable query result cache | `MorphiumProperties.java:368` |
+| `morphium.ssl.enabled` | `false` | Enable TLS | `MorphiumProperties.java:418` |
+| `morphium.ssl.keystore-path` | -- | Keystore path (JKS/PKCS12) for client-certificate TLS | `MorphiumProperties.java:426` |
+| `morphium.ssl.keystore-password` | -- | Keystore password | `MorphiumProperties.java:431` |
+
+If `spring-boot-configuration-processor` is on the classpath (it is an optional
+dependency of `morphium-spring-boot-autoconfigure`), every property above also appears
+in `META-INF/spring-configuration-metadata.json`, giving IDEs autocompletion and
+validation for `morphium.*` keys.
+
+## Transactions
+
+Requires a MongoDB replica set or Atlas.
+
+```java
+@Service
+public class OrderService {
+
+    @Autowired Morphium morphium;
+
+    @MorphiumTransactional
+    public void placeOrder(Order order, Payment payment) {
+        morphium.store(order);
+        morphium.store(payment);
+        // auto-commit on success, auto-rollback on exception
+    }
+}
+```
+
+## Actuator Health
+
+When `spring-boot-actuator` is on the classpath, a Morphium health indicator is
+automatically registered at `/actuator/health`:
+
+```json
+{
+  "status": "UP",
+  "components": {
+    "morphium": {
+      "status": "UP",
+      "details": {
+        "database": "my-database",
+        "driver": "PooledDriver",
+        "replicaSet": true,
+        "replicaSetName": "rs0"
+      }
+    }
+  }
+}
+```
+
+## Testing
+
+### Option A: InMemDriver (no MongoDB required)
+
+```properties
+# src/test/resources/application-test.properties
+morphium.database=test
+morphium.driver-name=InMemDriver
+```
+
+```java
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableMorphiumRepositories
+class ProductRepositoryTest {
+
+    @Autowired ProductRepository repository;
+
+    @Test
+    void shouldFindByCategory() {
+        repository.save(new Product("Widget", 9.99, "tools"));
+
+        var results = repository.findByCategory("tools");
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getName()).isEqualTo("Widget");
+    }
+}
+```
+
+### Option B: @MorphiumTest annotation
+
+The `morphium-spring-boot-test` module provides a composite annotation:
+
+```xml
+<dependency>
+    <groupId>de.caluga</groupId>
+    <artifactId>morphium-spring-boot-test</artifactId>
+    <version>6.3.0-SNAPSHOT</version>
+    <scope>test</scope>
+</dependency>
+```
+
+```java
+@MorphiumTest
+@EnableMorphiumRepositories
+class ProductRepositoryTest {
+
+    @Autowired ProductRepository repository;
+
+    @Test
+    void shouldFindByCategory() {
+        // InMemDriver is auto-configured
+    }
+}
+```
+
+## Module Structure
+
+```
+spring-boot-morphium/
+  morphium-spring-boot-autoconfigure/   Auto-configuration, repository proxy, AOP, health
+  morphium-spring-boot-starter/         Dependency-only POM (pull this in your app)
+  morphium-spring-boot-test/            @MorphiumTest annotation for test support
+```
+
+## Architecture
+
+This starter uses **JDK dynamic proxies** at runtime (the standard Spring Data pattern),
+in contrast to the [quarkus-morphium](https://github.com/Bardioc1977/quarkus-morphium)
+extension which uses **Gizmo bytecode generation** at build time. Concretely: a
+repository interface annotated `@Repository` is discovered at Spring context-startup
+time by `MorphiumRepositoryRegistrar`, which registers a `MorphiumRepositoryFactoryBean`
+that creates a `java.lang.reflect.Proxy` implementing the interface -- no implementation
+class is ever generated or compiled. Quarkus instead generates a real, compiled
+implementation class via Gizmo bytecode generation before the application starts,
+avoiding runtime reflection entirely at the cost of a build-time processing step.
+
+Both share the same query engine via the
+[morphium-jakarta-data](https://github.com/Bardioc1977/morphium-jakarta-data) module --
+a framework-agnostic library containing all Jakarta Data query derivation, JDQL parsing,
+pagination, and CRUD logic.
+
+```
+morphium (core ODM)
+  └── morphium-jakarta-data (shared Jakarta Data runtime)
+        ├── morphium-spring-boot-* (this project, JDK proxies)
+        └── quarkus-morphium (Gizmo bytecode, build-time)
+```
+
+### Relationship to `morphium-jakarta-data`
+
+`morphium-jakarta-data` contains the entire framework-agnostic Jakarta Data runtime:
+`MethodNameParser`/`QueryExecutor` (query derivation from method names), `JdqlParser`/
+`JdqlMethodBridge` (the `@Query` JDQL grammar), `FindMethodBridge` (`@Find`/`@Delete`
+with `@By` parameter binding), pagination (`AbstractMorphiumRepository`'s offset and
+cursor pagination), and sorting. None of that logic is duplicated here.
+
+This module (`morphium-spring-boot-*`) adds exactly the Spring-specific wiring on top:
+the `Morphium` bean and `MorphiumProperties` (`morphium.*` configuration,
+`MorphiumAutoConfiguration`), the `@EnableMorphiumRepositories`/
+`MorphiumRepositoryRegistrar`/`MorphiumRepositoryFactoryBean` JDK-proxy mechanism that
+turns a `@Repository` interface into a Spring bean, the `@MorphiumTransactional` AOP
+aspect, and the actuator health indicator. Every Jakarta Data feature documented for
+`morphium-jakarta-data` (query derivation keywords, JDQL grammar, pagination types,
+return-type handling) applies unchanged once wired through this module -- there is no
+separate, Spring-specific feature set to learn.
+
+### Abgrenzung zu Spring Data MongoDB
+
+This module is **not** a replacement for or a re-implementation of Spring Data
+MongoDB, and does not aim to be API-compatible with it:
+
+- It implements the **Jakarta Data 1.0** specification (`@Repository`,
+  `CrudRepository`, `@Find`, `@Query`/JDQL, `Page`/`CursoredPage`, `Sort`/`Order`), a
+  vendor-neutral Jakarta EE specification -- not Spring Data's own repository
+  interfaces (`MongoRepository`, `@Query` with a different string syntax, Spring
+  Data's `Criteria`/`Aggregation` API, etc.).
+- The underlying data access is always **Morphium**, not Spring Data MongoDB's own
+  `MongoTemplate`/`MongoOperations`. There is no `MongoTemplate` bean and no
+  Spring Data MongoDB entity mapping (`@Document`, Spring Data converters) --
+  entities use Morphium's own annotations (`@Entity`, `@Id`, `@Reference`, etc.).
+- Transactions here are Morphium transactions (`Morphium.startTransaction()`/
+  `commitTransaction()`/`abortTransaction()`) wrapped by a small AOP aspect, not
+  Spring's `PlatformTransactionManager`/`@Transactional` infrastructure.
+- Query derivation, JDQL, and pagination/sorting behavior come from
+  `morphium-jakarta-data`; the exact keyword set and grammar there differs in detail
+  from Spring Data's query-method conventions (see that module's README/docs for the
+  full grammar), even though many method names look similar in simple cases
+  (`findByCategory`, `countByStatus`, ...).
+
+If your application already uses Spring Data MongoDB and does not use Morphium, this
+module has nothing to offer you. If you are building on Morphium and want a
+Spring-managed, dependency-injected repository layer with Jakarta Data semantics, this
+is the module for that.
+
+## Building from Source
+
+```bash
+# Part of the Morphium reactor -- build from the reactor root, or standalone with
+# morphium and morphium-jakarta-data already installed to your local repository.
+
+mvn clean install
+
+# Run tests only
+mvn test -pl morphium-spring-boot-autoconfigure
+```
+
+## Related Projects
+
+- [Morphium](https://github.com/sboesebeck/morphium) -- the underlying MongoDB ORM
+- [morphium-jakarta-data](https://github.com/Bardioc1977/morphium-jakarta-data) -- shared Jakarta Data runtime
+- [quarkus-morphium](https://github.com/Bardioc1977/quarkus-morphium) -- Quarkus CDI extension (same Jakarta Data features)
+- [quarkus-morphium-showcase](https://github.com/Bardioc1977/quarkus-morphium-showcase) -- interactive demo
+- [Jakarta Data 1.0](https://jakarta.ee/specifications/data/1.0/) -- the specification
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+[Apache License 2.0](LICENSE)

--- a/spring-boot-morphium/docs-for-morphium/spring-boot.md
+++ b/spring-boot-morphium/docs-for-morphium/spring-boot.md
@@ -54,7 +54,7 @@ pagination runtime.
 </dependency>
 ```
 
-In the Morphium reactor, `${project.version}` currently resolves to `6.3.0-SNAPSHOT`.
+In the Morphium reactor, `${project.version}` currently resolves to `6.3.2-SNAPSHOT`.
 This module follows Morphium's regular release versioning — it is versioned and
 released in lockstep with Morphium; there is no separate version line to track.
 
@@ -270,7 +270,7 @@ class ProductRepositoryTest {
 `InMemDriver` is Morphium's in-memory MongoDB emulation — tests run against it with no
 container and no external MongoDB, exactly like the core Morphium test suite.
 
-## Abgrenzung zu Spring Data MongoDB
+## Distinction from Spring Data MongoDB
 
 This module is **not** a replacement for, or a re-implementation of, Spring Data
 MongoDB, and does not aim to be API-compatible with it:
@@ -301,7 +301,7 @@ This page is an overview. The complete module documentation — installation, th
 property reference, repository usage, transactions, testing, and the detailed
 architecture comparison with Quarkus — lives in the module's own README:
 
-[`morphium-spring-boot-starter/README.md`](https://github.com/sboesebeck/morphium/tree/develop/morphium-spring-boot-starter/README.md)
+[`spring-boot-morphium/README.md`](https://github.com/sboesebeck/morphium/blob/develop/spring-boot-morphium/README.md)
 
 See also [Jakarta Data](jakarta-data.md) for the framework-agnostic repository runtime
 this module builds on, and [Quarkus Extension](quarkus-extension.md) for the

--- a/spring-boot-morphium/docs-for-morphium/spring-boot.md
+++ b/spring-boot-morphium/docs-for-morphium/spring-boot.md
@@ -1,0 +1,308 @@
+# Spring Boot Starter: Auto-Configuration for Morphium
+
+`morphium-spring-boot-*` is an **optional Morphium module** that integrates Morphium
+into [Spring Boot](https://spring.io/projects/spring-boot) applications via
+auto-configuration, type-safe `@ConfigurationProperties`, declarative transactions,
+an Actuator health indicator, and Jakarta Data `@Repository` interfaces backed by JDK
+dynamic proxies at runtime — no build-time bytecode generation, no annotation
+processor for the repositories themselves. It pulls in
+[`morphium-jakarta-data`](jakarta-data.md) for the entire query-derivation, JDQL, and
+pagination runtime.
+
+!!! note "Optional module — the Morphium core does not depend on it"
+    `de.caluga:morphium` has zero compile- or runtime dependency on this module, on
+    Spring, or on `jakarta.data-api`. You only need `morphium-spring-boot-starter` if
+    you are building a Spring Boot application against MongoDB via Morphium.
+
+## What it provides
+
+- **Auto-configuration** — `MorphiumAutoConfiguration` creates the application's
+  single `Morphium` bean from `morphium.*` properties, with connection retry on
+  transient failures (linear backoff) and a best-effort classpath pre-scan for
+  `@Entity`/`@Embedded` classes so Morphium can skip its own internal scan at startup.
+- **Type-safe configuration** — every setting lives under `morphium.*` as
+  `@ConfigurationProperties`, with `spring-boot-configuration-processor`-generated
+  metadata for IDE autocompletion.
+- **Jakarta Data repositories** — declare a `@Repository` interface extending
+  `CrudRepository`/`MorphiumRepository` from `morphium-jakarta-data`; at Spring
+  context-startup time, `MorphiumRepositoryRegistrar` scans for such interfaces and
+  registers a `MorphiumRepositoryFactoryBean` for each, which creates a
+  `java.lang.reflect.Proxy` implementing the interface — see
+  [Proxy mechanism vs. Quarkus](#proxy-mechanism-vs-quarkus) below. See
+  [Jakarta Data](jakarta-data.md) for the full query-derivation, JDQL, and pagination
+  feature set — everything documented there works identically once wired through this
+  module's proxies.
+- **Declarative transactions** — `@MorphiumTransactional` on a Spring bean method
+  wraps the method body in `startTransaction()`/`commitTransaction()`/
+  `abortTransaction()` via an AspectJ `@Around` advice, active only when
+  `spring-boot-starter-aop` is on the classpath.
+- **Actuator health** — a `HealthIndicator` reporting live MongoDB connection status
+  (database, driver, replica-set state) under `/actuator/health`, active only when
+  `spring-boot-actuator` is present and a `Morphium` bean already exists.
+- **Test support** — the companion `morphium-spring-boot-test` module provides
+  `@MorphiumTest`, a composite annotation that wires `InMemDriver` (Morphium's
+  in-memory MongoDB emulation) into a `@SpringBootTest`, so repository tests run
+  without a MongoDB instance or container.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>de.caluga</groupId>
+  <artifactId>morphium-spring-boot-starter</artifactId>
+  <version>${project.version}</version>
+</dependency>
+```
+
+In the Morphium reactor, `${project.version}` currently resolves to `6.3.0-SNAPSHOT`.
+This module follows Morphium's regular release versioning — it is versioned and
+released in lockstep with Morphium; there is no separate version line to track.
+
+## Configuration Reference
+
+All properties live under `morphium.*` (not `spring.morphium.*` — the `spring.*`
+namespace is reserved for Spring Boot's own configuration keys). Every entry below is
+verified directly against `MorphiumProperties.java` in the
+`morphium-spring-boot-autoconfigure` module.
+
+| Property | Default | Description | Source |
+|---|---|---|---|
+| `morphium.database` | *(required)* | MongoDB database name | `MorphiumProperties.java:46` |
+| `morphium.hosts` | `localhost:27017` | Comma-separated `host:port` list; ignored if `morphium.atlas-url` is set | `MorphiumProperties.java:39` |
+| `morphium.username` / `.password` | -- | Optional credentials, applied only when both are set | `MorphiumProperties.java:52,57` |
+| `morphium.auth-database` | `admin` | Authentication database (`authSource`) | `MorphiumProperties.java:64` |
+| `morphium.driver-name` | `PooledDriver` | `PooledDriver` (production) or `InMemDriver` (tests, no MongoDB needed) | `MorphiumProperties.java:71` |
+| `morphium.read-preference` | `primary` | MongoDB read preference | `MorphiumProperties.java:77` |
+| `morphium.max-connections` | `250` | Connection pool size | `MorphiumProperties.java:82` |
+| `morphium.atlas-url` | -- | MongoDB Atlas SRV connection string (overrides `morphium.hosts` when set) | `MorphiumProperties.java:89` |
+| `morphium.replica-set-name` | -- | Replica set name (required for transactions) | `MorphiumProperties.java:97` |
+| `morphium.connect-retries` | `5` | Connection attempts before giving up on transient failures, linear backoff `attempt * 2000`ms | `MorphiumProperties.java:106` |
+| `morphium.index-check` | `CREATE_ON_STARTUP` | `CREATE_ON_STARTUP`, `WARN_ON_STARTUP`, `CREATE_ON_WRITE_NEW_COL`, `NO_CHECK` | `MorphiumProperties.java:115` |
+| `morphium.cache.global-valid-time` | `5000` | Cache TTL in milliseconds | `MorphiumProperties.java:361` |
+| `morphium.cache.read-cache-enabled` | `true` | Enable query result cache | `MorphiumProperties.java:368` |
+| `morphium.ssl.enabled` | `false` | Enable TLS | `MorphiumProperties.java:418` |
+| `morphium.ssl.keystore-path` / `.keystore-password` | -- | Keystore (JKS/PKCS12) for client-certificate TLS | `MorphiumProperties.java:426,431` |
+
+If `spring-boot-configuration-processor` is on the classpath (declared as an optional
+dependency of `morphium-spring-boot-autoconfigure`), every property above also appears
+in `META-INF/spring-configuration-metadata.json`, giving IDEs autocompletion and
+validation for `morphium.*` keys.
+
+## Quick Example
+
+```java
+@Entity(collectionName = "products")
+public class Product {
+    @Id private MorphiumId id;
+    private String name;
+    private double price;
+    private String category;
+    // getters/setters omitted
+}
+
+@Repository
+public interface ProductRepository extends MorphiumRepository<Product, MorphiumId> {
+    List<Product> findByCategory(String category);
+
+    List<Product> findByPriceGreaterThan(double minPrice);
+}
+
+@SpringBootApplication
+@EnableMorphiumRepositories
+public class MyApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MyApplication.class, args);
+    }
+}
+
+@Service
+public class ProductService {
+    @Autowired ProductRepository products;
+
+    public List<Product> findExpensive(double minPrice) {
+        return products.findByPriceGreaterThan(minPrice);
+    }
+}
+```
+
+```properties
+morphium.database=my-app-db
+morphium.hosts=localhost:27017
+```
+
+## Repository Usage
+
+Annotate a `@SpringBootApplication` (or any `@Configuration` class) with
+`@EnableMorphiumRepositories` to enable scanning. By default the scan covers the
+annotated class's package and sub-packages; pass explicit packages via `value()`/
+`basePackages()` to scan elsewhere.
+
+Repository interfaces extend either `jakarta.data.repository.CrudRepository<T, K>`
+(the plain Jakarta Data interface) or `de.caluga.morphium.data.MorphiumRepository<T,
+K>`, which adds Morphium-specific escape hatches with no Jakarta Data equivalent:
+
+```java
+// Distinct values for a field
+List<Object> categories = products.distinct("category");
+
+// Direct access to the Morphium API
+products.morphium().inc(product, "stock", 5);
+
+// A typed Morphium Query, for anything beyond derived queries/JDQL/@Find
+Query<Product> q = products.query();
+q.f("price").gt(100).f("category").eq("electronics");
+```
+
+### Proxy mechanism vs. Quarkus
+
+This module uses **JDK dynamic proxies at runtime** — the standard Spring Data
+pattern — in contrast to the [Quarkus extension](quarkus-extension.md), which uses
+**Gizmo bytecode generation at build time**.
+
+Concretely: at Spring context-startup time, `MorphiumRepositoryRegistrar` (imported by
+`@EnableMorphiumRepositories`) scans the configured base packages for `@Repository`
+interfaces and registers a `MorphiumRepositoryFactoryBean` bean definition for each
+one found. Each factory bean creates a `java.lang.reflect.Proxy` implementing the
+repository interface, backed by a `MorphiumRepositoryInvocationHandler` that
+dispatches every method call — derived queries, JDQL, `@Find`/`@Delete`, plain CRUD —
+to the shared `morphium-jakarta-data` runtime. No implementation class is ever
+generated or compiled; the proxy is synthesized by the JVM itself, once per repository
+interface, the first time the bean is requested.
+
+Quarkus's `quarkus-morphium` extension instead runs a build-time processor that emits
+a real, compiled implementation class via Gizmo bytecode generation before the
+application ever starts — no proxy or reflective dispatch exists at runtime there at
+all. The trade-off is the classic one: this module's proxies need zero build-time
+tooling and work with plain `javac`, at the cost of a small amount of per-call
+reflective dispatch overhead and no build-time validation of query derivation;
+Quarkus's build-time generation avoids that runtime cost and validates earlier, at the
+cost of requiring its build-time augmentation phase. Both mechanisms delegate to the
+exact same `morphium-jakarta-data` query engine — only *how* a repository interface is
+wired to that engine differs.
+
+## Transactions
+
+Requires a MongoDB replica set or Atlas cluster (`morphium.replica-set-name`) — a
+standalone MongoDB node rejects multi-document transactions.
+
+```java
+@Service
+public class OrderService {
+    @Autowired Morphium morphium;
+
+    @MorphiumTransactional
+    public void placeOrder(Order order, Payment payment) {
+        morphium.store(order);
+        morphium.store(payment);
+        // committed automatically on return, rolled back automatically on exception
+    }
+}
+```
+
+`@MorphiumTransactional` is picked up by an AspectJ `@Around` advice
+(`MorphiumTransactionAspect`) that is only active when `spring-boot-starter-aop` is on
+the classpath and a `Morphium` bean exists in the context. It starts a transaction
+before the advised method runs, commits on normal return, and aborts (rethrowing the
+original exception unchanged) if the method throws.
+
+## Health / Actuator
+
+When `spring-boot-actuator` is on the classpath and a `Morphium` bean already exists,
+`MorphiumHealthAutoConfiguration` registers a `HealthIndicator` under
+`/actuator/health`:
+
+```json
+{
+  "components": {
+    "morphium": {
+      "status": "UP",
+      "details": {
+        "database": "my-app-db",
+        "driver": "PooledDriver",
+        "replicaSet": true,
+        "replicaSetName": "rs0"
+      }
+    }
+  }
+}
+```
+
+Disable it with `management.health.morphium.enabled=false`, or override it entirely
+by defining your own `@Bean(name = "morphiumHealthIndicator") HealthIndicator` — the
+auto-configured bean backs off via `@ConditionalOnMissingBean(name =
+"morphiumHealthIndicator")`.
+
+## Testing without a MongoDB instance
+
+```properties
+# src/test/resources/application-test.properties
+morphium.database=test
+morphium.driver-name=InMemDriver
+```
+
+```java
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableMorphiumRepositories
+class ProductRepositoryTest {
+    @Autowired ProductRepository repository;
+
+    @Test
+    void shouldFindByCategory() {
+        repository.save(new Product("Widget", 9.99, "tools"));
+        assertThat(repository.findByCategory("tools")).hasSize(1);
+    }
+}
+```
+
+The companion `morphium-spring-boot-test` module wraps the same properties into a
+composite `@MorphiumTest` annotation:
+
+```java
+@MorphiumTest
+@EnableMorphiumRepositories
+class ProductRepositoryTest {
+    @Autowired ProductRepository repository;
+    // InMemDriver is auto-configured — no MongoDB instance or container needed
+}
+```
+
+`InMemDriver` is Morphium's in-memory MongoDB emulation — tests run against it with no
+container and no external MongoDB, exactly like the core Morphium test suite.
+
+## Abgrenzung zu Spring Data MongoDB
+
+This module is **not** a replacement for, or a re-implementation of, Spring Data
+MongoDB, and does not aim to be API-compatible with it:
+
+- It implements the **Jakarta Data 1.0** specification (`@Repository`,
+  `CrudRepository`, `@Find`, `@Query`/JDQL, `Page`/`CursoredPage`, `Sort`/`Order`) — a
+  vendor-neutral Jakarta EE specification — not Spring Data's own repository
+  interfaces or query-method conventions.
+- The underlying data access is always **Morphium**, not Spring Data MongoDB's
+  `MongoTemplate`/`MongoOperations`. There is no `MongoTemplate` bean and no Spring
+  Data MongoDB entity mapping; entities use Morphium's own annotations (`@Entity`,
+  `@Id`, `@Reference`, etc.).
+- Transactions are Morphium transactions wrapped by a small AOP aspect, not Spring's
+  `PlatformTransactionManager`/`@Transactional` infrastructure.
+- Query derivation, JDQL, and pagination/sorting behavior come from
+  `morphium-jakarta-data`; the keyword set and grammar differ in detail from Spring
+  Data's query-method conventions, even though simple method names
+  (`findByCategory`, `countByStatus`, ...) often look similar.
+
+If your application already uses Spring Data MongoDB and does not use Morphium, this
+module has nothing to offer you. If you are building on Morphium and want a
+Spring-managed, dependency-injected repository layer with Jakarta Data semantics, this
+is the module for that.
+
+## Full Documentation
+
+This page is an overview. The complete module documentation — installation, the full
+property reference, repository usage, transactions, testing, and the detailed
+architecture comparison with Quarkus — lives in the module's own README:
+
+[`morphium-spring-boot-starter/README.md`](https://github.com/sboesebeck/morphium/tree/develop/morphium-spring-boot-starter/README.md)
+
+See also [Jakarta Data](jakarta-data.md) for the framework-agnostic repository runtime
+this module builds on, and [Quarkus Extension](quarkus-extension.md) for the
+build-time-bytecode alternative to this module's runtime JDK proxies.

--- a/spring-boot-morphium/docs-for-morphium/spring-boot.md
+++ b/spring-boot-morphium/docs-for-morphium/spring-boot.md
@@ -18,8 +18,7 @@ pagination runtime.
 
 - **Auto-configuration** — `MorphiumAutoConfiguration` creates the application's
   single `Morphium` bean from `morphium.*` properties, with connection retry on
-  transient failures (linear backoff) and a best-effort classpath pre-scan for
-  `@Entity`/`@Embedded` classes so Morphium can skip its own internal scan at startup.
+  transient failures (linear backoff).
 - **Type-safe configuration** — every setting lives under `morphium.*` as
   `@ConfigurationProperties`, with `spring-boot-configuration-processor`-generated
   metadata for IDE autocompletion.

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.caluga</groupId>
+    <artifactId>morphium-spring-boot-parent</artifactId>
+    <version>6.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>morphium-spring-boot-autoconfigure</artifactId>
+  <name>Morphium Spring Boot – Autoconfigure</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <!-- Generates META-INF/spring-configuration-metadata.json for
+         MorphiumProperties, so IDEs offer autocompletion/validation for
+         morphium.* keys in application.properties/.yml. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>de.caluga</groupId>
+      <artifactId>morphium</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- classgraph: Dependency-Deklaration bleibt bestehen (Entity-Pre-Scan in
+         MorphiumAutoConfiguration), die Versionsverwaltung übernimmt künftig
+         morphium-parent's dependencyManagement (siehe morphium/pom.xml) statt
+         einer eigenen Version hier. -->
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.caluga</groupId>
+      <artifactId>morphium-jakarta-data</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.data</groupId>
+      <artifactId>jakarta.data-api</artifactId>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <!-- Aktiviert die im morphium-parent-pluginManagement bereits versionierte
+       source-/javadoc-jar-Erzeugung (Central-Pflicht) — analog zum Muster in
+       morphium/quarkus-morphium/runtime/pom.xml und morphium/morphium-jakarta-data/pom.xml.
+       maven-surefire-plugin braucht hier keine explizite Referenz: es ist Teil
+       des Default-Lifecycles für Packaging "jar" und übernimmt die im
+       Parent-pluginManagement hinterlegte Version automatisch. -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <!-- spring-boot-configuration-processor (declared as an optional
+           dependency above) is not picked up automatically from the plain
+           compile classpath on this toolchain (verified: the processor jar
+           IS on -classpath, yet javac produces no
+           META-INF/spring-configuration-metadata.json without an explicit
+           -processorpath — reproduced with a bare javac invocation using the
+           exact same classpath/compiler args Maven emits). Declaring the
+           annotation processor path explicitly is also what Spring Boot's
+           own official guide recommends, independent of this specific
+           symptom. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-configuration-processor</artifactId>
+              <version>${spring-boot.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.caluga</groupId>
     <artifactId>morphium-spring-boot-parent</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>6.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>morphium-spring-boot-autoconfigure</artifactId>

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/pom.xml
@@ -41,14 +41,6 @@
       <artifactId>morphium</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- classgraph: Dependency-Deklaration bleibt bestehen (Entity-Pre-Scan in
-         MorphiumAutoConfiguration), die Versionsverwaltung übernimmt künftig
-         morphium-parent's dependencyManagement (siehe morphium/pom.xml) statt
-         einer eigenen Version hier. -->
-    <dependency>
-      <groupId>io.github.classgraph</groupId>
-      <artifactId>classgraph</artifactId>
-    </dependency>
     <dependency>
       <groupId>de.caluga</groupId>
       <artifactId>morphium-jakarta-data</artifactId>

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/EnableMorphiumRepositories.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/EnableMorphiumRepositories.java
@@ -1,0 +1,86 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.*;
+
+/**
+ * Enables scanning for Jakarta Data {@code @Repository} interfaces (extending
+ * {@code jakarta.data.repository.CrudRepository} or
+ * {@code de.caluga.morphium.data.MorphiumRepository}) and registers a Spring bean for
+ * each one found, backed by a JDK dynamic proxy.
+ *
+ * <p>By default the scan covers the package of the class annotated with
+ * {@code @EnableMorphiumRepositories} and its sub-packages; pass explicit packages via
+ * {@link #value()} or {@link #basePackages()} to scan elsewhere.
+ *
+ * <pre>{@code
+ * @SpringBootApplication
+ * @EnableMorphiumRepositories
+ * public class MyApplication {
+ *     public static void main(String[] args) {
+ *         SpringApplication.run(MyApplication.class, args);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <pre>{@code
+ * @Repository
+ * public interface ProductRepository extends MorphiumRepository<Product, MorphiumId> {
+ *     List<Product> findByCategory(String category);
+ * }
+ *
+ * @Service
+ * public class ProductService {
+ *     @Autowired ProductRepository products; // JDK proxy, injected like any bean
+ * }
+ * }</pre>
+ *
+ * <h2>How the proxy mechanism works</h2>
+ * This annotation triggers {@code @Import(MorphiumRepositoryRegistrar.class)}. At
+ * context-startup time, {@link MorphiumRepositoryRegistrar} scans the configured
+ * base packages for {@code @Repository} interfaces and registers one
+ * {@link MorphiumRepositoryFactoryBean} bean definition per interface found. Each
+ * {@code FactoryBean} creates a {@link java.lang.reflect.Proxy JDK dynamic proxy}
+ * implementing the repository interface, backed by a
+ * {@link MorphiumRepositoryInvocationHandler} that dispatches every method call —
+ * derived queries ({@code findBy*}), {@code @Query} (JDQL), {@code @Find}/{@code
+ * @Delete}, and plain CRUD — to the shared, framework-agnostic runtime in
+ * {@code morphium-jakarta-data}. No implementation class is ever generated or
+ * compiled; the interface's bytecode is used unmodified, and Java's built-in
+ * {@code java.lang.reflect.Proxy} mechanism creates the implementing class
+ * <strong>at application startup, in the running JVM</strong>.
+ *
+ * <p>This is deliberately different from the {@code quarkus-morphium} extension's
+ * approach to the same problem: Quarkus generates a concrete implementation class for
+ * each repository interface via Gizmo bytecode generation <strong>at build
+ * time</strong>, so no proxy or reflection exists at runtime at all — the generated
+ * class is compiled into the application the same as any other class. The trade-off
+ * is the classic one between the two approaches: this module's JDK proxies need zero
+ * build-time tooling and work unmodified with plain {@code javac}, at the cost of a
+ * small amount of reflective dispatch overhead per repository call and no build-time
+ * validation of query derivation; Quarkus's build-time generation shifts that
+ * validation earlier and avoids the runtime dispatch cost, at the cost of requiring
+ * its build-time augmentation phase. Both approaches share the same query engine
+ * (query derivation, JDQL parsing, pagination, CRUD) via {@code morphium-jakarta-data}
+ * — only the mechanism that wires a repository interface to that engine differs.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(MorphiumRepositoryRegistrar.class)
+public @interface EnableMorphiumRepositories {
+
+    /**
+     * Base packages to scan for {@code @Repository} interfaces. Equivalent to
+     * {@link #basePackages()} — both arrays are merged if both are given. Defaults to
+     * an empty array, in which case the package of the annotated class is scanned.
+     */
+    String[] value() default {};
+
+    /**
+     * Alias for {@link #value()}, provided for readability when only base packages
+     * (and no other attribute) are specified.
+     */
+    String[] basePackages() default {};
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumAutoConfiguration.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumAutoConfiguration.java
@@ -1,10 +1,7 @@
 package de.caluga.morphium.spring.autoconfigure;
 
-import de.caluga.morphium.AnnotationAndReflectionHelper;
 import de.caluga.morphium.Morphium;
 import de.caluga.morphium.MorphiumConfig;
-import de.caluga.morphium.annotations.Embedded;
-import de.caluga.morphium.annotations.Entity;
 import de.caluga.morphium.config.CollectionCheckSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,9 +10,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Auto-configuration that creates the application's single {@link Morphium} bean from
@@ -65,12 +59,8 @@ public class MorphiumAutoConfiguration {
 
     /**
      * Builds and connects the application's {@link Morphium} instance from
-     * {@code properties}. Before connecting, it best-effort pre-registers every
-     * {@code @Entity}/{@code @Embedded} class found on the classpath via a
-     * {@code ClassGraph} scan, so Morphium can skip its own internal classpath scan at
-     * startup (see {@link #preRegisterEntities()}). It then builds a
-     * {@code MorphiumConfig} from {@code properties} (see {@link #buildConfig}) and
-     * connects with retry (see {@link #connectWithRetry}).
+     * {@code properties}: it builds a {@code MorphiumConfig} from {@code properties}
+     * (see {@link #buildConfig}) and connects with retry (see {@link #connectWithRetry}).
      *
      * <p>Only runs if no other {@code Morphium} bean is already defined in the context
      * ({@code @ConditionalOnMissingBean}) — see the class-level documentation for how
@@ -86,9 +76,6 @@ public class MorphiumAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public Morphium morphium(MorphiumProperties properties) {
-        // Pre-register entity type IDs from classpath scan to skip Morphium's internal ClassGraph scan
-        preRegisterEntities();
-
         MorphiumConfig cfg = buildConfig(properties);
         Morphium m = connectWithRetry(cfg, properties.getConnectRetries());
 
@@ -102,41 +89,6 @@ public class MorphiumAutoConfiguration {
                 m.getDriver().isReplicaSet());
 
         return m;
-    }
-
-    /**
-     * Scans the classpath for @Entity/@Embedded classes and pre-registers their type IDs.
-     * This skips Morphium's internal ClassGraph scan at startup.
-     * Best-effort: if scanning fails, Morphium falls back to its own ClassGraph scan.
-     */
-    private void preRegisterEntities() {
-        try {
-            io.github.classgraph.ScanResult scanResult = new io.github.classgraph.ClassGraph()
-                    .enableAnnotationInfo()
-                    .scan();
-            Map<String, String> typeIds = new HashMap<>();
-            try (scanResult) {
-                for (String annotationName : new String[]{Entity.class.getName(), Embedded.class.getName()}) {
-                    for (var ci : scanResult.getClassesWithAnnotation(annotationName)) {
-                        String cn = ci.getName();
-                        typeIds.put(cn, cn);
-                        var ai = ci.getAnnotationInfo(annotationName);
-                        if (ai != null) {
-                            var typeIdParam = ai.getParameterValues().getValue("typeId");
-                            if (typeIdParam instanceof String tid && !".".equals(tid)) {
-                                typeIds.put(tid, cn);
-                            }
-                        }
-                    }
-                }
-            }
-            if (!typeIds.isEmpty()) {
-                AnnotationAndReflectionHelper.registerTypeIds(typeIds);
-                log.info("Pre-registered {} entity type IDs, Morphium will skip ClassGraph scan", typeIds.size());
-            }
-        } catch (Exception e) {
-            log.debug("Entity pre-registration skipped, Morphium will use its own ClassGraph scan: {}", e.getMessage());
-        }
     }
 
     /**

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumAutoConfiguration.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumAutoConfiguration.java
@@ -1,0 +1,285 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.AnnotationAndReflectionHelper;
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.MorphiumConfig;
+import de.caluga.morphium.annotations.Embedded;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.config.CollectionCheckSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Auto-configuration that creates the application's single {@link Morphium} bean from
+ * {@link MorphiumProperties} ({@code morphium.*} keys). It applies only when
+ * {@code de.caluga.morphium.Morphium} is on the classpath
+ * ({@code @ConditionalOnClass(Morphium.class)}); on a plain Spring Boot application
+ * with the {@code morphium-spring-boot-starter} dependency, this is always the case.
+ *
+ * <p>Adding the starter and configuring at least {@code morphium.database} is enough
+ * to get a connected, injectable {@code Morphium} instance:
+ *
+ * <pre>{@code
+ * // application.properties
+ * morphium.database=my-database
+ * morphium.hosts=localhost:27017
+ * }</pre>
+ *
+ * <pre>{@code
+ * @Service
+ * public class ProductService {
+ *     @Autowired Morphium morphium;
+ * }
+ * }</pre>
+ *
+ * <h2>Overriding the {@code Morphium} bean</h2>
+ * The {@link #morphium(MorphiumProperties)} bean method is annotated
+ * {@code @ConditionalOnMissingBean}: if the application context already defines its
+ * own {@code Morphium} bean (of any name), this auto-configuration backs off entirely
+ * and its bean method is never invoked. This is the standard Spring Boot
+ * "auto-configuration as a default, not a mandate" pattern — define your own
+ * {@code @Bean Morphium morphium(...)} to take full control of connection setup while
+ * still using every other part of this module ({@link EnableMorphiumRepositories},
+ * {@link MorphiumTransactional}, the actuator health indicator).
+ *
+ * <p>Connection retries: transient failures during the initial connection attempt
+ * (MongoDB not yet electing a primary, or not yet accepting connections) are retried
+ * up to {@link MorphiumProperties#getConnectRetries()} times with a linear backoff of
+ * {@code attempt * 2000} milliseconds; non-transient failures propagate on the first
+ * attempt.
+ */
+@AutoConfiguration
+@ConditionalOnClass(Morphium.class)
+@EnableConfigurationProperties(MorphiumProperties.class)
+public class MorphiumAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(MorphiumAutoConfiguration.class);
+
+    /**
+     * Builds and connects the application's {@link Morphium} instance from
+     * {@code properties}. Before connecting, it best-effort pre-registers every
+     * {@code @Entity}/{@code @Embedded} class found on the classpath via a
+     * {@code ClassGraph} scan, so Morphium can skip its own internal classpath scan at
+     * startup (see {@link #preRegisterEntities()}). It then builds a
+     * {@code MorphiumConfig} from {@code properties} (see {@link #buildConfig}) and
+     * connects with retry (see {@link #connectWithRetry}).
+     *
+     * <p>Only runs if no other {@code Morphium} bean is already defined in the context
+     * ({@code @ConditionalOnMissingBean}) — see the class-level documentation for how
+     * to supply your own.
+     *
+     * @param properties the bound {@code morphium.*} configuration
+     * @return a connected {@code Morphium} instance, ready for injection
+     * @throws RuntimeException (or a Morphium-specific subtype) if the connection
+     *         cannot be established within {@link MorphiumProperties#getConnectRetries()}
+     *         attempts, or if building an SSL context from
+     *         {@link MorphiumProperties.SslProperties} fails
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public Morphium morphium(MorphiumProperties properties) {
+        // Pre-register entity type IDs from classpath scan to skip Morphium's internal ClassGraph scan
+        preRegisterEntities();
+
+        MorphiumConfig cfg = buildConfig(properties);
+        Morphium m = connectWithRetry(cfg, properties.getConnectRetries());
+
+        if (properties.getReplicaSetName() != null && !m.getDriver().isReplicaSet()) {
+            log.debug("Forcing replicaSet=true on driver (single-node replica set workaround)");
+            m.getDriver().setReplicaSet(true);
+        }
+
+        log.info("Morphium connected to '{}' (driver: {}, replicaSet: {})",
+                properties.getDatabase(), properties.getDriverName(),
+                m.getDriver().isReplicaSet());
+
+        return m;
+    }
+
+    /**
+     * Scans the classpath for @Entity/@Embedded classes and pre-registers their type IDs.
+     * This skips Morphium's internal ClassGraph scan at startup.
+     * Best-effort: if scanning fails, Morphium falls back to its own ClassGraph scan.
+     */
+    private void preRegisterEntities() {
+        try {
+            io.github.classgraph.ScanResult scanResult = new io.github.classgraph.ClassGraph()
+                    .enableAnnotationInfo()
+                    .scan();
+            Map<String, String> typeIds = new HashMap<>();
+            try (scanResult) {
+                for (String annotationName : new String[]{Entity.class.getName(), Embedded.class.getName()}) {
+                    for (var ci : scanResult.getClassesWithAnnotation(annotationName)) {
+                        String cn = ci.getName();
+                        typeIds.put(cn, cn);
+                        var ai = ci.getAnnotationInfo(annotationName);
+                        if (ai != null) {
+                            var typeIdParam = ai.getParameterValues().getValue("typeId");
+                            if (typeIdParam instanceof String tid && !".".equals(tid)) {
+                                typeIds.put(tid, cn);
+                            }
+                        }
+                    }
+                }
+            }
+            if (!typeIds.isEmpty()) {
+                AnnotationAndReflectionHelper.registerTypeIds(typeIds);
+                log.info("Pre-registered {} entity type IDs, Morphium will skip ClassGraph scan", typeIds.size());
+            }
+        } catch (Exception e) {
+            log.debug("Entity pre-registration skipped, Morphium will use its own ClassGraph scan: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Translates every {@link MorphiumProperties} field into the corresponding
+     * {@code MorphiumConfig} setting: database, driver name, connection pool size,
+     * read preference, index-check mode, host list (or Atlas URL if configured, which
+     * then takes precedence over the host list), replica set name, credentials, cache
+     * settings, and — if {@code morphium.ssl.enabled} is {@code true} — an SSL context
+     * built from the configured keystore.
+     *
+     * @param properties the bound {@code morphium.*} configuration
+     * @return a fully populated {@code MorphiumConfig}, not yet connected
+     * @throws IllegalStateException if {@code morphium.ssl.enabled} is {@code true}
+     *         and building the {@code SSLContext} from the configured keystore fails
+     */
+    private MorphiumConfig buildConfig(MorphiumProperties properties) {
+        MorphiumConfig cfg = new MorphiumConfig();
+
+        cfg.connectionSettings().setDatabase(properties.getDatabase());
+        cfg.driverSettings().setDriverName(properties.getDriverName());
+        cfg.connectionSettings().setMaxConnections(properties.getMaxConnections());
+        cfg.driverSettings().setDefaultReadPreferenceType(properties.getReadPreference());
+
+        // Index check mode
+        switch (properties.getIndexCheck()) {
+            case "CREATE_ON_STARTUP":
+                cfg.collectionCheckSettings().setIndexCheck(CollectionCheckSettings.IndexCheck.CREATE_ON_STARTUP);
+                break;
+            case "WARN_ON_STARTUP":
+                cfg.collectionCheckSettings().setIndexCheck(CollectionCheckSettings.IndexCheck.WARN_ON_STARTUP);
+                break;
+            case "CREATE_ON_WRITE_NEW_COL":
+                cfg.setAutoIndexAndCappedCreationOnWrite(true);
+                break;
+            case "NO_CHECK":
+                cfg.collectionCheckSettings().setIndexCheck(CollectionCheckSettings.IndexCheck.NO_CHECK);
+                break;
+        }
+
+        // Host configuration
+        if (properties.getAtlasUrl() != null && !properties.getAtlasUrl().isBlank()) {
+            cfg.clusterSettings().setAtlasUrl(properties.getAtlasUrl());
+        } else {
+            for (String host : properties.getHosts()) {
+                String trimmed = host.trim();
+                if (!trimmed.isEmpty()) {
+                    cfg.clusterSettings().addHostToSeed(trimmed);
+                }
+            }
+        }
+
+        // Replica set name
+        if (properties.getReplicaSetName() != null && !properties.getReplicaSetName().isBlank()) {
+            cfg.clusterSettings().setRequiredReplicaSetName(properties.getReplicaSetName());
+        }
+
+        // Credentials
+        if (properties.getUsername() != null && properties.getPassword() != null) {
+            cfg.authSettings().setMongoLogin(properties.getUsername());
+            cfg.authSettings().setMongoPassword(properties.getPassword());
+            cfg.authSettings().setMongoAuthDb(properties.getAuthDatabase());
+        }
+
+        // Cache
+        cfg.cacheSettings().setGlobalCacheValidTime(properties.getCache().getGlobalValidTime());
+        cfg.cacheSettings().setReadCacheEnabled(properties.getCache().isReadCacheEnabled());
+
+        // SSL
+        if (properties.getSsl().isEnabled()) {
+            cfg.setUseSSL(true);
+            String keystorePath = properties.getSsl().getKeystorePath();
+            String keystorePassword = properties.getSsl().getKeystorePassword();
+            if (keystorePath != null) {
+                try {
+                    var sslContext = de.caluga.morphium.driver.wire.SslHelper.createSslContext(
+                            keystorePath, keystorePassword, null, null);
+                    cfg.setSslContext(sslContext);
+                } catch (Exception e) {
+                    throw new IllegalStateException("Failed to build SSLContext: " + e.getMessage(), e);
+                }
+            }
+        }
+
+        return cfg;
+    }
+
+    /**
+     * Attempts to construct a connected {@link Morphium} instance from {@code cfg},
+     * retrying up to {@code maxRetries} times (at least once, regardless of the value
+     * passed) when {@link #isTransient(Throwable)} recognizes the failure as
+     * transient. Each retry waits {@code attempt * 2000} milliseconds before trying
+     * again.
+     *
+     * @param cfg the configuration to connect with
+     * @param maxRetries maximum number of connection attempts; values less than 1 are
+     *                    treated as 1
+     * @return a connected {@code Morphium} instance
+     * @throws RuntimeException the original exception from the last attempt, if every
+     *         attempt failed with a transient error, or immediately if an attempt
+     *         failed with a non-transient error
+     * @throws IllegalStateException never thrown in practice — present only to satisfy
+     *         the compiler after the retry loop, which always returns or throws
+     */
+    private Morphium connectWithRetry(MorphiumConfig cfg, int maxRetries) {
+        int maxAttempts = Math.max(1, maxRetries);
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return new Morphium(cfg);
+            } catch (Exception e) {
+                if (!isTransient(e) || attempt == maxAttempts) {
+                    throw e;
+                }
+                long delayMs = attempt * 2000L;
+                log.warn("Morphium connection attempt {}/{} failed: {}. Retrying in {}ms...",
+                        attempt, maxAttempts, e.getMessage(), delayMs);
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while retrying Morphium connection", ie);
+                }
+            }
+        }
+        throw new IllegalStateException("Unreachable");
+    }
+
+    /**
+     * Walks the exception's cause chain looking for messages that indicate a
+     * transient MongoDB connection state ("No primary node found", "not connected
+     * yet") rather than a permanent configuration or authentication error.
+     *
+     * @param t the throwable raised while connecting
+     * @return {@code true} if any exception in the cause chain matches a known
+     *         transient-failure message
+     */
+    private static boolean isTransient(Throwable t) {
+        while (t != null) {
+            String msg = t.getMessage();
+            if (msg != null && (msg.contains("No primary node found") || msg.contains("not connected yet"))) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumHealthAutoConfiguration.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumHealthAutoConfiguration.java
@@ -1,0 +1,98 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration that registers a Spring Boot Actuator {@link HealthIndicator}
+ * reporting the connection status of the application's {@link Morphium} bean under
+ * {@code /actuator/health}. It runs after {@link MorphiumAutoConfiguration}
+ * ({@code @AutoConfiguration(after = MorphiumAutoConfiguration.class)}) and applies
+ * only when all of the following hold:
+ * <ul>
+ *   <li>{@code org.springframework.boot.actuate.health.HealthIndicator} is on the
+ *       classpath ({@code @ConditionalOnClass}) — i.e. {@code spring-boot-actuator}
+ *       is present;</li>
+ *   <li>a {@link Morphium} bean already exists in the context
+ *       ({@code @ConditionalOnBean}) — there is nothing to report on otherwise.</li>
+ * </ul>
+ *
+ * <p>With both conditions met and no further configuration, {@code /actuator/health}
+ * includes:
+ *
+ * <pre>{@code
+ * {
+ *   "components": {
+ *     "morphium": {
+ *       "status": "UP",
+ *       "details": {
+ *         "database": "my-database",
+ *         "driver": "PooledDriver",
+ *         "replicaSet": true,
+ *         "replicaSetName": "rs0"
+ *       }
+ *     }
+ *   }
+ * }
+ * }</pre>
+ *
+ * <h2>Disabling or overriding the indicator</h2>
+ * The bean method is additionally guarded by
+ * {@code @ConditionalOnEnabledHealthIndicator("morphium")} — set
+ * {@code management.health.morphium.enabled=false} to turn it off entirely — and by
+ * {@code @ConditionalOnMissingBean(name = "morphiumHealthIndicator")}, so defining
+ * your own {@code @Bean(name = "morphiumHealthIndicator") HealthIndicator} in the
+ * application context takes precedence over the auto-configured one.
+ */
+@AutoConfiguration(after = MorphiumAutoConfiguration.class)
+@ConditionalOnClass(HealthIndicator.class)
+@ConditionalOnBean(Morphium.class)
+public class MorphiumHealthAutoConfiguration {
+
+    /**
+     * Builds the {@code morphium} health indicator. On each invocation it checks
+     * {@code morphium.getDriver().isConnected()} and reports {@code UP}/{@code DOWN}
+     * accordingly, attaching the configured database name, driver name, and replica
+     * set status/name as detail fields. Any exception thrown while querying the
+     * driver is caught and reported as {@code DOWN} with the exception attached.
+     *
+     * <p>Guarded by {@code @ConditionalOnEnabledHealthIndicator("morphium")} (respects
+     * {@code management.health.morphium.enabled}) and
+     * {@code @ConditionalOnMissingBean(name = "morphiumHealthIndicator")} so a
+     * user-defined bean of the same name overrides this one instead of colliding with
+     * it.
+     *
+     * @param morphium the application's {@link Morphium} bean, guaranteed present by
+     *                 {@code @ConditionalOnBean(Morphium.class)} on the class
+     * @return a {@link HealthIndicator} reporting live connection status on every
+     *         health check invocation
+     */
+    @Bean
+    @ConditionalOnEnabledHealthIndicator("morphium")
+    @ConditionalOnMissingBean(name = "morphiumHealthIndicator")
+    public HealthIndicator morphiumHealthIndicator(Morphium morphium) {
+        return () -> {
+            try {
+                var driver = morphium.getDriver();
+                boolean connected = driver.isConnected();
+                var builder = connected ? Health.up() : Health.down();
+                builder.withDetail("database", morphium.getConfig().connectionSettings().getDatabase());
+                builder.withDetail("driver", morphium.getConfig().driverSettings().getDriverName());
+                builder.withDetail("replicaSet", driver.isReplicaSet());
+                if (driver.getReplicaSetName() != null) {
+                    builder.withDetail("replicaSetName", driver.getReplicaSetName());
+                }
+                return builder.build();
+            } catch (Exception e) {
+                return Health.down(e).build();
+            }
+        };
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumProperties.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumProperties.java
@@ -1,0 +1,478 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+/**
+ * Binds every {@code morphium.*} key from {@code application.properties}/{@code .yml}
+ * to a {@link de.caluga.morphium.MorphiumConfig} that {@link MorphiumAutoConfiguration}
+ * uses to build the {@link de.caluga.morphium.Morphium} bean. Registered via
+ * {@code @EnableConfigurationProperties(MorphiumProperties.class)} on
+ * {@link MorphiumAutoConfiguration}, so it is only active together with that
+ * auto-configuration (i.e. when {@code de.caluga.morphium.Morphium} is on the
+ * classpath).
+ *
+ * <p>The property prefix is {@code morphium} (not {@code spring.morphium}) — the
+ * {@code spring.*} namespace is reserved for Spring Boot's own configuration keys.
+ * A minimal configuration only needs the database name and, unless the default
+ * applies, the host list:
+ *
+ * <pre>{@code
+ * morphium.database=my-database
+ * morphium.hosts=localhost:27017
+ * }</pre>
+ *
+ * <p>If {@code spring-boot-configuration-processor} is on the classpath (it is an
+ * optional dependency of this module), every field below also appears in
+ * {@code META-INF/spring-configuration-metadata.json}, giving IDEs autocompletion
+ * and validation for {@code morphium.*} keys.
+ */
+@ConfigurationProperties(prefix = "morphium")
+public class MorphiumProperties {
+
+    /**
+     * Comma-separated {@code host:port} list of MongoDB seed nodes, used unless
+     * {@link #atlasUrl} is set (in which case {@link #atlasUrl} takes precedence).
+     * Default: {@code localhost:27017}.
+     */
+    private List<String> hosts = List.of("localhost:27017");
+
+    /**
+     * Name of the MongoDB database Morphium connects to. Required — there is no
+     * default; {@link MorphiumAutoConfiguration} passes this straight to
+     * {@code MorphiumConfig.connectionSettings().setDatabase(...)}.
+     */
+    private String database;
+
+    /**
+     * MongoDB username. Only applied if both {@link #username} and {@link #password}
+     * are non-null; no default (unset means no authentication).
+     */
+    private String username;
+
+    /**
+     * MongoDB password, applied together with {@link #username}. No default.
+     */
+    private String password;
+
+    /**
+     * Database against which {@link #username}/{@link #password} are authenticated
+     * (MongoDB's {@code authSource}). Default: {@code admin}. Ignored unless
+     * {@link #username} and {@link #password} are both set.
+     */
+    private String authDatabase = "admin";
+
+    /**
+     * Name of the Morphium driver implementation to use, e.g. {@code PooledDriver}
+     * for production against a real MongoDB, or {@code InMemDriver} for tests that
+     * run without a MongoDB instance. Default: {@code PooledDriver}.
+     */
+    private String driverName = "PooledDriver";
+
+    /**
+     * MongoDB read preference applied to the driver (e.g. {@code primary},
+     * {@code secondary}, {@code primaryPreferred}). Default: {@code primary}.
+     */
+    private String readPreference = "primary";
+
+    /**
+     * Maximum number of pooled connections to MongoDB. Default: {@code 250}.
+     */
+    private int maxConnections = 250;
+
+    /**
+     * MongoDB Atlas SRV connection string. When set (non-null and non-blank), it
+     * overrides {@link #hosts} entirely — {@link MorphiumAutoConfiguration} configures
+     * the cluster from this URL instead of iterating {@link #hosts}. No default.
+     */
+    private String atlasUrl;
+
+    /**
+     * Name of the MongoDB replica set. Required for multi-document transactions
+     * (see {@link MorphiumTransactional}); a standalone MongoDB node does not support
+     * them. No default — if unset, Morphium connects without asserting a replica set
+     * name.
+     */
+    private String replicaSetName;
+
+    /**
+     * Number of connection attempts {@link MorphiumAutoConfiguration} makes before
+     * giving up when a transient connection error occurs (e.g. "no primary node
+     * found", "not connected yet"). Retries use a linear backoff of
+     * {@code attempt * 2000} milliseconds. Default: {@code 5}. Non-transient failures
+     * are never retried and propagate immediately.
+     */
+    private int connectRetries = 5;
+
+    /**
+     * Index management strategy applied at startup, one of {@code CREATE_ON_STARTUP}
+     * (create missing indexes eagerly), {@code WARN_ON_STARTUP} (log a warning instead
+     * of creating), {@code CREATE_ON_WRITE_NEW_COL} (defer index creation to the first
+     * write on a new collection), or {@code NO_CHECK} (skip index checking entirely).
+     * Default: {@code CREATE_ON_STARTUP}.
+     */
+    private String indexCheck = "CREATE_ON_STARTUP";
+
+    /**
+     * Query result cache settings, bound under the {@code morphium.cache.*} prefix.
+     */
+    private CacheProperties cache = new CacheProperties();
+
+    /**
+     * TLS/SSL connection settings, bound under the {@code morphium.ssl.*} prefix.
+     */
+    private SslProperties ssl = new SslProperties();
+
+    /**
+     * Returns the configured MongoDB seed host list ({@code morphium.hosts}).
+     *
+     * @return comma-separated {@code host:port} entries; defaults to a single-element
+     *         list containing {@code localhost:27017}
+     */
+    public List<String> getHosts() { return hosts; }
+
+    /**
+     * Sets the MongoDB seed host list bound from {@code morphium.hosts}. Ignored by
+     * {@link MorphiumAutoConfiguration} if {@link #atlasUrl} is also set.
+     *
+     * @param hosts {@code host:port} entries to seed the MongoDB cluster connection
+     */
+    public void setHosts(List<String> hosts) { this.hosts = hosts; }
+
+    /**
+     * Returns the configured MongoDB database name ({@code morphium.database}).
+     *
+     * @return the database name, or {@code null} if not yet configured
+     */
+    public String getDatabase() { return database; }
+
+    /**
+     * Sets the MongoDB database name bound from {@code morphium.database}. This value
+     * is required for {@link MorphiumAutoConfiguration} to build a working
+     * {@code MorphiumConfig} — Morphium connects successfully with a {@code null}
+     * database only in degenerate/test scenarios.
+     *
+     * @param database the database Morphium operates against
+     */
+    public void setDatabase(String database) { this.database = database; }
+
+    /**
+     * Returns the configured MongoDB username ({@code morphium.username}).
+     *
+     * @return the username, or {@code null} if authentication is not configured
+     */
+    public String getUsername() { return username; }
+
+    /**
+     * Sets the MongoDB username bound from {@code morphium.username}. Authentication
+     * is only applied by {@link MorphiumAutoConfiguration} once both this and
+     * {@link #password} are non-null.
+     *
+     * @param username the MongoDB username to authenticate with
+     */
+    public void setUsername(String username) { this.username = username; }
+
+    /**
+     * Returns the configured MongoDB password ({@code morphium.password}).
+     *
+     * @return the password, or {@code null} if authentication is not configured
+     */
+    public String getPassword() { return password; }
+
+    /**
+     * Sets the MongoDB password bound from {@code morphium.password}. See
+     * {@link #setUsername(String)} for when it takes effect.
+     *
+     * @param password the MongoDB password to authenticate with
+     */
+    public void setPassword(String password) { this.password = password; }
+
+    /**
+     * Returns the authentication database ({@code morphium.auth-database}).
+     *
+     * @return the database MongoDB authenticates {@link #username}/{@link #password}
+     *         against; defaults to {@code admin}
+     */
+    public String getAuthDatabase() { return authDatabase; }
+
+    /**
+     * Sets the authentication database bound from {@code morphium.auth-database}.
+     *
+     * @param authDatabase the MongoDB {@code authSource} database
+     */
+    public void setAuthDatabase(String authDatabase) { this.authDatabase = authDatabase; }
+
+    /**
+     * Returns the configured driver implementation name ({@code morphium.driver-name}).
+     *
+     * @return {@code PooledDriver}, {@code InMemDriver}, or another Morphium driver
+     *         name; defaults to {@code PooledDriver}
+     */
+    public String getDriverName() { return driverName; }
+
+    /**
+     * Sets the driver implementation name bound from {@code morphium.driver-name}.
+     * Use {@code InMemDriver} in tests to run against Morphium's in-memory MongoDB
+     * emulation without a real MongoDB instance.
+     *
+     * @param driverName the Morphium driver implementation to instantiate
+     */
+    public void setDriverName(String driverName) { this.driverName = driverName; }
+
+    /**
+     * Returns the configured read preference ({@code morphium.read-preference}).
+     *
+     * @return the MongoDB read preference; defaults to {@code primary}
+     */
+    public String getReadPreference() { return readPreference; }
+
+    /**
+     * Sets the MongoDB read preference bound from {@code morphium.read-preference}.
+     *
+     * @param readPreference one of MongoDB's read preference names, e.g.
+     *                       {@code primary}, {@code secondary}, {@code primaryPreferred}
+     */
+    public void setReadPreference(String readPreference) { this.readPreference = readPreference; }
+
+    /**
+     * Returns the configured connection pool size ({@code morphium.max-connections}).
+     *
+     * @return the maximum number of pooled MongoDB connections; defaults to {@code 250}
+     */
+    public int getMaxConnections() { return maxConnections; }
+
+    /**
+     * Sets the connection pool size bound from {@code morphium.max-connections}.
+     *
+     * @param maxConnections maximum number of pooled connections to MongoDB
+     */
+    public void setMaxConnections(int maxConnections) { this.maxConnections = maxConnections; }
+
+    /**
+     * Returns the configured MongoDB Atlas SRV URL ({@code morphium.atlas-url}).
+     *
+     * @return the Atlas connection string, or {@code null} if {@link #hosts} is used
+     *         instead
+     */
+    public String getAtlasUrl() { return atlasUrl; }
+
+    /**
+     * Sets the MongoDB Atlas SRV URL bound from {@code morphium.atlas-url}. When set
+     * to a non-blank value, {@link MorphiumAutoConfiguration} uses it instead of
+     * {@link #hosts} to configure the cluster.
+     *
+     * @param atlasUrl the Atlas {@code mongodb+srv://...} connection string
+     */
+    public void setAtlasUrl(String atlasUrl) { this.atlasUrl = atlasUrl; }
+
+    /**
+     * Returns the configured replica set name ({@code morphium.replica-set-name}).
+     *
+     * @return the required replica set name, or {@code null} if not set
+     */
+    public String getReplicaSetName() { return replicaSetName; }
+
+    /**
+     * Sets the replica set name bound from {@code morphium.replica-set-name}. Required
+     * for {@code @}{@link MorphiumTransactional} to work — MongoDB rejects
+     * multi-document transactions on a standalone (non-replica-set) node.
+     *
+     * @param replicaSetName the MongoDB replica set name to require
+     */
+    public void setReplicaSetName(String replicaSetName) { this.replicaSetName = replicaSetName; }
+
+    /**
+     * Returns the configured connection retry count ({@code morphium.connect-retries}).
+     *
+     * @return the number of connection attempts before giving up; defaults to
+     *         {@code 5}
+     */
+    public int getConnectRetries() { return connectRetries; }
+
+    /**
+     * Sets the connection retry count bound from {@code morphium.connect-retries}.
+     * {@link MorphiumAutoConfiguration} only retries transient connection failures
+     * (e.g. no primary elected yet); other exceptions propagate on the first attempt.
+     *
+     * @param connectRetries maximum number of connection attempts (at least 1 is
+     *                       always attempted regardless of this value)
+     */
+    public void setConnectRetries(int connectRetries) { this.connectRetries = connectRetries; }
+
+    /**
+     * Returns the configured index check mode ({@code morphium.index-check}).
+     *
+     * @return one of {@code CREATE_ON_STARTUP}, {@code WARN_ON_STARTUP},
+     *         {@code CREATE_ON_WRITE_NEW_COL}, {@code NO_CHECK}; defaults to
+     *         {@code CREATE_ON_STARTUP}
+     */
+    public String getIndexCheck() { return indexCheck; }
+
+    /**
+     * Sets the index check mode bound from {@code morphium.index-check}. Any value
+     * other than the four documented modes is silently ignored by
+     * {@link MorphiumAutoConfiguration} (the underlying {@code MorphiumConfig} keeps
+     * its own default in that case).
+     *
+     * @param indexCheck the index management strategy name
+     */
+    public void setIndexCheck(String indexCheck) { this.indexCheck = indexCheck; }
+
+    /**
+     * Returns the query result cache settings ({@code morphium.cache.*}).
+     *
+     * @return the nested cache configuration
+     */
+    public CacheProperties getCache() { return cache; }
+
+    /**
+     * Replaces the query result cache settings bound from {@code morphium.cache.*}.
+     *
+     * @param cache the nested cache configuration to use
+     */
+    public void setCache(CacheProperties cache) { this.cache = cache; }
+
+    /**
+     * Returns the TLS/SSL settings ({@code morphium.ssl.*}).
+     *
+     * @return the nested SSL configuration
+     */
+    public SslProperties getSsl() { return ssl; }
+
+    /**
+     * Replaces the TLS/SSL settings bound from {@code morphium.ssl.*}.
+     *
+     * @param ssl the nested SSL configuration to use
+     */
+    public void setSsl(SslProperties ssl) { this.ssl = ssl; }
+
+    /**
+     * Query result cache settings, bound under {@code morphium.cache.*} and applied
+     * by {@link MorphiumAutoConfiguration} to
+     * {@code MorphiumConfig.cacheSettings()}.
+     */
+    public static class CacheProperties {
+
+        /**
+         * Time-to-live, in milliseconds, for cached query results before Morphium
+         * considers a cache entry invalid. Default: {@code 5000} (5 seconds).
+         */
+        private int globalValidTime = 5000;
+
+        /**
+         * Whether Morphium's read cache is enabled at all. When {@code false}, every
+         * query bypasses the cache regardless of any per-query or per-entity cache
+         * annotation. Default: {@code true}.
+         */
+        private boolean readCacheEnabled = true;
+
+        /**
+         * Returns the cache TTL ({@code morphium.cache.global-valid-time}).
+         *
+         * @return the cache validity duration in milliseconds; defaults to
+         *         {@code 5000}
+         */
+        public int getGlobalValidTime() { return globalValidTime; }
+
+        /**
+         * Sets the cache TTL bound from {@code morphium.cache.global-valid-time}.
+         *
+         * @param globalValidTime cache validity duration in milliseconds
+         */
+        public void setGlobalValidTime(int globalValidTime) { this.globalValidTime = globalValidTime; }
+
+        /**
+         * Returns whether the read cache is enabled
+         * ({@code morphium.cache.read-cache-enabled}).
+         *
+         * @return {@code true} if query results may be cached; defaults to
+         *         {@code true}
+         */
+        public boolean isReadCacheEnabled() { return readCacheEnabled; }
+
+        /**
+         * Sets whether the read cache is enabled, bound from
+         * {@code morphium.cache.read-cache-enabled}.
+         *
+         * @param readCacheEnabled {@code false} to disable query result caching
+         *                        entirely
+         */
+        public void setReadCacheEnabled(boolean readCacheEnabled) { this.readCacheEnabled = readCacheEnabled; }
+    }
+
+    /**
+     * TLS/SSL connection settings, bound under {@code morphium.ssl.*} and applied by
+     * {@link MorphiumAutoConfiguration} when {@link #enabled} is {@code true}. Only
+     * keystore-based client configuration is exposed here; truststore configuration
+     * is not covered by this module.
+     */
+    public static class SslProperties {
+
+        /**
+         * Whether Morphium connects to MongoDB over TLS. Default: {@code false}. When
+         * {@code true}, {@link MorphiumAutoConfiguration} builds an {@code SSLContext}
+         * (using {@link #keystorePath}/{@link #keystorePassword} if set) and enables
+         * it on the driver.
+         */
+        private boolean enabled = false;
+
+        /**
+         * Filesystem path to a keystore (JKS or PKCS12) holding the client
+         * certificate/private key for TLS. No default. Only read when {@link #enabled}
+         * is {@code true}; if {@code null} while {@link #enabled} is {@code true},
+         * TLS is enabled without a client keystore.
+         */
+        private String keystorePath;
+
+        /**
+         * Password protecting {@link #keystorePath}. No default.
+         */
+        private String keystorePassword;
+
+        /**
+         * Returns whether TLS is enabled ({@code morphium.ssl.enabled}).
+         *
+         * @return {@code true} if Morphium connects over TLS; defaults to
+         *         {@code false}
+         */
+        public boolean isEnabled() { return enabled; }
+
+        /**
+         * Sets whether TLS is enabled, bound from {@code morphium.ssl.enabled}.
+         *
+         * @param enabled {@code true} to connect to MongoDB over TLS
+         */
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+        /**
+         * Returns the configured keystore path ({@code morphium.ssl.keystore-path}).
+         *
+         * @return the keystore file path, or {@code null} if not configured
+         */
+        public String getKeystorePath() { return keystorePath; }
+
+        /**
+         * Sets the keystore path bound from {@code morphium.ssl.keystore-path}.
+         *
+         * @param keystorePath filesystem path to a JKS or PKCS12 keystore
+         */
+        public void setKeystorePath(String keystorePath) { this.keystorePath = keystorePath; }
+
+        /**
+         * Returns the configured keystore password
+         * ({@code morphium.ssl.keystore-password}).
+         *
+         * @return the password protecting the keystore, or {@code null} if not
+         *         configured
+         */
+        public String getKeystorePassword() { return keystorePassword; }
+
+        /**
+         * Sets the keystore password bound from {@code morphium.ssl.keystore-password}.
+         *
+         * @param keystorePassword password protecting {@link #keystorePath}
+         */
+        public void setKeystorePassword(String keystorePassword) { this.keystorePassword = keystorePassword; }
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryFactoryBean.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryFactoryBean.java
@@ -1,0 +1,178 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.data.RepositoryMetadata;
+import jakarta.data.repository.CrudRepository;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+
+/**
+ * Spring {@link FactoryBean} that creates a {@link Proxy JDK dynamic proxy}
+ * implementing a Morphium Jakarta Data repository interface. {@link
+ * MorphiumRepositoryRegistrar} registers exactly one bean definition of this type per
+ * {@code @Repository} interface discovered under {@link EnableMorphiumRepositories} —
+ * application code never instantiates this class directly.
+ *
+ * <p>At bean-creation time (see {@link #getObject()}), it resolves the repository
+ * interface's entity and ID type arguments, finds the entity's {@code @Id} field,
+ * builds a {@code RepositoryMetadata}, and creates a proxy backed by a
+ * {@link MorphiumRepositoryInvocationHandler}. This is the mechanism-level detail
+ * behind {@link EnableMorphiumRepositories}'s "JDK dynamic proxy at runtime" — no
+ * class is generated or compiled; {@code java.lang.reflect.Proxy} synthesizes the
+ * implementing class in the running JVM, once per repository interface, the first
+ * time the bean is requested (the bean is a singleton, so this happens at most once
+ * per application context).
+ *
+ * @param <T> the repository interface type this factory bean produces
+ */
+public class MorphiumRepositoryFactoryBean<T> implements FactoryBean<T> {
+
+    private final Class<T> repositoryInterface;
+
+    @Autowired
+    private Morphium morphium;
+
+    /**
+     * Creates a factory bean for the given repository interface. Called only by
+     * {@link MorphiumRepositoryRegistrar} while building the bean definition; the
+     * {@link Morphium} dependency is injected afterwards by Spring
+     * ({@code @Autowired}), not passed here.
+     *
+     * @param repositoryInterface the {@code @Repository} interface this factory bean
+     *                            will produce a proxy implementation for
+     */
+    public MorphiumRepositoryFactoryBean(Class<T> repositoryInterface) {
+        this.repositoryInterface = repositoryInterface;
+    }
+
+    /**
+     * Creates the JDK dynamic proxy implementing {@code repositoryInterface}. Resolves
+     * the entity and ID type arguments from the interface's {@code CrudRepository<T,
+     * K>} supertype (see {@link #resolveTypeArguments(Class)}), locates the entity's
+     * {@code @Id} field name (see {@link #findIdFieldName(Class)}), and wires both
+     * into a new {@link MorphiumRepositoryInvocationHandler} that dispatches every
+     * proxied method call to the shared {@code morphium-jakarta-data} runtime.
+     *
+     * @return a new proxy instance implementing the repository interface; a fresh
+     *         instance is returned on every call, but {@link #isSingleton()} tells
+     *         Spring to only call this once and cache the result
+     * @throws IllegalArgumentException if the entity/ID type arguments cannot be
+     *         resolved from the repository interface hierarchy, or if the entity class
+     *         has no {@code @Id}-annotated field and no fallback {@code id}/{@code
+     *         morphiumId} field either
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public T getObject() {
+        var typeArgs = resolveTypeArguments(repositoryInterface);
+        Class<?> entityClass = typeArgs[0];
+        Class<?> idClass = typeArgs[1];
+        String idFieldName = findIdFieldName(entityClass);
+
+        var metadata = new RepositoryMetadata(entityClass, idClass, idFieldName);
+        var handler = new MorphiumRepositoryInvocationHandler(morphium, metadata, repositoryInterface);
+
+        return (T) Proxy.newProxyInstance(
+                repositoryInterface.getClassLoader(),
+                new Class<?>[]{ repositoryInterface },
+                handler);
+    }
+
+    /**
+     * Reports the repository interface itself as this factory bean's product type,
+     * so Spring's type-based autowiring (e.g. {@code @Autowired ProductRepository})
+     * resolves to the proxy this factory bean produces.
+     *
+     * @return the {@code @Repository} interface class passed to the constructor
+     */
+    @Override
+    public Class<?> getObjectType() {
+        return repositoryInterface;
+    }
+
+    /**
+     * Declares that {@link #getObject()} is called at most once and its result cached
+     * by Spring — the same proxy instance is returned to every injection point.
+     *
+     * @return always {@code true}
+     */
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    /**
+     * Walks the interface hierarchy to find CrudRepository&lt;T, K&gt; type arguments.
+     *
+     * @param repoInterface the repository interface (or a super-interface reached
+     *                     through recursion) to inspect
+     * @return a two-element array {@code { entityClass, idClass }} resolved from the
+     *         first {@code CrudRepository<T, K>}-parameterized supertype found
+     * @throws IllegalArgumentException if no generic {@code CrudRepository<T, K>}
+     *         supertype with resolvable type arguments exists anywhere in the
+     *         interface hierarchy
+     */
+    static Class<?>[] resolveTypeArguments(Class<?> repoInterface) {
+        for (Type iface : repoInterface.getGenericInterfaces()) {
+            if (iface instanceof ParameterizedType pt) {
+                Type raw = pt.getRawType();
+                if (raw instanceof Class<?> rawClass && CrudRepository.class.isAssignableFrom(rawClass)) {
+                    Type[] args = pt.getActualTypeArguments();
+                    if (args.length >= 2 && args[0] instanceof Class<?> entity && args[1] instanceof Class<?> id) {
+                        return new Class<?>[]{ entity, id };
+                    }
+                }
+            }
+        }
+        // Recurse into super-interfaces
+        for (Class<?> superIface : repoInterface.getInterfaces()) {
+            try {
+                return resolveTypeArguments(superIface);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        throw new IllegalArgumentException(
+                "Cannot resolve entity/id types from " + repoInterface.getName());
+    }
+
+    /**
+     * Finds the field annotated with {@code @Id} in the entity class hierarchy.
+     *
+     * @param entityClass the entity class to search, including its superclasses
+     * @return the name of the {@code @Id}-annotated field, or — if none is found — the
+     *         name of a field literally called {@code id} or {@code morphiumId} as a
+     *         fallback
+     * @throws IllegalArgumentException if neither an {@code @Id}-annotated field nor a
+     *         fallback {@code id}/{@code morphiumId} field exists on {@code entityClass}
+     */
+    private static String findIdFieldName(Class<?> entityClass) {
+        Class<?> cls = entityClass;
+        while (cls != null && cls != Object.class) {
+            for (Field f : cls.getDeclaredFields()) {
+                if (f.isAnnotationPresent(Id.class)) {
+                    return f.getName();
+                }
+            }
+            cls = cls.getSuperclass();
+        }
+        // Fallback: look for a field named "id" or "morphiumId"
+        try {
+            entityClass.getDeclaredField("id");
+            return "id";
+        } catch (NoSuchFieldException ignored) {
+        }
+        try {
+            entityClass.getDeclaredField("morphiumId");
+            return "morphiumId";
+        } catch (NoSuchFieldException ignored) {
+        }
+        throw new IllegalArgumentException(
+                "No @Id field found in " + entityClass.getName());
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryInvocationHandler.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryInvocationHandler.java
@@ -1,0 +1,308 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.data.*;
+import jakarta.data.Order;
+import jakarta.data.Sort;
+import jakarta.data.Limit;
+import jakarta.data.page.CursoredPage;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Param;
+import jakarta.data.repository.Query;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * JDK dynamic proxy handler for Morphium repository interfaces.
+ * Dispatches method calls to CRUD operations on {@link AbstractMorphiumRepository}
+ * or to the query bridges ({@link QueryMethodBridge}, {@link JdqlMethodBridge},
+ * {@link FindMethodBridge}) from the shared morphium-jakarta-data module.
+ */
+class MorphiumRepositoryInvocationHandler implements InvocationHandler {
+
+    private final SpringMorphiumRepository delegate;
+    private final Class<?> repositoryInterface;
+    private final ConcurrentHashMap<Method, MethodHandler> handlers = new ConcurrentHashMap<>();
+
+    MorphiumRepositoryInvocationHandler(Morphium morphium, RepositoryMetadata metadata,
+                                         Class<?> repositoryInterface) {
+        this.repositoryInterface = repositoryInterface;
+        this.delegate = new SpringMorphiumRepository(metadata);
+        this.delegate.setMorphium(morphium);
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        // Object methods
+        if (method.getDeclaringClass() == Object.class) {
+            return switch (method.getName()) {
+                case "toString" -> repositoryInterface.getSimpleName() + "@MorphiumProxy";
+                case "hashCode" -> System.identityHashCode(proxy);
+                case "equals" -> proxy == args[0];
+                default -> method.invoke(this, args);
+            };
+        }
+
+        return handlers.computeIfAbsent(method, this::analyzeMethod).handle(args);
+    }
+
+    private MethodHandler analyzeMethod(Method method) {
+        String name = method.getName();
+        Class<?> returnType = method.getReturnType();
+
+        // --- CrudRepository standard methods ---
+        if (name.equals("findById") && method.getParameterCount() == 1) {
+            return args -> delegate.doFindById(args[0]);
+        }
+        if (name.equals("findAll") && method.getParameterCount() == 0) {
+            return args -> delegate.doFindAll();
+        }
+        if (name.equals("findAll") && method.getParameterCount() == 2) {
+            return args -> delegate.doFindAllPaged((PageRequest) args[0], (Order) args[1]);
+        }
+        if (name.equals("save") && method.getParameterCount() == 1) {
+            return args -> delegate.doSave(args[0]);
+        }
+        if (name.equals("saveAll") && method.getParameterCount() == 1) {
+            return args -> delegate.doSaveAll((List<?>) args[0]);
+        }
+        if (name.equals("insert") && method.getParameterCount() == 1) {
+            return args -> delegate.doInsert(args[0]);
+        }
+        if (name.equals("insertAll") && method.getParameterCount() == 1) {
+            return args -> delegate.doInsertAll((List<?>) args[0]);
+        }
+        if (name.equals("update") && method.getParameterCount() == 1) {
+            return args -> delegate.doUpdate(args[0]);
+        }
+        if (name.equals("updateAll") && method.getParameterCount() == 1) {
+            return args -> delegate.doUpdateAll((List<?>) args[0]);
+        }
+        if (name.equals("delete") && method.getParameterCount() == 1) {
+            return args -> { delegate.doDelete(args[0]); return null; };
+        }
+        if (name.equals("deleteById") && method.getParameterCount() == 1) {
+            return args -> { delegate.doDeleteById(args[0]); return null; };
+        }
+        if (name.equals("deleteAll") && method.getParameterCount() == 1) {
+            return args -> { delegate.doDeleteAll((List<?>) args[0]); return null; };
+        }
+        if (name.equals("deleteAll") && method.getParameterCount() == 0) {
+            return args -> { delegate.doDeleteAllNoArg(); return null; };
+        }
+
+        // --- MorphiumRepository extensions ---
+        if (name.equals("distinct") && method.getParameterCount() == 1) {
+            return args -> delegate.doDistinct((String) args[0]);
+        }
+        if (name.equals("morphium") && method.getParameterCount() == 0) {
+            return args -> delegate.doMorphium();
+        }
+        if (name.equals("query") && method.getParameterCount() == 0) {
+            return args -> delegate.doQuery();
+        }
+
+        // --- @Query (JDQL) ---
+        Query queryAnno = method.getAnnotation(Query.class);
+        if (queryAnno != null) {
+            return buildJdqlHandler(method, queryAnno);
+        }
+
+        // --- @Find ---
+        Find findAnno = method.getAnnotation(Find.class);
+        if (findAnno != null) {
+            return buildFindHandler(method);
+        }
+
+        // --- @Delete ---
+        Delete deleteAnno = method.getAnnotation(Delete.class);
+        if (deleteAnno != null) {
+            return buildDeleteHandler(method);
+        }
+
+        // --- Derived query (findBy*, countBy*, existsBy*, deleteBy*) ---
+        if (name.startsWith("findBy") || name.startsWith("countBy")
+                || name.startsWith("existsBy") || name.startsWith("deleteBy")) {
+            return buildDerivedQueryHandler(method);
+        }
+
+        throw new UnsupportedOperationException(
+                "Unsupported repository method: " + repositoryInterface.getSimpleName() + "." + name);
+    }
+
+    private MethodHandler buildDerivedQueryHandler(Method method) {
+        boolean returnsSingle = !List.class.isAssignableFrom(method.getReturnType())
+                && !Stream.class.isAssignableFrom(method.getReturnType())
+                && !Page.class.isAssignableFrom(method.getReturnType())
+                && !Iterable.class.isAssignableFrom(method.getReturnType())
+                && !method.getReturnType().equals(long.class)
+                && !method.getReturnType().equals(Long.class)
+                && !method.getReturnType().equals(boolean.class)
+                && !method.getReturnType().equals(Boolean.class)
+                && !Optional.class.isAssignableFrom(method.getReturnType())
+                && !CompletionStage.class.isAssignableFrom(method.getReturnType());
+        boolean returnsOptional = Optional.class.isAssignableFrom(method.getReturnType());
+        boolean returnsBoolean = method.getReturnType() == boolean.class
+                || method.getReturnType() == Boolean.class;
+        boolean returnsStream = Stream.class.isAssignableFrom(method.getReturnType());
+
+        String orderBySpec = getOrderBySpec(method);
+
+        return args -> QueryMethodBridge.executeQuery(
+                delegate, method.getName(), args != null ? args : new Object[0],
+                returnsSingle, returnsOptional, returnsBoolean, returnsStream, orderBySpec);
+    }
+
+    private MethodHandler buildJdqlHandler(Method method, Query queryAnno) {
+        String jdql = queryAnno.value();
+        String paramMapSpec = buildParamMapSpec(method);
+        int sortIdx = findParamIndex(method, Sort.class);
+        int orderIdx = findParamIndex(method, Order.class);
+        int pageRequestIdx = findParamIndex(method, PageRequest.class);
+        int limitIdx = findParamIndex(method, Limit.class);
+
+        boolean returnsSingle = isSingleReturn(method);
+        boolean returnsCount = method.getReturnType() == long.class || method.getReturnType() == Long.class;
+        boolean returnsBoolean = method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class;
+        boolean returnsOptional = Optional.class.isAssignableFrom(method.getReturnType());
+        boolean returnsCursoredPage = CursoredPage.class.isAssignableFrom(method.getReturnType());
+        boolean returnsStream = Stream.class.isAssignableFrom(method.getReturnType());
+        String orderBySpec = getOrderBySpec(method);
+
+        return args -> JdqlMethodBridge.executeJdql(
+                delegate, jdql, paramMapSpec,
+                sortIdx, orderIdx, pageRequestIdx, limitIdx,
+                args != null ? args : new Object[0],
+                returnsSingle, returnsCount, returnsBoolean, returnsOptional,
+                returnsCursoredPage, orderBySpec, returnsStream, null);
+    }
+
+    private MethodHandler buildFindHandler(Method method) {
+        String conditionsSpec = buildConditionsSpec(method);
+        String orderBySpec = getOrderBySpec(method);
+        int sortIdx = findParamIndex(method, Sort.class);
+        int orderIdx = findParamIndex(method, Order.class);
+        int pageRequestIdx = findParamIndex(method, PageRequest.class);
+        int limitIdx = findParamIndex(method, Limit.class);
+
+        boolean returnsSingle = isSingleReturn(method);
+        boolean returnsOptional = Optional.class.isAssignableFrom(method.getReturnType());
+        boolean returnsCursoredPage = CursoredPage.class.isAssignableFrom(method.getReturnType());
+        boolean returnsStream = Stream.class.isAssignableFrom(method.getReturnType());
+
+        return args -> FindMethodBridge.executeFind(
+                delegate, conditionsSpec, orderBySpec,
+                sortIdx, orderIdx, pageRequestIdx, limitIdx,
+                args != null ? args : new Object[0],
+                returnsSingle, returnsOptional, returnsCursoredPage, returnsStream);
+    }
+
+    private MethodHandler buildDeleteHandler(Method method) {
+        String conditionsSpec = buildConditionsSpec(method);
+        return args -> {
+            FindMethodBridge.executeAnnotatedDelete(
+                    delegate, conditionsSpec, args != null ? args : new Object[0]);
+            return null;
+        };
+    }
+
+    // --- Helpers ---
+
+    private String buildParamMapSpec(Method method) {
+        StringBuilder sb = new StringBuilder();
+        Parameter[] params = method.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            Param paramAnno = params[i].getAnnotation(Param.class);
+            if (paramAnno != null) {
+                if (sb.length() > 0) sb.append(",");
+                sb.append(paramAnno.value()).append(":").append(i);
+            } else if (!isSpecialParam(params[i].getType())) {
+                // Use parameter name (requires -parameters compiler flag)
+                if (sb.length() > 0) sb.append(",");
+                sb.append(params[i].getName()).append(":").append(i);
+            }
+        }
+        return sb.toString();
+    }
+
+    private String buildConditionsSpec(Method method) {
+        StringBuilder sb = new StringBuilder();
+        Parameter[] params = method.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            if (isSpecialParam(params[i].getType())) continue;
+            Param paramAnno = params[i].getAnnotation(Param.class);
+            String fieldName = paramAnno != null ? paramAnno.value() : params[i].getName();
+            if (sb.length() > 0) sb.append(",");
+            sb.append(fieldName).append(":").append(i);
+        }
+        return sb.toString();
+    }
+
+    private static boolean isSpecialParam(Class<?> type) {
+        return Sort.class.isAssignableFrom(type)
+                || Order.class.isAssignableFrom(type)
+                || PageRequest.class.isAssignableFrom(type)
+                || Limit.class.isAssignableFrom(type);
+    }
+
+    private static int findParamIndex(Method method, Class<?> paramType) {
+        Parameter[] params = method.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            if (paramType.isAssignableFrom(params[i].getType())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private boolean isSingleReturn(Method method) {
+        Class<?> rt = method.getReturnType();
+        return !List.class.isAssignableFrom(rt)
+                && !Stream.class.isAssignableFrom(rt)
+                && !Page.class.isAssignableFrom(rt)
+                && !CursoredPage.class.isAssignableFrom(rt)
+                && !Iterable.class.isAssignableFrom(rt)
+                && !Optional.class.isAssignableFrom(rt)
+                && rt != long.class && rt != Long.class
+                && rt != boolean.class && rt != Boolean.class
+                && rt != void.class && rt != Void.class;
+    }
+
+    private static String getOrderBySpec(Method method) {
+        OrderBy orderBy = method.getAnnotation(OrderBy.class);
+        if (orderBy == null) return "";
+        return orderBy.value();
+    }
+
+    @FunctionalInterface
+    private interface MethodHandler {
+        Object handle(Object[] args) throws Exception;
+    }
+
+    /**
+     * Concrete (non-abstract) subclass of AbstractMorphiumRepository for Spring proxy use.
+     * The setMorphium() method is package-visible through the parent.
+     */
+    private static class SpringMorphiumRepository extends AbstractMorphiumRepository<Object, Object> {
+        SpringMorphiumRepository(RepositoryMetadata metadata) {
+            super(metadata);
+        }
+
+        @Override
+        public void setMorphium(Morphium morphium) {
+            super.setMorphium(morphium);
+        }
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryInvocationHandler.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryInvocationHandler.java
@@ -56,6 +56,17 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
             };
         }
 
+        // A default method carries its own implementation, so it must run as written instead
+        // of being analysed as a query. Handled here rather than in analyzeMethod() because
+        // InvocationHandler.invokeDefault needs the proxy instance, which the MethodHandler
+        // functional interface (args only) cannot carry - and handled BEFORE the derived-query
+        // check further down, since a default method is free to be named findBy*/countBy*.
+        // Without this, any default method ended in the "Unsupported repository method"
+        // UnsupportedOperationException at the bottom of analyzeMethod().
+        if (method.isDefault()) {
+            return InvocationHandler.invokeDefault(proxy, method, args);
+        }
+
         return handlers.computeIfAbsent(method, this::analyzeMethod).handle(args);
     }
 
@@ -162,6 +173,18 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
 
         String orderBySpec = getOrderBySpec(method);
 
+        // Regression fix: this handler never looked up dynamic Sort/Order/PageRequest/Limit
+        // parameters and always dispatched to the simple executeQuery overload -- a Page<T>
+        // method got a plain List back (ClassCastException at the proxy boundary) and a
+        // Sort<T> argument was silently dropped (wrong order, no error). Determine the four
+        // indices the same way buildJdqlHandler/buildFindHandler already do and always call
+        // the overload that takes them; it short-circuits back to the simple overload itself
+        // when all four indices are -1, so this is safe for the common case too.
+        int sortIdx = findParamIndex(method, Sort.class);
+        int orderIdx = findParamIndex(method, Order.class);
+        int pageRequestIdx = findParamIndex(method, PageRequest.class);
+        int limitIdx = findParamIndex(method, Limit.class);
+
         // Strip the "Async" suffix for parsing (e.g. "findByStatusAsync" -> "findByStatus"),
         // matching quarkus-morphium's MorphiumDataProcessor convention for derived-query
         // methods with a CompletionStage return type.
@@ -172,11 +195,13 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
         if (returnsAsync) {
             return args -> QueryMethodBridge.executeQueryAsync(
                     delegate, parseableName, args != null ? args : new Object[0],
-                    returnsSingle, returnsOptional, returnsBoolean, returnsStream, orderBySpec);
+                    returnsSingle, returnsOptional, returnsBoolean, returnsStream, orderBySpec,
+                    sortIdx, orderIdx, pageRequestIdx, limitIdx);
         }
         return args -> QueryMethodBridge.executeQuery(
                 delegate, parseableName, args != null ? args : new Object[0],
-                returnsSingle, returnsOptional, returnsBoolean, returnsStream, orderBySpec);
+                returnsSingle, returnsOptional, returnsBoolean, returnsStream, orderBySpec,
+                sortIdx, orderIdx, pageRequestIdx, limitIdx);
     }
 
     private MethodHandler buildJdqlHandler(Method method, Query queryAnno) {
@@ -187,6 +212,7 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
         int pageRequestIdx = findParamIndex(method, PageRequest.class);
         int limitIdx = findParamIndex(method, Limit.class);
 
+        boolean returnsAsync = CompletionStage.class.isAssignableFrom(method.getReturnType());
         boolean returnsSingle = isSingleReturn(method);
         boolean returnsCount = method.getReturnType() == long.class || method.getReturnType() == Long.class;
         boolean returnsBoolean = method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class;
@@ -194,6 +220,23 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
         boolean returnsCursoredPage = CursoredPage.class.isAssignableFrom(method.getReturnType());
         boolean returnsStream = Stream.class.isAssignableFrom(method.getReturnType());
         String orderBySpec = getOrderBySpec(method);
+
+        // Regression fix: neither this method nor isSingleReturn(Method) excluded
+        // CompletionStage, so a `CompletionStage<List<T>>` method was analyzed as a
+        // single-entity query, ran synchronously on the caller's thread, and handed the
+        // entity itself to the proxy where a CompletionStage was expected --
+        // ClassCastException. Dispatch to the async bridge with the same parameters as
+        // the sync call, matching quarkus-morphium's convention (used already by
+        // buildDerivedQueryHandler) that a CompletionStage-returning query method
+        // resolves to a plain (non-single, non-Optional) result.
+        if (returnsAsync) {
+            return args -> JdqlMethodBridge.executeJdqlAsync(
+                    delegate, jdql, paramMapSpec,
+                    sortIdx, orderIdx, pageRequestIdx, limitIdx,
+                    args != null ? args : new Object[0],
+                    returnsSingle, returnsCount, returnsBoolean, returnsOptional,
+                    returnsCursoredPage, orderBySpec, returnsStream, null);
+        }
 
         return args -> JdqlMethodBridge.executeJdql(
                 delegate, jdql, paramMapSpec,
@@ -211,10 +254,23 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
         int pageRequestIdx = findParamIndex(method, PageRequest.class);
         int limitIdx = findParamIndex(method, Limit.class);
 
+        boolean returnsAsync = CompletionStage.class.isAssignableFrom(method.getReturnType());
         boolean returnsSingle = isSingleReturn(method);
         boolean returnsOptional = Optional.class.isAssignableFrom(method.getReturnType());
         boolean returnsCursoredPage = CursoredPage.class.isAssignableFrom(method.getReturnType());
         boolean returnsStream = Stream.class.isAssignableFrom(method.getReturnType());
+
+        // Regression fix: same CompletionStage gap as buildJdqlHandler above -- a
+        // `CompletionStage<List<T>>` @Find method ran synchronously and returned the
+        // entity/list directly instead of a CompletionStage, causing a
+        // ClassCastException at the proxy boundary.
+        if (returnsAsync) {
+            return args -> FindMethodBridge.executeFindAsync(
+                    delegate, conditionsSpec, orderBySpec,
+                    sortIdx, orderIdx, pageRequestIdx, limitIdx,
+                    args != null ? args : new Object[0],
+                    returnsSingle, returnsOptional, returnsCursoredPage, returnsStream);
+        }
 
         return args -> FindMethodBridge.executeFind(
                 delegate, conditionsSpec, orderBySpec,
@@ -225,6 +281,21 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
 
     private MethodHandler buildDeleteHandler(Method method) {
         String conditionsSpec = buildConditionsSpec(method);
+        Class<?> returnType = method.getReturnType();
+
+        // Regression fix: Jakarta Data 1.0 permits void, int, and long return types for
+        // @Delete methods -- the numeric variants must return the number of deleted
+        // entities. This used to always call the void bridge and return null, which blew
+        // up as a NullPointerException when the proxy tried to unbox null into a
+        // primitive long/int return value.
+        if (returnType == long.class || returnType == Long.class) {
+            return args -> FindMethodBridge.executeAnnotatedDeleteCounted(
+                    delegate, conditionsSpec, args != null ? args : new Object[0]);
+        }
+        if (returnType == int.class || returnType == Integer.class) {
+            return args -> (int) FindMethodBridge.executeAnnotatedDeleteCounted(
+                    delegate, conditionsSpec, args != null ? args : new Object[0]);
+        }
         return args -> {
             FindMethodBridge.executeAnnotatedDelete(
                     delegate, conditionsSpec, args != null ? args : new Object[0]);
@@ -289,6 +360,7 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
                 && !CursoredPage.class.isAssignableFrom(rt)
                 && !Iterable.class.isAssignableFrom(rt)
                 && !Optional.class.isAssignableFrom(rt)
+                && !CompletionStage.class.isAssignableFrom(rt)
                 && rt != long.class && rt != Long.class
                 && rt != boolean.class && rt != Boolean.class
                 && rt != void.class && rt != Void.class;

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryInvocationHandler.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryInvocationHandler.java
@@ -8,6 +8,7 @@ import jakarta.data.Limit;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
@@ -143,6 +144,7 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
     }
 
     private MethodHandler buildDerivedQueryHandler(Method method) {
+        boolean returnsAsync = CompletionStage.class.isAssignableFrom(method.getReturnType());
         boolean returnsSingle = !List.class.isAssignableFrom(method.getReturnType())
                 && !Stream.class.isAssignableFrom(method.getReturnType())
                 && !Page.class.isAssignableFrom(method.getReturnType())
@@ -152,7 +154,7 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
                 && !method.getReturnType().equals(boolean.class)
                 && !method.getReturnType().equals(Boolean.class)
                 && !Optional.class.isAssignableFrom(method.getReturnType())
-                && !CompletionStage.class.isAssignableFrom(method.getReturnType());
+                && !returnsAsync;
         boolean returnsOptional = Optional.class.isAssignableFrom(method.getReturnType());
         boolean returnsBoolean = method.getReturnType() == boolean.class
                 || method.getReturnType() == Boolean.class;
@@ -160,8 +162,20 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
 
         String orderBySpec = getOrderBySpec(method);
 
+        // Strip the "Async" suffix for parsing (e.g. "findByStatusAsync" -> "findByStatus"),
+        // matching quarkus-morphium's MorphiumDataProcessor convention for derived-query
+        // methods with a CompletionStage return type.
+        String methodName = method.getName();
+        String parseableName = returnsAsync && methodName.endsWith("Async")
+                ? methodName.substring(0, methodName.length() - 5) : methodName;
+
+        if (returnsAsync) {
+            return args -> QueryMethodBridge.executeQueryAsync(
+                    delegate, parseableName, args != null ? args : new Object[0],
+                    returnsSingle, returnsOptional, returnsBoolean, returnsStream, orderBySpec);
+        }
         return args -> QueryMethodBridge.executeQuery(
-                delegate, method.getName(), args != null ? args : new Object[0],
+                delegate, parseableName, args != null ? args : new Object[0],
                 returnsSingle, returnsOptional, returnsBoolean, returnsStream, orderBySpec);
     }
 
@@ -242,8 +256,8 @@ class MorphiumRepositoryInvocationHandler implements InvocationHandler {
         Parameter[] params = method.getParameters();
         for (int i = 0; i < params.length; i++) {
             if (isSpecialParam(params[i].getType())) continue;
-            Param paramAnno = params[i].getAnnotation(Param.class);
-            String fieldName = paramAnno != null ? paramAnno.value() : params[i].getName();
+            By byAnno = params[i].getAnnotation(By.class);
+            String fieldName = byAnno != null ? byAnno.value() : params[i].getName();
             if (sb.length() > 0) sb.append(",");
             sb.append(fieldName).append(":").append(i);
         }

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryRegistrar.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryRegistrar.java
@@ -1,0 +1,129 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.data.MorphiumRepository;
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * {@link ImportBeanDefinitionRegistrar} that performs the actual classpath scan
+ * behind {@link EnableMorphiumRepositories}: it looks for interfaces annotated with
+ * {@code jakarta.data.repository.Repository} that extend {@link CrudRepository} or
+ * {@link MorphiumRepository}, and registers one {@link MorphiumRepositoryFactoryBean}
+ * bean definition per interface found. Never referenced directly by application
+ * code — Spring instantiates and invokes it automatically because
+ * {@code @EnableMorphiumRepositories} carries {@code @Import(MorphiumRepositoryRegistrar.class)}.
+ *
+ * <p>This is where this module's proxy mechanism differs architecturally from the
+ * {@code quarkus-morphium} extension: this class runs at Spring context-startup time,
+ * in the running JVM, and only ever registers a {@link MorphiumRepositoryFactoryBean}
+ * — a {@code FactoryBean} that later produces a
+ * {@link java.lang.reflect.Proxy JDK dynamic proxy}. No bytecode is generated or
+ * written to disk. Quarkus's equivalent mechanism runs as a build-time processor and
+ * emits a real, compiled implementation class via Gizmo before the application ever
+ * starts. See {@link EnableMorphiumRepositories} for the full comparison.
+ */
+public class MorphiumRepositoryRegistrar implements ImportBeanDefinitionRegistrar {
+
+    private static final Logger log = LoggerFactory.getLogger(MorphiumRepositoryRegistrar.class);
+
+    /**
+     * Scans the base packages derived from {@code @EnableMorphiumRepositories} (see
+     * {@link #getBasePackages(AnnotationMetadata)}) for interfaces annotated with
+     * {@code @Repository} that also extend {@link CrudRepository} or
+     * {@link MorphiumRepository}, and registers a {@link MorphiumRepositoryFactoryBean}
+     * bean definition — constructed with the repository interface as its sole
+     * constructor argument and wired by type — for each match. The registered bean
+     * name is the uncapitalized simple interface name (e.g. {@code ProductRepository}
+     * becomes {@code productRepository}). Candidates that fail to load are logged as
+     * a warning and skipped; interfaces that are annotated {@code @Repository} but do
+     * not extend either supported base interface are silently skipped.
+     *
+     * @param importingClassMetadata metadata of the class carrying
+     *                               {@code @EnableMorphiumRepositories}, used to read
+     *                               its {@code value()}/{@code basePackages()}
+     *                               attributes
+     * @param registry the bean definition registry to register discovered repository
+     *                 factory beans into
+     */
+    @Override
+    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
+                                        BeanDefinitionRegistry registry) {
+        Set<String> basePackages = getBasePackages(importingClassMetadata);
+        if (basePackages.isEmpty()) {
+            return;
+        }
+
+        var scanner = new ClassPathScanningCandidateComponentProvider(false) {
+            @Override
+            protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+                // Allow interfaces (default implementation rejects them)
+                return beanDefinition.getMetadata().isInterface()
+                        && beanDefinition.getMetadata().isIndependent();
+            }
+        };
+        scanner.addIncludeFilter(new AnnotationTypeFilter(Repository.class));
+
+        for (String basePackage : basePackages) {
+            for (var candidate : scanner.findCandidateComponents(basePackage)) {
+                String className = candidate.getBeanClassName();
+                if (className == null) continue;
+
+                try {
+                    Class<?> iface = ClassUtils.forName(className, getClass().getClassLoader());
+                    if (!iface.isInterface()) continue;
+                    if (!CrudRepository.class.isAssignableFrom(iface)
+                            && !MorphiumRepository.class.isAssignableFrom(iface)) {
+                        continue;
+                    }
+
+                    String beanName = StringUtils.uncapitalize(iface.getSimpleName());
+
+                    var bd = BeanDefinitionBuilder.genericBeanDefinition(MorphiumRepositoryFactoryBean.class)
+                            .addConstructorArgValue(iface)
+                            .setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE)
+                            .getBeanDefinition();
+
+                    registry.registerBeanDefinition(beanName, bd);
+                    log.debug("Registered Morphium repository bean '{}' for {}", beanName, className);
+                } catch (ClassNotFoundException e) {
+                    log.warn("Could not load repository candidate class: {}", className);
+                }
+            }
+        }
+    }
+
+    private Set<String> getBasePackages(AnnotationMetadata metadata) {
+        Set<String> packages = new HashSet<>();
+
+        var attrs = AnnotationAttributes.fromMap(
+                metadata.getAnnotationAttributes(EnableMorphiumRepositories.class.getName()));
+
+        if (attrs != null) {
+            packages.addAll(Arrays.asList(attrs.getStringArray("value")));
+            packages.addAll(Arrays.asList(attrs.getStringArray("basePackages")));
+        }
+
+        if (packages.isEmpty()) {
+            packages.add(ClassUtils.getPackageName(metadata.getClassName()));
+        }
+
+        return packages;
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspect.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspect.java
@@ -1,0 +1,96 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.stereotype.Component;
+
+/**
+ * AspectJ aspect that wraps every method (or every method of every class) annotated
+ * with {@code @}{@link MorphiumTransactional} in a Morphium transaction:
+ * {@code startTransaction()} before the method runs, {@code commitTransaction()} on
+ * normal return, {@code abortTransaction()} if the method throws.
+ *
+ * <p>Registered as a plain {@code @Component}, so it only becomes an active Spring
+ * bean — and only then does its {@code @Around} advice apply — when both hold:
+ * <ul>
+ *   <li>{@code org.aspectj.lang.annotation.Aspect} is on the classpath
+ *       ({@code @ConditionalOnClass(name = "org.aspectj.lang.annotation.Aspect")}) —
+ *       i.e. {@code spring-boot-starter-aop} (an optional dependency of this module)
+ *       is present;</li>
+ *   <li>a {@link Morphium} bean already exists in the context
+ *       ({@code @ConditionalOnBean}).</li>
+ * </ul>
+ * Unlike the {@code @AutoConfiguration} classes in this package, this class is a
+ * plain {@code @Component} picked up by Spring Boot's component scan (or explicit
+ * bean registration) rather than the auto-configuration import mechanism — but the
+ * two {@code @Conditional} annotations are evaluated the same way.
+ *
+ * <p>Requires a MongoDB replica set or Atlas cluster
+ * ({@code morphium.replica-set-name}) — a standalone MongoDB node rejects
+ * multi-document transactions.
+ *
+ * <pre>{@code
+ * @Service
+ * public class OrderService {
+ *     @Autowired Morphium morphium;
+ *
+ *     @MorphiumTransactional
+ *     public void placeOrder(Order order, Payment payment) {
+ *         morphium.store(order);
+ *         morphium.store(payment);
+ *         // committed automatically on return, rolled back automatically on exception
+ *     }
+ * }
+ * }</pre>
+ */
+@Aspect
+@Component
+@ConditionalOnClass(name = "org.aspectj.lang.annotation.Aspect")
+@ConditionalOnBean(Morphium.class)
+public class MorphiumTransactionAspect {
+
+    private final Morphium morphium;
+
+    /**
+     * Creates the aspect bound to the application's single {@link Morphium} instance.
+     * Instantiated by Spring, not application code — see the class-level
+     * {@code @Conditional} documentation for when this happens.
+     *
+     * @param morphium the {@link Morphium} bean every advised method's transaction is
+     *                 started, committed, or aborted on
+     */
+    public MorphiumTransactionAspect(Morphium morphium) {
+        this.morphium = morphium;
+    }
+
+    /**
+     * Advice applied around any method annotated with {@code @MorphiumTransactional},
+     * or any method of a class annotated with it. Calls
+     * {@code morphium.startTransaction()} before {@code pjp.proceed()}; on normal
+     * completion, calls {@code commitTransaction()} and returns the method's result
+     * unchanged; if {@code pjp.proceed()} throws anything, calls
+     * {@code abortTransaction()} and rethrows the original exception unchanged.
+     *
+     * @param pjp the join point representing the intercepted method invocation
+     * @return whatever the advised method returned
+     * @throws Throwable whatever the advised method threw, after the transaction has
+     *         been aborted
+     */
+    @Around("@annotation(de.caluga.morphium.spring.autoconfigure.MorphiumTransactional) || " +
+            "@within(de.caluga.morphium.spring.autoconfigure.MorphiumTransactional)")
+    public Object aroundTransactional(ProceedingJoinPoint pjp) throws Throwable {
+        morphium.startTransaction();
+        try {
+            Object result = pjp.proceed();
+            morphium.commitTransaction();
+            return result;
+        } catch (Throwable t) {
+            morphium.abortTransaction();
+            throw t;
+        }
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspect.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspect.java
@@ -4,9 +4,9 @@ import de.caluga.morphium.Morphium;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.stereotype.Component;
 
 /**
  * AspectJ aspect that wraps every method (or every method of every class) annotated
@@ -14,8 +14,10 @@ import org.springframework.stereotype.Component;
  * {@code startTransaction()} before the method runs, {@code commitTransaction()} on
  * normal return, {@code abortTransaction()} if the method throws.
  *
- * <p>Registered as a plain {@code @Component}, so it only becomes an active Spring
- * bean — and only then does its {@code @Around} advice apply — when both hold:
+ * <p>Registered as {@code @AutoConfiguration} (not a plain {@code @Component}
+ * picked up by component scan — see the "why" note below), so it only becomes an
+ * active Spring bean — and only then does its {@code @Around} advice apply — when
+ * both hold:
  * <ul>
  *   <li>{@code org.aspectj.lang.annotation.Aspect} is on the classpath
  *       ({@code @ConditionalOnClass(name = "org.aspectj.lang.annotation.Aspect")}) —
@@ -24,10 +26,18 @@ import org.springframework.stereotype.Component;
  *   <li>a {@link Morphium} bean already exists in the context
  *       ({@code @ConditionalOnBean}).</li>
  * </ul>
- * Unlike the {@code @AutoConfiguration} classes in this package, this class is a
- * plain {@code @Component} picked up by Spring Boot's component scan (or explicit
- * bean registration) rather than the auto-configuration import mechanism — but the
- * two {@code @Conditional} annotations are evaluated the same way.
+ * <p><b>Why {@code @AutoConfiguration} and not {@code @Component}:</b> this class
+ * lives in {@code de.caluga.morphium.spring.autoconfigure}, a package that belongs to
+ * this library, not to any application using it. Spring Boot's component scan only
+ * looks at the application's own base package (and its sub-packages) unless told
+ * otherwise, so a plain {@code @Component} here is picked up only by coincidence —
+ * for any real application depending on this starter as an external jar, it is
+ * simply never scanned, silently leaving {@code @MorphiumTransactional} methods
+ * running without a transaction. Registering this class in
+ * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}
+ * (alongside {@link MorphiumAutoConfiguration} and
+ * {@link MorphiumHealthAutoConfiguration}) makes Spring Boot's auto-configuration
+ * import mechanism instantiate it regardless of the application's package structure.</p>
  *
  * <p>Requires a MongoDB replica set or Atlas cluster
  * ({@code morphium.replica-set-name}) — a standalone MongoDB node rejects
@@ -48,7 +58,7 @@ import org.springframework.stereotype.Component;
  * }</pre>
  */
 @Aspect
-@Component
+@AutoConfiguration
 @ConditionalOnClass(name = "org.aspectj.lang.annotation.Aspect")
 @ConditionalOnBean(Morphium.class)
 public class MorphiumTransactionAspect {

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspect.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspect.java
@@ -85,6 +85,20 @@ public class MorphiumTransactionAspect {
      * unchanged; if {@code pjp.proceed()} throws anything, calls
      * {@code abortTransaction()} and rethrows the original exception unchanged.
      *
+     * <p><b>REQUIRED propagation</b> (same semantics as quarkus-morphium's
+     * {@code MorphiumTransactionalInterceptor}): when a transaction is already active on
+     * this thread, the invocation simply joins it - no second {@code startTransaction()},
+     * and neither commit nor abort here, because the outermost advised call owns the
+     * transaction's outcome. This matters because all drivers reject a second
+     * {@code startTransaction()} with an {@code IllegalArgumentException}; without joining,
+     * one {@code @MorphiumTransactional} service calling another would abort the OUTER
+     * transaction and lose all of its work. No explicit nesting counter is needed:
+     * Morphium already tracks the active transaction per thread.
+     *
+     * <p><b>No rollback rules.</b> Unlike Spring's {@code @Transactional}, which by default
+     * rolls back on unchecked exceptions only, this aspect aborts on <i>any</i>
+     * {@code Throwable} - including checked exceptions and {@code Error}s.
+     *
      * @param pjp the join point representing the intercepted method invocation
      * @return whatever the advised method returned
      * @throws Throwable whatever the advised method threw, after the transaction has
@@ -93,6 +107,10 @@ public class MorphiumTransactionAspect {
     @Around("@annotation(de.caluga.morphium.spring.autoconfigure.MorphiumTransactional) || " +
             "@within(de.caluga.morphium.spring.autoconfigure.MorphiumTransactional)")
     public Object aroundTransactional(ProceedingJoinPoint pjp) throws Throwable {
+        // REQUIRED propagation: if a transaction is already active, just participate.
+        if (morphium.getTransaction() != null) {
+            return pjp.proceed();
+        }
         morphium.startTransaction();
         try {
             Object result = pjp.proceed();

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspect.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspect.java
@@ -58,7 +58,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
  * }</pre>
  */
 @Aspect
-@AutoConfiguration
+@AutoConfiguration(after = MorphiumAutoConfiguration.class)
 @ConditionalOnClass(name = "org.aspectj.lang.annotation.Aspect")
 @ConditionalOnBean(Morphium.class)
 public class MorphiumTransactionAspect {

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactional.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactional.java
@@ -1,0 +1,31 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a method, or every method of a class, to run inside a Morphium transaction.
+ * {@link MorphiumTransactionAspect} intercepts every call to an annotated element,
+ * calling {@code Morphium.startTransaction()} beforehand and, depending on outcome,
+ * either {@code commitTransaction()} (normal return) or {@code abortTransaction()}
+ * (any thrown exception) afterwards — the caller does not manage the transaction
+ * manually.
+ *
+ * <p>Requires a MongoDB replica set or Atlas cluster
+ * ({@code morphium.replica-set-name}) — single-node standalone MongoDB does not
+ * support multi-document transactions. Requires {@code spring-boot-starter-aop} on
+ * the classpath for the aspect to be woven in; see {@link MorphiumTransactionAspect}
+ * for the exact activation conditions.
+ *
+ * <pre>{@code
+ * @MorphiumTransactional
+ * public void placeOrder(Order order, Payment payment) {
+ *     morphium.store(order);
+ *     morphium.store(payment);
+ * }
+ * }</pre>
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MorphiumTransactional {
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+de.caluga.morphium.spring.autoconfigure.MorphiumAutoConfiguration
+de.caluga.morphium.spring.autoconfigure.MorphiumHealthAutoConfiguration

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 de.caluga.morphium.spring.autoconfigure.MorphiumAutoConfiguration
 de.caluga.morphium.spring.autoconfigure.MorphiumHealthAutoConfiguration
+de.caluga.morphium.spring.autoconfigure.MorphiumTransactionAspect

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumAutoConfigurationTest.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumAutoConfigurationTest.java
@@ -1,0 +1,29 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = TestApplication.class)
+@ActiveProfiles("test")
+class MorphiumAutoConfigurationTest {
+
+    @Autowired
+    Morphium morphium;
+
+    @Test
+    void morphiumBeanIsCreated() {
+        assertNotNull(morphium);
+        assertEquals("test", morphium.getConfig().connectionSettings().getDatabase());
+    }
+
+    @Test
+    void driverIsInMemory() {
+        assertTrue(morphium.getDriver().getClass().getSimpleName().contains("InMem"),
+                "Expected InMemDriver but got: " + morphium.getDriver().getClass().getName());
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryProxyTest.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryProxyTest.java
@@ -1,0 +1,100 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = TestApplication.class)
+@ActiveProfiles("test")
+class MorphiumRepositoryProxyTest {
+
+    @Autowired
+    TestEntityRepository repository;
+
+    @Autowired
+    Morphium morphium;
+
+    @BeforeEach
+    void cleanUp() {
+        morphium.clearCollection(TestEntity.class);
+    }
+
+    @Test
+    void repositoryIsInjected() {
+        assertNotNull(repository);
+    }
+
+    @Test
+    void saveAndFindById() {
+        var entity = new TestEntity("test", "active", 1);
+        var saved = (TestEntity) repository.save(entity);
+        assertNotNull(saved.getId());
+
+        var found = repository.findById(saved.getId());
+        assertTrue(found.isPresent());
+        assertEquals("test", ((TestEntity) found.get()).getName());
+    }
+
+    @Test
+    void findByStatus() {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "inactive", 3));
+
+        List<TestEntity> active = repository.findByStatus("active");
+        assertEquals(2, active.size());
+    }
+
+    @Test
+    void findByStatusAndPriority() {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "active", 1));
+
+        List<TestEntity> result = repository.findByStatusAndPriority("active", 1);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void countByStatus() {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "inactive", 3));
+
+        assertEquals(2, repository.countByStatus("active"));
+        assertEquals(1, repository.countByStatus("inactive"));
+    }
+
+    @Test
+    void deleteById() {
+        var entity = new TestEntity("test", "active", 1);
+        var saved = (TestEntity) repository.save(entity);
+
+        repository.deleteById(saved.getId());
+
+        var found = repository.findById(saved.getId());
+        assertTrue(found.isEmpty());
+    }
+
+    @Test
+    void morphiumAccessViaMorphiumRepository() {
+        assertNotNull(repository.morphium());
+        assertSame(morphium, repository.morphium());
+    }
+
+    @Test
+    void queryAccessViaMorphiumRepository() {
+        repository.save(new TestEntity("test", "active", 1));
+
+        var query = repository.query();
+        assertNotNull(query);
+        assertEquals(1, query.countAll());
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryProxyTest.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryProxyTest.java
@@ -8,6 +8,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -96,5 +98,34 @@ class MorphiumRepositoryProxyTest {
         var query = repository.query();
         assertNotNull(query);
         assertEquals(1, query.countAll());
+    }
+
+    // -- Regression: @Find methods must honor @By parameter bindings, not @Param --
+
+    @Test
+    void findWithByAnnotationBindsTheAnnotatedField() throws Exception {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "inactive", 3));
+
+        // buildConditionsSpec() previously read @Param (never present here) or the
+        // reflected parameter name -- without -parameters that name is "arg0", so the
+        // condition became "arg0:0" instead of "status:0" and matched nothing.
+        List<TestEntity> active = repository.byStatus("active");
+        assertEquals(2, active.size());
+    }
+
+    // -- Regression: derived query methods returning CompletionStage must actually
+    //    run asynchronously, not throw ClassCastException on the raw sync result --
+
+    @Test
+    void derivedQueryWithCompletionStageReturnTypeExecutesAsynchronously() throws Exception {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "inactive", 3));
+
+        CompletionStage<List<TestEntity>> stage = repository.findByStatusAsync("active");
+        List<TestEntity> active = stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertEquals(2, active.size());
     }
 }

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryProxyTest.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumRepositoryProxyTest.java
@@ -1,6 +1,9 @@
 package de.caluga.morphium.spring.autoconfigure;
 
 import de.caluga.morphium.Morphium;
+import jakarta.data.Sort;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,5 +130,100 @@ class MorphiumRepositoryProxyTest {
         CompletionStage<List<TestEntity>> stage = repository.findByStatusAsync("active");
         List<TestEntity> active = stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
         assertEquals(2, active.size());
+    }
+
+    // ---- Review finding 1: derived queries dropped dynamic Sort/PageRequest ----
+
+    @Test
+    void derivedQueryHonoursDynamicSortArgument() {
+        repository.save(new TestEntity("low", "active", 1));
+        repository.save(new TestEntity("high", "active", 9));
+        repository.save(new TestEntity("mid", "active", 5));
+
+        // Without the fix the Sort argument was silently dropped: no exception, but the
+        // result came back in insertion order. Assert the ORDER, not just the size.
+        List<TestEntity> desc = repository.findByStatus("active", Sort.desc("priority"));
+        assertEquals(3, desc.size());
+        assertEquals(List.of(9, 5, 1), desc.stream().map(TestEntity::getPriority).toList());
+
+        List<TestEntity> asc = repository.findByStatus("active", Sort.asc("priority"));
+        assertEquals(List.of(1, 5, 9), asc.stream().map(TestEntity::getPriority).toList());
+    }
+
+    @Test
+    void derivedQueryWithPageReturnTypeYieldsAPage() {
+        for (int i = 1; i <= 5; i++) {
+            repository.save(new TestEntity("e" + i, "active", i));
+        }
+
+        // Without the fix this threw ClassCastException: the simple bridge overload
+        // returned a plain ArrayList where the proxy expected a Page.
+        Page<TestEntity> page = repository.findByStatus("active", PageRequest.ofSize(2));
+        assertNotNull(page);
+        assertEquals(2, page.content().size());
+    }
+
+    // ---- Review finding 2: @Delete with a numeric return type returned null ----
+
+    @Test
+    void annotatedDeleteWithLongReturnTypeReturnsTheDeleteCount() {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "inactive", 3));
+
+        // Without the fix the void bridge ran and the handler returned null, which blew up
+        // as a NullPointerException unboxing null into the primitive long return value.
+        long deleted = repository.deleteCountedByStatus("active");
+        assertEquals(2, deleted);
+
+        // ... and the rows really are gone, not just counted.
+        assertEquals(0, repository.findByStatus("active").size());
+        assertEquals(1, repository.findByStatus("inactive").size());
+    }
+
+    // ---- Review finding 3: @Query / @Find with CompletionStage ran synchronously ----
+
+    @Test
+    void jdqlQueryWithCompletionStageReturnTypeYieldsAList() throws Exception {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "inactive", 3));
+
+        CompletionStage<List<TestEntity>> stage = repository.queryByStatusAsync("active");
+        Object result = stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        // Two distinct defects were possible here. Without the async branch the proxy threw
+        // ClassCastException outright. With the async branch but a returnsSingle that still
+        // ignored CompletionStage, the stage completed with ONE entity instead of a list --
+        // no exception, wrong result. Assert the shape explicitly to catch both.
+        assertInstanceOf(List.class, result, "stage must complete with a List, not a single entity");
+        assertEquals(2, ((List<?>) result).size());
+    }
+
+    @Test
+    void annotatedFindWithCompletionStageReturnTypeYieldsAList() throws Exception {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "inactive", 3));
+
+        CompletionStage<List<TestEntity>> stage = repository.findAsyncByStatus("active");
+        Object result = stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        assertInstanceOf(List.class, result, "stage must complete with a List, not a single entity");
+        assertEquals(2, ((List<?>) result).size());
+    }
+
+    // ---- Review finding 4: default methods hit "Unsupported repository method" ----
+
+    @Test
+    void defaultMethodRunsItsOwnImplementation() {
+        repository.save(new TestEntity("a", "active", 1));
+        repository.save(new TestEntity("b", "active", 2));
+        repository.save(new TestEntity("c", "inactive", 3));
+
+        // Deliberately named countBy* so this also proves the isDefault() check wins over
+        // derived-query parsing. Without the fix: UnsupportedOperationException.
+        assertEquals(2, repository.countByStatusViaDefaultMethod("active"));
+        assertEquals(1, repository.countByStatusViaDefaultMethod("inactive"));
     }
 }

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspectTest.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspectTest.java
@@ -63,4 +63,33 @@ class MorphiumTransactionAspectTest {
         // document would still be present.
         assertEquals(0, morphium.createQueryFor(TestEntity.class).countAll());
     }
+
+    // ---- Review finding 6: nested @MorphiumTransactional lost the outer transaction ----
+
+    @Test
+    void nestedTransactionalCallJoinsTheOuterTransaction() {
+        // The inner call goes through a second proxied bean, so the aspect really runs twice.
+        // Without REQUIRED propagation the inner startTransaction() threw
+        // IllegalArgumentException ("transaction in progress"), that exception propagated into
+        // the outer advice's catch, and the outer transaction was aborted -- so NEITHER
+        // document survived. Both must be present now.
+        service.saveOuterThenNestedInner(
+                new TestEntity("outer", "active", 1),
+                new TestEntity("inner", "active", 2));
+
+        assertEquals(2, morphium.createQueryFor(TestEntity.class).countAll());
+    }
+
+    @Test
+    void nestedTransactionalRollsBackBothOnInnerFailure() {
+        // The inner method throws while joined to the outer transaction. The exception must
+        // reach the caller, and because the inner call neither committed nor aborted on its
+        // own, the outer advice's abort has to roll back the outer AND the inner write.
+        assertThrows(IllegalStateException.class,
+                () -> service.saveOuterThenNestedInnerThrows(
+                        new TestEntity("outer", "active", 1),
+                        new TestEntity("inner", "active", 2)));
+
+        assertEquals(0, morphium.createQueryFor(TestEntity.class).countAll());
+    }
 }

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspectTest.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/MorphiumTransactionAspectTest.java
@@ -1,0 +1,66 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression tests for {@link MorphiumTransactionAspect}. Verifies that the aspect is
+ * actually registered as a Spring bean (it previously relied on component scan,
+ * which never finds it when this module is used as an external starter dependency
+ * outside its own package — see the class-level documentation on
+ * {@link MorphiumTransactionAspect} for the fix), and that
+ * {@code @MorphiumTransactional} methods actually run inside a transaction.
+ */
+@SpringBootTest(classes = TestApplication.class)
+@ActiveProfiles("test")
+class MorphiumTransactionAspectTest {
+
+    @Autowired(required = false)
+    MorphiumTransactionAspect aspect;
+
+    @Autowired
+    TransactionalTestService service;
+
+    @Autowired
+    Morphium morphium;
+
+    @BeforeEach
+    void cleanUp() {
+        morphium.clearCollection(TestEntity.class);
+    }
+
+    @Test
+    void aspectBeanIsRegistered() {
+        // Regression: previously a plain @Component, never picked up by component
+        // scan for a real application depending on this module as an external jar.
+        assertNotNull(aspect, "MorphiumTransactionAspect must be registered as an "
+                + "auto-configuration bean, not rely on component scan");
+    }
+
+    @Test
+    void transactionalMethodCommitsOnNormalReturn() {
+        service.saveWithinTransaction(new TestEntity("a", "active", 1));
+
+        assertEquals(1, morphium.createQueryFor(TestEntity.class).countAll());
+    }
+
+    @Test
+    void transactionalMethodAbortsOnException() {
+        assertThrows(IllegalStateException.class,
+                () -> service.saveThenThrow(new TestEntity("a", "active", 1)));
+
+        // InMemDriver's abortTransaction() rolls back writes made within the
+        // transaction -- if the aspect were never woven in (the original bug), the
+        // store() call would have committed outside any transaction and this
+        // document would still be present.
+        assertEquals(0, morphium.createQueryFor(TestEntity.class).countAll());
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/NestedTransactionalTestService.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/NestedTransactionalTestService.java
@@ -1,0 +1,30 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import org.springframework.stereotype.Service;
+
+/**
+ * Second transactional bean, so {@link TransactionalTestService} can nest a
+ * {@code @MorphiumTransactional} call through a real Spring proxy rather than a
+ * self-invocation (which would bypass the aspect entirely and prove nothing).
+ */
+@Service
+public class NestedTransactionalTestService {
+
+    private final Morphium morphium;
+
+    public NestedTransactionalTestService(Morphium morphium) {
+        this.morphium = morphium;
+    }
+
+    @MorphiumTransactional
+    public void saveInner(TestEntity entity) {
+        morphium.store(entity);
+    }
+
+    @MorphiumTransactional
+    public void saveInnerThenThrow(TestEntity entity) {
+        morphium.store(entity);
+        throw new IllegalStateException("forced failure inside the nested transaction");
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestApplication.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestApplication.java
@@ -1,0 +1,8 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@EnableMorphiumRepositories
+public class TestApplication {
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestEntity.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestEntity.java
@@ -1,0 +1,31 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.driver.MorphiumId;
+
+@Entity
+public class TestEntity {
+    @Id
+    private MorphiumId id;
+    private String name;
+    private String status;
+    private int priority;
+
+    public TestEntity() {}
+
+    public TestEntity(String name, String status, int priority) {
+        this.name = name;
+        this.status = status;
+        this.priority = priority;
+    }
+
+    public MorphiumId getId() { return id; }
+    public void setId(MorphiumId id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public int getPriority() { return priority; }
+    public void setPriority(int priority) { this.priority = priority; }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestEntityRepository.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestEntityRepository.java
@@ -1,0 +1,17 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.data.MorphiumRepository;
+import de.caluga.morphium.driver.MorphiumId;
+import jakarta.data.repository.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TestEntityRepository extends MorphiumRepository<TestEntity, MorphiumId> {
+
+    List<TestEntity> findByStatus(String status);
+
+    List<TestEntity> findByStatusAndPriority(String status, int priority);
+
+    long countByStatus(String status);
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestEntityRepository.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestEntityRepository.java
@@ -2,9 +2,12 @@ package de.caluga.morphium.spring.autoconfigure;
 
 import de.caluga.morphium.data.MorphiumRepository;
 import de.caluga.morphium.driver.MorphiumId;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Repository;
 
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 @Repository
 public interface TestEntityRepository extends MorphiumRepository<TestEntity, MorphiumId> {
@@ -14,4 +17,9 @@ public interface TestEntityRepository extends MorphiumRepository<TestEntity, Mor
     List<TestEntity> findByStatusAndPriority(String status, int priority);
 
     long countByStatus(String status);
+
+    CompletionStage<List<TestEntity>> findByStatusAsync(String status);
+
+    @Find
+    List<TestEntity> byStatus(@By("status") String status);
 }

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestEntityRepository.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TestEntityRepository.java
@@ -2,8 +2,13 @@ package de.caluga.morphium.spring.autoconfigure;
 
 import de.caluga.morphium.data.MorphiumRepository;
 import de.caluga.morphium.driver.MorphiumId;
+import jakarta.data.Sort;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
 import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 import java.util.List;
@@ -22,4 +27,38 @@ public interface TestEntityRepository extends MorphiumRepository<TestEntity, Mor
 
     @Find
     List<TestEntity> byStatus(@By("status") String status);
+
+    // --- Regression coverage: dynamic Sort/PageRequest on a derived query (review finding 1) ---
+
+    /** A dynamic {@link Sort} argument must actually reach the query, not be dropped. */
+    List<TestEntity> findByStatus(String status, Sort<TestEntity> sort);
+
+    /** A {@link Page} return type requires the paging-aware bridge overload. */
+    Page<TestEntity> findByStatus(String status, PageRequest pageRequest);
+
+    // --- Regression coverage: @Delete with a numeric return type (review finding 2) ---
+
+    /** Jakarta Data permits void/int/long here; the numeric variants return the delete count. */
+    @Delete
+    long deleteCountedByStatus(@By("status") String status);
+
+    // --- Regression coverage: CompletionStage on @Query and @Find (review finding 3) ---
+
+    /** Must resolve to the async JDQL bridge and yield a LIST, not a single entity. */
+    @Query("WHERE status = :status")
+    CompletionStage<List<TestEntity>> queryByStatusAsync(@jakarta.data.repository.Param("status") String status);
+
+    /** Must resolve to the async find bridge and yield a LIST, not a single entity. */
+    @Find
+    CompletionStage<List<TestEntity>> findAsyncByStatus(@By("status") String status);
+
+    // --- Regression coverage: default method dispatch (review finding 4) ---
+
+    /**
+     * A default method composes other repository calls and must run as written. Deliberately
+     * named {@code countBy...} to also prove the default check wins over derived-query parsing.
+     */
+    default long countByStatusViaDefaultMethod(String status) {
+        return findByStatus(status).size();
+    }
 }

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TransactionalTestService.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TransactionalTestService.java
@@ -14,9 +14,11 @@ import org.springframework.stereotype.Service;
 public class TransactionalTestService {
 
     private final Morphium morphium;
+    private final NestedTransactionalTestService nested;
 
-    public TransactionalTestService(Morphium morphium) {
+    public TransactionalTestService(Morphium morphium, NestedTransactionalTestService nested) {
         this.morphium = morphium;
+        this.nested = nested;
     }
 
     @MorphiumTransactional
@@ -28,5 +30,29 @@ public class TransactionalTestService {
     public void saveThenThrow(TestEntity entity) {
         morphium.store(entity);
         throw new IllegalStateException("forced failure to exercise abortTransaction()");
+    }
+
+    /**
+     * Outer transactional method calling a second {@code @MorphiumTransactional} bean.
+     * The inner call goes through the injected proxy (not {@code this}), so the aspect
+     * really does run twice - which is exactly the nesting case REQUIRED propagation has
+     * to survive. Without it, the inner {@code startTransaction()} throws and the outer
+     * transaction is aborted, losing {@code outer} as well.
+     */
+    @MorphiumTransactional
+    public void saveOuterThenNestedInner(TestEntity outer, TestEntity inner) {
+        morphium.store(outer);
+        nested.saveInner(inner);
+    }
+
+    /**
+     * Same nesting, but the inner method throws. The exception must propagate out of the
+     * outer method and the outer work must be rolled back - the inner call must not have
+     * committed anything on its own.
+     */
+    @MorphiumTransactional
+    public void saveOuterThenNestedInnerThrows(TestEntity outer, TestEntity inner) {
+        morphium.store(outer);
+        nested.saveInnerThenThrow(inner);
     }
 }

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TransactionalTestService.java
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/java/de/caluga/morphium/spring/autoconfigure/TransactionalTestService.java
@@ -1,0 +1,32 @@
+package de.caluga.morphium.spring.autoconfigure;
+
+import de.caluga.morphium.Morphium;
+import org.springframework.stereotype.Service;
+
+/**
+ * Test-only service exercising {@link MorphiumTransactional} through the
+ * {@link MorphiumTransactionAspect}, to verify the aspect is actually woven in
+ * when this module is used as an external starter dependency (see
+ * {@link MorphiumTransactionAspect}'s class-level documentation for why a plain
+ * {@code @Component} would not have been picked up in that scenario).
+ */
+@Service
+public class TransactionalTestService {
+
+    private final Morphium morphium;
+
+    public TransactionalTestService(Morphium morphium) {
+        this.morphium = morphium;
+    }
+
+    @MorphiumTransactional
+    public void saveWithinTransaction(TestEntity entity) {
+        morphium.store(entity);
+    }
+
+    @MorphiumTransactional
+    public void saveThenThrow(TestEntity entity) {
+        morphium.store(entity);
+        throw new IllegalStateException("forced failure to exercise abortTransaction()");
+    }
+}

--- a/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/resources/application-test.properties
+++ b/spring-boot-morphium/morphium-spring-boot-autoconfigure/src/test/resources/application-test.properties
@@ -1,0 +1,3 @@
+morphium.database=test
+morphium.driver-name=InMemDriver
+morphium.hosts=localhost:27017

--- a/spring-boot-morphium/morphium-spring-boot-starter/pom.xml
+++ b/spring-boot-morphium/morphium-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.caluga</groupId>
     <artifactId>morphium-spring-boot-parent</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>6.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>morphium-spring-boot-starter</artifactId>

--- a/spring-boot-morphium/morphium-spring-boot-starter/pom.xml
+++ b/spring-boot-morphium/morphium-spring-boot-starter/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.caluga</groupId>
+    <artifactId>morphium-spring-boot-parent</artifactId>
+    <version>6.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>morphium-spring-boot-starter</artifactId>
+  <name>Morphium Spring Boot – Starter</name>
+  <description>Starter POM for Spring Boot Morphium integration</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>de.caluga</groupId>
+      <artifactId>morphium-spring-boot-autoconfigure</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.caluga</groupId>
+      <artifactId>morphium</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.caluga</groupId>
+      <artifactId>morphium-jakarta-data</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.data</groupId>
+      <artifactId>jakarta.data-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <!-- Aktiviert die im morphium-parent-pluginManagement bereits versionierte
+       source-/javadoc-jar-Erzeugung (Central-Pflicht). -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring-boot-morphium/morphium-spring-boot-starter/src/main/java/de/caluga/morphium/spring/starter/package-info.java
+++ b/spring-boot-morphium/morphium-spring-boot-starter/src/main/java/de/caluga/morphium/spring/starter/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Marker package for the {@code morphium-spring-boot-starter} artifact.
+ *
+ * <p>This starter is intentionally an empty jar: it exists only to pull in the
+ * {@code morphium-spring-boot-autoconfigure} module and its transitive dependencies
+ * with a single Maven coordinate, following Spring Boot's own starter convention
+ * (see {@code spring-boot-starter-web} and similar). All auto-configuration classes,
+ * {@code @ConfigurationProperties}, and repository infrastructure live in
+ * {@code morphium-spring-boot-autoconfigure} instead.
+ *
+ * <p>This package-info exists solely so that {@code maven-javadoc-plugin} and
+ * {@code maven-source-plugin} have at least one compilation unit to process —
+ * Maven Central requires a {@code -sources.jar} and {@code -javadoc.jar} for every
+ * published artifact, and both plugins otherwise silently produce no jar at all
+ * when a module's source tree is completely empty.
+ */
+package de.caluga.morphium.spring.starter;

--- a/spring-boot-morphium/morphium-spring-boot-test/pom.xml
+++ b/spring-boot-morphium/morphium-spring-boot-test/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.caluga</groupId>
+    <artifactId>morphium-spring-boot-parent</artifactId>
+    <version>6.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>morphium-spring-boot-test</artifactId>
+  <name>Morphium Spring Boot – Test Support</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>de.caluga</groupId>
+      <artifactId>morphium-spring-boot-autoconfigure</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <!-- Aktiviert die im morphium-parent-pluginManagement bereits versionierte
+       source-/javadoc-jar-Erzeugung (Central-Pflicht). -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring-boot-morphium/morphium-spring-boot-test/pom.xml
+++ b/spring-boot-morphium/morphium-spring-boot-test/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.caluga</groupId>
     <artifactId>morphium-spring-boot-parent</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>6.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>morphium-spring-boot-test</artifactId>

--- a/spring-boot-morphium/morphium-spring-boot-test/src/main/java/de/caluga/morphium/spring/test/MorphiumTest.java
+++ b/spring-boot-morphium/morphium-spring-boot-test/src/main/java/de/caluga/morphium/spring/test/MorphiumTest.java
@@ -1,0 +1,29 @@
+package de.caluga.morphium.spring.test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.lang.annotation.*;
+
+/**
+ * Composite test annotation that configures a Spring Boot test with the Morphium
+ * in-memory driver. No MongoDB instance required.
+ *
+ * <pre>
+ * {@code @MorphiumTest}
+ * class MyRepositoryTest {
+ *     {@code @Autowired} MyRepository repo;
+ * }
+ * </pre>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@SpringBootTest
+@TestPropertySource(properties = {
+        "morphium.database=test",
+        "morphium.driver-name=InMemDriver",
+        "morphium.hosts=localhost:27017"
+})
+public @interface MorphiumTest {
+}

--- a/spring-boot-morphium/pom.xml
+++ b/spring-boot-morphium/pom.xml
@@ -7,8 +7,7 @@
   <parent>
     <groupId>de.caluga</groupId>
     <artifactId>morphium-parent</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>6.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>morphium-spring-boot-parent</artifactId>

--- a/spring-boot-morphium/pom.xml
+++ b/spring-boot-morphium/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.caluga</groupId>
+    <artifactId>morphium-parent</artifactId>
+    <version>6.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>morphium-spring-boot-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Morphium Spring Boot – Parent</name>
+  <description>Spring Boot integration for Morphium MongoDB ODM with Jakarta Data repository support</description>
+  <url>https://github.com/Bardioc1977/spring-boot-morphium</url>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <modules>
+    <module>morphium-spring-boot-autoconfigure</module>
+    <module>morphium-spring-boot-starter</module>
+    <module>morphium-spring-boot-test</module>
+  </modules>
+
+  <!-- groupId/version are inherited from morphium-parent (Lockstep-Versionierung,
+       siehe D1) — kein eigenes <version>-Element hier. -->
+
+  <!-- Die spring-boot.version-Property ist nach morphium-parent gewandert
+       (analog zum bestehenden quarkus.version-Muster, siehe morphium/pom.xml),
+       damit ein Spring-Boot-Upgrade eine Ein-Zeilen-Änderung im Parent wird.
+       Der spring-boot-dependencies-BOM-Import bleibt bewusst hier im Modul-POM
+       und darf NICHT nach morphium-parent wandern (siehe D3, Invariante I4,
+       analog zum Quarkus-BOM-Kommentar in morphium/quarkus-morphium/pom.xml):
+       sonst müsste jeder Kern-Build (morphium-core/poppydb) ~250+ Spring-Boot-
+       verwaltete Koordinaten auflösen, nur um dieses Parent-POM zu lesen. -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>


### PR DESCRIPTION
Hi Stephan,

Third and final building block of the modularization, following #266 and #267: `spring-boot-morphium`, a Spring Boot auto-configuration for Morphium with the same Jakarta Data repository support as the Quarkus extension.

## What this PR does

Three modules (`morphium-spring-boot-autoconfigure`, `morphium-spring-boot-starter`, `morphium-spring-boot-test`):
- Auto-configuration — `Morphium` bean built from `morphium.*` properties (`MorphiumProperties`, `MorphiumAutoConfiguration`)
- Jakarta Data repositories via JDK dynamic proxies (`MorphiumRepositoryFactoryBean`/`MorphiumRepositoryRegistrar`/`MorphiumRepositoryInvocationHandler`) — query derivation (`findBy*`/`countBy*`/`existsBy*`/`deleteBy*` with And/Or, Between, In, Like, ...), JDQL (`@Query("WHERE status = :s ORDER BY name")`), and `@Find`/`@Delete` with explicit `@By` field binding
- `@MorphiumTransactional` as a registered auto-configuration (AOP-based commit/rollback via `MorphiumTransactionAspect`), not a plain `@Component` — that distinction mattered, see "Community review" below
- Actuator health indicator (`MorphiumHealthAutoConfiguration`) surfacing connection status under `/actuator/health`
- `@MorphiumTest` composite annotation (`morphium-spring-boot-test`) wiring `InMemDriver` for tests with no MongoDB needed
- `MorphiumRepository` escape hatch for `distinct()`/`query()`/direct `morphium()` access when the derived-query surface isn't enough

## Optionality

`git diff --stat` against `develop` shows only `spring-boot-morphium`, doc, and reactor-registration changes — `morphium-core`, `poppydb`, `morphium-jakarta-data`, and `quarkus-morphium` are untouched. Same pattern as #267: the `spring-boot-dependencies` BOM import stays in `spring-boot-morphium/pom.xml`, only the version property (`spring-boot.version`) lives in the parent, so a Spring Boot upgrade is a one-line change without every core build resolving ~250 Spring-managed coordinates.

## Community review before this PR

Same process as #266/#267: a review PR against my own fork first (CodeRabbit auto-disabled on the non-default base branch, GitHub Copilot review triggered manually), which found three real bugs, all fixed and covered by regression tests before this PR:
- `MorphiumTransactionAspect` was a plain `@Component`, not a registered auto-configuration — meant it silently never activated unless a consuming application happened to component-scan the auto-configure package itself, defeating the point of an auto-configuration starter
- `@By`-bound parameters on `@Find`/`@Delete` methods were ignored — the binding info was parsed but never applied when building the query
- `CompletionStage`-returning derived query methods dispatched synchronously on the calling thread instead of the configured async executor

## Verification

- Extension modules in isolation: 15/15 tests green
- Full reactor (`-Pextensions install`): `BUILD SUCCESS` across all 13 modules
- Full core test suite: no regression

## What's next

With all three optional modules (`morphium-jakarta-data`, `quarkus-morphium`, `spring-boot-morphium`) now proposed, M6 (consolidation — CI workflow, `release.sh` cross-module check, doc pass) is the remaining piece of the original modularization plan.

## Open questions for you

- Same question as #267: should this get its own Antora-style doc tree, or is `docs/spring-boot.md` (MkDocs) enough?
- Extension status: `preview` or `stable`, same as the Quarkus one?
