### PR TITLE
fix(tests): share in-memory database after driver fallback

### DIFF
--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/MultiDriverTestBase.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/MultiDriverTestBase.java
@@ -206,7 +206,12 @@ public class MultiDriverTestBase {
         //
         if (includeInMem && allowed.contains(InMemoryDriver.driverName)) {
             MorphiumConfig inMemCfg = MorphiumConfig.fromProperties(base.asProperties());
-            inMemCfg.driverSettings().setDriverName(InMemoryDriver.driverName);
+            // The base config may have been loaded for an external driver, where sharing defaults
+            // to false. Tests commonly create additional Morphium instances from this config and
+            // expect them to behave like clients connected to the same database.
+            inMemCfg.driverSettings()
+                    .setDriverName(InMemoryDriver.driverName)
+                    .setInMemorySharedDatabases(true);
             inMemCfg.authSettings().setMongoAuthDb(null).setMongoLogin(null).setMongoPassword(null);
             inMemCfg.connectionSettings().setDatabase(baseDbPrefix + "_" + number.incrementAndGet());
             // Clear host seed for InMemoryDriver - it doesn't need external hosts


### PR DESCRIPTION
## Summary

- enable shared in-memory databases when MultiDriverTestBase switches a copied external-driver config to InMemoryDriver
- keep Morphium instances created from the test config connected to the same in-memory database
- restore delivery in the messaging compatibility and exclusivity tests when Maven is run without an explicit morphium.driver

## Root cause

TestConfig initially defaults to the pooled driver, so in-memory database sharing is disabled. When no external database is configured, MultiDriverTestBase later switches the copied config to InMemoryDriver but previously retained the disabled sharing flag. Sender and receiver Morphium instances therefore used isolated stores despite sharing a database name.

This also corrects the original single-JVM theory: the current Surefire configuration uses reuseForks=false. The failure reproduces in the isolated DualChannelMessagingCompatTest without an explicit driver and disappears when sharing is enabled.

## Tests

- mvn -pl morphium-core -am clean test -DskipExtensions -Dtest=DualChannelMessagingCompatTest,ExclusiveMessageTests -Dsurefire.failIfNoSpecifiedTests=false
- 7 tests, 0 failures, 0 errors

Fixes #294