### PR TITLE
chore(release): register spring-boot-morphium README for version bumps

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -167,7 +167,7 @@ MODULE_EXTRA_CLASSIFIERS=("" "cli" "" "" "" "" "" "" "")
 # its three published submodules and MODULE_DIRS would point at three paths that
 # hold no README at all. Adding a new extension module here is what keeps its
 # README from rotting.
-MODULE_README_FILES=(morphium-jakarta-data/README.md quarkus-morphium/README.md)
+MODULE_README_FILES=(morphium-jakarta-data/README.md quarkus-morphium/README.md spring-boot-morphium/README.md)
 
 # All module pom.xml paths plus the root pom.xml, for git add/commit calls.
 # Note: MODULE_DIRS only lists directories that hold a *published* artifact

--- a/spring-boot-morphium/README.md
+++ b/spring-boot-morphium/README.md
@@ -45,7 +45,7 @@ for Java -- with full **Jakarta Data 1.0** repository support.
 |---|---|
 | Java | 21 |
 | Spring Boot | 3.4.x |
-| Morphium | 6.2.2 ([sboesebeck/morphium](https://github.com/sboesebeck/morphium)) |
+| Morphium | 6.3.2-SNAPSHOT (built in lockstep as part of the [sboesebeck/morphium](https://github.com/sboesebeck/morphium) reactor) |
 
 ## Installation
 
@@ -59,8 +59,8 @@ Add the starter to your `pom.xml`:
 </dependency>
 ```
 
-In the Morphium reactor, `${project.version}` currently resolves to `6.3.2-SNAPSHOT`.
-This module follows Morphium's regular release versioning -- there is no independent
+The Morphium reactor's `${project.version}` is currently 6.3.2-SNAPSHOT. This module
+follows Morphium's regular release versioning -- there is no independent
 version to pin beyond the reactor version.
 
 > **Note:** Until published to Maven Central, build the reactor locally:


### PR DESCRIPTION
Follow-up from your #299 approve comment: `spring-boot-morphium/README.md` was missing from `MODULE_README_FILES` in `release.sh`.

While wiring it in, verified the bump actually fires end-to-end rather than assuming registration alone is enough — found two phrasings in the README that wouldn't have matched the existing `sed` patterns even with the file registered:

- "currently resolves to `X-SNAPSHOT`" has words between "currently" and the version; the pattern has no wildcard for that. Reworded to "... is currently X-SNAPSHOT.", matching the phrasing that already works in `morphium-jakarta-data/README.md`.
- The prerequisites table still said "Morphium | 6.2.2" — stale from before this module tracked the reactor version in lockstep, and not in the `| Morphium | X-SNAPSHOT` shape the pattern expects either. Updated to the same "X-SNAPSHOT (built in lockstep as part of the reactor)" phrasing `quarkus-morphium/README.md` uses.

Verified by copying the file, running the three real `sed` substitutions from `bump_module_readme_snapshots()` with a fake target version, confirming all four SNAPSHOT-bearing lines update, then restoring byte-identical (diff-confirmed) before committing the actual fix.