### PR TITLE
feat(core): opt-in BSON-Date parity for java.time types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `LocalDate`, `LocalTime`, `LocalDateTime` and `Instant` marshal to a native BSON Date
 (type `0x09`) instead of Morphium's own per-type formats — epoch-day / nano-of-day longs for
 `LocalDate`/`LocalTime`, `Doc` sub-documents for `LocalDateTime`/`Instant`. The written value is
-bit-compatible with the official MongoDB Java driver's `org.bson.codecs.jsr310` codecs, so
-`mongosh` shows `ISODate`, and native date range/sort queries and TTL indexes work directly on
-those fields.
+bit-compatible with the official MongoDB Java driver's `org.bson.codecs.jsr310` codecs.
 
 `LocalDate` is anchored at UTC start-of-day and `LocalTime` at epoch day 0 UTC, the same
 convention the official driver's codecs use. Sub-millisecond precision is lost when the flag is
 on, which is the same trade-off the driver makes for these types.
+
+**Scalar fields only.** A scalar field becomes a bare BSON Date, so `mongosh` shows `ISODate` and
+native date range/sort queries and TTL indexes work directly on it. Elements of a
+`List`/array/`Map` field do not: they keep the `{"value": …}` wrapper the generic serialization
+path produces for every scalar-returning custom mapper, with a native `Date` inside. Those values
+round-trip correctly, but a native date query against a container has to address `field.value`,
+and an index has to be declared on that sub-path.
+
+Also not covered by the flag: the update APIs (`set()`, `push()`, `addToSet()`), which route
+through `MorphiumWriterImpl#marshallIfNecessary` and never consult the custom mappers, so they
+keep writing the legacy format at either setting — pre-existing behaviour, tracked separately in
+[#335](https://github.com/sboesebeck/morphium/issues/335).
 
 **With the flag off — the default — nothing changes on disk.** The write path is untouched at the
 default, so documents stay byte-identical to previous versions and older versions keep reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Opt-in: `java.time` types can be stored as native BSON Date (`useBsonDateForJavaTime`)
+`ObjectMappingSettings#setUseBsonDateForJavaTime(boolean)` (default `false`) makes
+`LocalDate`, `LocalTime`, `LocalDateTime` and `Instant` marshal to a native BSON Date
+(type `0x09`) instead of Morphium's own per-type formats — epoch-day / nano-of-day longs for
+`LocalDate`/`LocalTime`, `Doc` sub-documents for `LocalDateTime`/`Instant`. The written value is
+bit-compatible with the official MongoDB Java driver's `org.bson.codecs.jsr310` codecs, so
+`mongosh` shows `ISODate`, and native date range/sort queries and TTL indexes work directly on
+those fields.
+
+`LocalDate` is anchored at UTC start-of-day and `LocalTime` at epoch day 0 UTC, the same
+convention the official driver's codecs use. Sub-millisecond precision is lost when the flag is
+on, which is the same trade-off the driver makes for these types.
+
+**With the flag off — the default — nothing changes on disk.** The write path is untouched at the
+default, so documents stay byte-identical to previous versions and older versions keep reading
+documents written by this one. Reading is tolerant either way: each of the four mappers accepts
+both its legacy shape and a native `Date`, so a database written before or after flipping the flag
+stays readable, and the flag can be switched at runtime on an already-constructed mapper (the
+mappers read it through a supplier rather than copying it at construction time).
+
 ### Fixed
 
 #### CHITSPERC/CMISSPERC reported NaN instead of 0 before any cached read had happened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ through `MorphiumWriterImpl#marshallIfNecessary` and never consult the custom ma
 keep writing the legacy format at either setting — pre-existing behaviour, tracked separately in
 [#335](https://github.com/sboesebeck/morphium/issues/335).
 
+> **Do not enable this for a field you also update through the query API.** With the flag on,
+> `store()` writes a native Date into such a field while `set()`/`push()` write the legacy shape,
+> so one field holds two different BSON types. MongoDB's range operators are type-bracketed —
+> `$lt`/`$lte`/`$gt`/`$gte` do not compare across BSON types — so a range query silently **drops**
+> the documents written by the update path instead of ordering them oddly. Measured against a real
+> mongod: 1 of 2 documents matched. Sweep-style queries ("everything overdue", "every expired
+> lease") are the dangerous case, because a short result set looks like "nothing to do". Until
+> [#335](https://github.com/sboesebeck/morphium/issues/335) is fixed, either leave the flag off for
+> such fields or write them exclusively via `store()`.
+
 **With the flag off — the default — nothing changes on disk.** The write path is untouched at the
 default, so documents stay byte-identical to previous versions and older versions keep reading
 documents written by this one. Reading is tolerant either way: each of the four mappers accepts

--- a/morphium-core/src/main/java/de/caluga/morphium/ObjectMapperImpl.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/ObjectMapperImpl.java
@@ -136,11 +136,11 @@ public class ObjectMapperImpl implements MorphiumObjectMapper {
         customMappers.put(AtomicBoolean.class, new AtomicBooleanMapper());
         customMappers.put(AtomicInteger.class, new AtomicIntegerMapper());
         customMappers.put(AtomicLong.class, new AtomicLongMapper());
-        customMappers.put(LocalDate.class, new LocalDateMapper());
-        customMappers.put(LocalTime.class, new LocalTimeMapper());
-        customMappers.put(LocalDateTime.class, new LocalDateTimeMapper());
+        customMappers.put(LocalDate.class, new LocalDateMapper(this::useBsonDateForJavaTime));
+        customMappers.put(LocalTime.class, new LocalTimeMapper(this::useBsonDateForJavaTime));
+        customMappers.put(LocalDateTime.class, new LocalDateTimeMapper(this::useBsonDateForJavaTime));
         customMappers.put(Timestamp.class, new TimestampMapper());
-        customMappers.put(Instant.class, new InstantMapper());
+        customMappers.put(Instant.class, new InstantMapper(this::useBsonDateForJavaTime));
         customMappers.put(BigDecimal.class, new BigDecimalMapper());
         customMappers.put(BigInteger.class, new BigIntegerTypeMapper());
         customMappers.put(Geo.class, new BsonGeoMapper());
@@ -193,6 +193,19 @@ public class ObjectMapperImpl implements MorphiumObjectMapper {
     @Override
     public Morphium getMorphium() {
         return morphium;
+    }
+
+    /**
+     * Queried fresh on every {@code marshall()} call by the four java.time mappers (they hold a
+     * {@link java.util.function.BooleanSupplier}, not a copied boolean), so toggling
+     * {@code ObjectMappingSettings#setUseBsonDateForJavaTime(boolean)} takes effect on this
+     * already-constructed mapper. A value copied at construction time could never work: the
+     * mappers are registered in this class's constructor, before {@link #setMorphium(Morphium)}
+     * has supplied the config they would read it from.
+     */
+    private boolean useBsonDateForJavaTime() {
+        return morphium != null && morphium.getConfig() != null
+            && morphium.getConfig().objectMappingSettings().isUseBsonDateForJavaTime();
     }
 
     /**

--- a/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
@@ -120,8 +120,7 @@ public class ObjectMappingSettings extends Settings {
      * {@code Instant} are marshalled as native BSON Date (type {@code 0x09}) instead of
      * Morphium's legacy per-type formats (epoch-day/nano-of-day longs, or {@code Doc}
      * sub-documents). This is bit-compatible with the official MongoDB Java driver's
-     * {@code org.bson.codecs.jsr310} codecs -- {@code mongosh} shows a native {@code ISODate},
-     * and native date sort/range queries work directly. Values are stored to millisecond
+     * {@code org.bson.codecs.jsr310} codecs. Values are stored to millisecond
      * precision (sub-millisecond precision is lost, same trade-off the official driver makes
      * for these types). {@code LocalDate}/{@code LocalTime} are anchored to
      * {@link java.time.ZoneOffset#UTC} (date-only values at start-of-day, time-only values on
@@ -132,12 +131,26 @@ public class ObjectMappingSettings extends Settings {
      * at runtime and takes effect immediately, including for already-constructed
      * {@code ObjectMapperImpl} instances.
      * <p>
-     * Only affects the standard {@code ObjectMapperImpl}-driven marshalling path (entity
-     * persistence and the type-safe {@code Query<T>} API, e.g. {@code query.f("field").eq(...)}
-     * -- see {@code MongoFieldImpl#checkValue}). Raw {@code Doc.of("field", someLocalDateTime)}
-     * calls that bypass the Query API and go directly through
-     * {@code de.caluga.morphium.driver.bson.BsonEncoder} are NOT covered by this flag; that
-     * low-level encoder keeps writing the legacy format regardless of this setting.
+     * <b>Scalar fields only.</b> A scalar field is written as a bare BSON Date, so
+     * {@code mongosh} shows {@code ISODate} and native date sort/range queries work directly on
+     * it. Elements of a {@code List}/array/{@code Map} field are NOT: they keep the
+     * {@code {"value": ...}} wrapper that the generic serialization path produces for every
+     * custom mapper returning a scalar, with a native Date inside it. Such values round-trip
+     * correctly, but a native date query against a container has to address
+     * {@code field.value}, and an index has to be declared on that sub-path.
+     * <p>
+     * Only affects the {@code ObjectMapperImpl}-driven marshalling path: entity persistence
+     * ({@code store()}) and the type-safe {@code Query<T>} API, e.g.
+     * {@code query.f("field").eq(...)} -- see {@code MongoFieldImpl#checkValue}. NOT covered:
+     * <ul>
+     *   <li>the update APIs -- {@code set()}, {@code push()}, {@code addToSet()} and friends
+     *       route through {@code MorphiumWriterImpl#marshallIfNecessary}, which never consults
+     *       the custom mappers, so the value reaches the driver unmapped and keeps the legacy
+     *       format at either setting of this flag (pre-existing behaviour, tracked separately);</li>
+     *   <li>raw {@code Doc.of("field", someLocalDateTime)} calls that go directly through
+     *       {@code de.caluga.morphium.driver.bson.BsonEncoder}; that low-level encoder writes
+     *       the legacy format regardless of this setting.</li>
+     * </ul>
      */
     public boolean isUseBsonDateForJavaTime() {
         return useBsonDateForJavaTime;

--- a/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
@@ -11,6 +11,10 @@ public class ObjectMappingSettings extends Settings {
     private boolean camelCaseConversionEnabled = true;
     private boolean warnOnNoEntitySerialization = false;
     private boolean translateAggregationFieldNames = false;
+    // volatile unlike its siblings above: read on every marshall() call via a BooleanSupplier from
+    // already-constructed mapper instances (see ObjectMapperImpl's java.time mapper registration),
+    // so a runtime setUseBsonDateForJavaTime(...) from another thread has to be visible to them.
+    private volatile boolean useBsonDateForJavaTime = false;
     public boolean isCheckForNew() {
         return checkForNew;
     }
@@ -108,6 +112,49 @@ public class ObjectMappingSettings extends Settings {
 
     public ObjectMappingSettings disableTranslateAggregationFieldNames() {
         translateAggregationFieldNames = false;
+        return this;
+    }
+
+    /**
+     * if enabled, {@code LocalDate}, {@code LocalTime}, {@code LocalDateTime}, and
+     * {@code Instant} are marshalled as native BSON Date (type {@code 0x09}) instead of
+     * Morphium's legacy per-type formats (epoch-day/nano-of-day longs, or {@code Doc}
+     * sub-documents). This is bit-compatible with the official MongoDB Java driver's
+     * {@code org.bson.codecs.jsr310} codecs -- {@code mongosh} shows a native {@code ISODate},
+     * and native date sort/range queries work directly. Values are stored to millisecond
+     * precision (sub-millisecond precision is lost, same trade-off the official driver makes
+     * for these types). {@code LocalDate}/{@code LocalTime} are anchored to
+     * {@link java.time.ZoneOffset#UTC} (date-only values at start-of-day, time-only values on
+     * epoch day 0) -- same convention the official driver's codecs use.
+     * <p>
+     * Default {@code false} = legacy behavior (unchanged for existing data/tests). Read live
+     * on every marshall call (not cached at mapper-construction time), so this may be toggled
+     * at runtime and takes effect immediately, including for already-constructed
+     * {@code ObjectMapperImpl} instances.
+     * <p>
+     * Only affects the standard {@code ObjectMapperImpl}-driven marshalling path (entity
+     * persistence and the type-safe {@code Query<T>} API, e.g. {@code query.f("field").eq(...)}
+     * -- see {@code MongoFieldImpl#checkValue}). Raw {@code Doc.of("field", someLocalDateTime)}
+     * calls that bypass the Query API and go directly through
+     * {@code de.caluga.morphium.driver.bson.BsonEncoder} are NOT covered by this flag; that
+     * low-level encoder keeps writing the legacy format regardless of this setting.
+     */
+    public boolean isUseBsonDateForJavaTime() {
+        return useBsonDateForJavaTime;
+    }
+
+    public ObjectMappingSettings setUseBsonDateForJavaTime(boolean useBsonDateForJavaTime) {
+        this.useBsonDateForJavaTime = useBsonDateForJavaTime;
+        return this;
+    }
+
+    public ObjectMappingSettings enableBsonDateForJavaTime() {
+        useBsonDateForJavaTime = true;
+        return this;
+    }
+
+    public ObjectMappingSettings disableBsonDateForJavaTime() {
+        useBsonDateForJavaTime = false;
         return this;
     }
 }

--- a/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/config/ObjectMappingSettings.java
@@ -151,6 +151,18 @@ public class ObjectMappingSettings extends Settings {
      *       {@code de.caluga.morphium.driver.bson.BsonEncoder}; that low-level encoder writes
      *       the legacy format regardless of this setting.</li>
      * </ul>
+     * <p>
+     * <b>Do not enable this for a field you also update through the query API.</b> With the flag
+     * on, {@code store()} writes a native Date into such a field while {@code set()}/{@code push()}
+     * write the legacy shape, so one field ends up holding two different BSON types. MongoDB's
+     * range operators are type-bracketed -- {@code $lt}/{@code $lte}/{@code $gt}/{@code $gte} do
+     * not compare across BSON types -- so a range query does not merely order those documents
+     * oddly, it drops the ones written by the update path out of the result set entirely, with no
+     * error. Measured against a real mongod: a range query over such a mixed field matched 1 of 2
+     * documents. Sweep-style queries ("everything overdue", "every expired lease") are the ones
+     * that hurt, because a silently short result looks like "nothing to do". Until the update path
+     * consults the custom mappers, either leave this off for such fields or write them only via
+     * {@code store()}.
      */
     public boolean isUseBsonDateForJavaTime() {
         return useBsonDateForJavaTime;

--- a/morphium-core/src/main/java/de/caluga/morphium/objectmapping/InstantMapper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/objectmapping/InstantMapper.java
@@ -2,19 +2,59 @@
 package de.caluga.morphium.objectmapping;
 
 import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 import de.caluga.morphium.driver.Doc;
 
 public class InstantMapper implements MorphiumTypeMapper<Instant> {
 
+    private final BooleanSupplier useBsonDateSupplier;
+
+    /** Default constructor: uses the legacy Morphium Doc{type, seconds, nanos} format. */
+    public InstantMapper() {
+        this(() -> false);
+    }
+
+    /**
+     * @param useBsonDate when {@code true}, marshalls Instant as a BSON Date
+     *                    ({@link java.util.Date}) which is bit-compatible with the official
+     *                    MongoDB Java driver's {@code org.bson.codecs.jsr310.InstantCodec}
+     *                    (native mongosh ISODate, native date sort/range queries). Sub-millisecond
+     *                    precision is lost, same trade-off the official driver makes.
+     *                    When {@code false}, uses the legacy Morphium
+     *                    Doc{type: "instant", seconds, nanos} format.
+     */
+    public InstantMapper(boolean useBsonDate) {
+        this(() -> useBsonDate);
+    }
+
+    /**
+     * @param useBsonDateSupplier queried fresh on every {@link #marshall(Instant)} call (not
+     *                            cached), so the effective value can change at runtime -- e.g.
+     *                            via {@code ObjectMappingSettings#setUseBsonDateForJavaTime}
+     *                            after this mapper has already been constructed and registered.
+     */
+    public InstantMapper(BooleanSupplier useBsonDateSupplier) {
+        this.useBsonDateSupplier = useBsonDateSupplier;
+    }
+
     @Override
     public Object marshall(Instant o) {
+        if (useBsonDateSupplier.getAsBoolean()) {
+            return Date.from(o);
+        }
         return Doc.of("type", "instant", "seconds", o.getEpochSecond(), "nanos", o.getNano());
     }
 
     @Override
     public Instant unmarshall(Object d) {
         if (d==null) return null;
+        // BSON Date format: written by Morphium when useBsonDate=true
+        if (d instanceof Date) {
+            return ((Date) d).toInstant();
+        }
+        // Legacy Morphium format: Doc{"type": "instant", "seconds": epochSecond, "nanos": nano}
         Map o = (Map) d;
         return Instant.ofEpochSecond((long) o.get("seconds"), (int) o.get("nanos"));
     }

--- a/morphium-core/src/main/java/de/caluga/morphium/objectmapping/LocalDateMapper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/objectmapping/LocalDateMapper.java
@@ -1,17 +1,57 @@
 package de.caluga.morphium.objectmapping;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.function.BooleanSupplier;
 
 public class LocalDateMapper implements MorphiumTypeMapper<LocalDate> {
 
+    private final BooleanSupplier useBsonDateSupplier;
+
+    /** Default constructor: uses the legacy Morphium epoch-day long format. */
+    public LocalDateMapper() {
+        this(() -> false);
+    }
+
+    /**
+     * @param useBsonDate when {@code true}, marshalls LocalDate as a BSON Date
+     *                    ({@link java.util.Date}) which is bit-compatible with the official
+     *                    MongoDB Java driver's {@code org.bson.codecs.jsr310.LocalDateCodec}
+     *                    (anchored at {@link ZoneOffset#UTC} start-of-day, same convention the
+     *                    official driver's codec uses). When {@code false}, uses the legacy
+     *                    Morphium epoch-day long format ({@link LocalDate#toEpochDay()}).
+     */
+    public LocalDateMapper(boolean useBsonDate) {
+        this(() -> useBsonDate);
+    }
+
+    /**
+     * @param useBsonDateSupplier queried fresh on every {@link #marshall(LocalDate)} call (not
+     *                            cached), so the effective value can change at runtime -- e.g.
+     *                            via {@code ObjectMappingSettings#setUseBsonDateForJavaTime}
+     *                            after this mapper has already been constructed and registered.
+     */
+    public LocalDateMapper(BooleanSupplier useBsonDateSupplier) {
+        this.useBsonDateSupplier = useBsonDateSupplier;
+    }
+
     @Override
     public Object marshall(LocalDate o) {
+        if (useBsonDateSupplier.getAsBoolean()) {
+            return Date.from(o.atStartOfDay(ZoneOffset.UTC).toInstant());
+        }
         return o.toEpochDay();
     }
 
     @Override
     public LocalDate unmarshall(Object d) {
         if (d==null) return null;
+        // BSON Date format: written by Morphium when useBsonDate=true
+        if (d instanceof Date) {
+            return ((Date) d).toInstant().atZone(ZoneOffset.UTC).toLocalDate();
+        }
+        // Legacy Morphium format: epoch-day long
         return LocalDate.ofEpochDay((Long) d);
     }
 

--- a/morphium-core/src/main/java/de/caluga/morphium/objectmapping/LocalDateTimeMapper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/objectmapping/LocalDateTimeMapper.java
@@ -5,15 +5,16 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 import de.caluga.morphium.driver.Doc;
 
 public class LocalDateTimeMapper implements MorphiumTypeMapper<LocalDateTime>{
 
-    private final boolean useBsonDate;
+    private final BooleanSupplier useBsonDateSupplier;
 
     /** Default constructor: uses the legacy Morphium Map{sec, n} format. */
     public LocalDateTimeMapper() {
-        this(false);
+        this(() -> false);
     }
 
     /**
@@ -21,14 +22,29 @@ public class LocalDateTimeMapper implements MorphiumTypeMapper<LocalDateTime>{
      *                    ({@link java.util.Date}) which is compatible with native MongoDB
      *                    date operations (sort, range queries, mongosh ISODate).
      *                    When {@code false}, uses the legacy Morphium Map{sec, n} format.
+     *                    Fixed for the lifetime of this mapper instance -- for a mapper that
+     *                    follows a runtime-changeable setting, use
+     *                    {@link #LocalDateTimeMapper(BooleanSupplier)} instead (this is what
+     *                    {@code ObjectMapperImpl}'s standard registration uses, backed by
+     *                    {@code ObjectMappingSettings#isUseBsonDateForJavaTime()}).
      */
     public LocalDateTimeMapper(boolean useBsonDate) {
-        this.useBsonDate = useBsonDate;
+        this(() -> useBsonDate);
+    }
+
+    /**
+     * @param useBsonDateSupplier queried fresh on every {@link #marshall(LocalDateTime)} call
+     *                            (not cached), so the effective value can change at runtime --
+     *                            e.g. via {@code ObjectMappingSettings#setUseBsonDateForJavaTime}
+     *                            after this mapper has already been constructed and registered.
+     */
+    public LocalDateTimeMapper(BooleanSupplier useBsonDateSupplier) {
+        this.useBsonDateSupplier = useBsonDateSupplier;
     }
 
     @Override
     public Object marshall(LocalDateTime o) {
-        if (useBsonDate) {
+        if (useBsonDateSupplier.getAsBoolean()) {
             return Date.from(o.toInstant(ZoneOffset.UTC));
         }
         return Doc.of("sec",o.toEpochSecond(ZoneOffset.UTC),"n",o.getNano());

--- a/morphium-core/src/main/java/de/caluga/morphium/objectmapping/LocalTimeMapper.java
+++ b/morphium-core/src/main/java/de/caluga/morphium/objectmapping/LocalTimeMapper.java
@@ -1,17 +1,61 @@
 package de.caluga.morphium.objectmapping;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.function.BooleanSupplier;
 
 public class LocalTimeMapper implements MorphiumTypeMapper<LocalTime>{
 
+    private final BooleanSupplier useBsonDateSupplier;
+
+    /** Default constructor: uses the legacy Morphium nano-of-day long format. */
+    public LocalTimeMapper() {
+        this(() -> false);
+    }
+
+    /**
+     * @param useBsonDate when {@code true}, marshalls LocalTime as a BSON Date
+     *                    ({@link java.util.Date}) which is bit-compatible with the official
+     *                    MongoDB Java driver's {@code org.bson.codecs.jsr310.LocalTimeCodec}
+     *                    (anchored at epoch day 0, {@link ZoneOffset#UTC} -- only the time
+     *                    component is meaningful, same convention the official driver's codec
+     *                    uses). When {@code false}, uses the legacy Morphium nano-of-day long
+     *                    format ({@link LocalTime#toNanoOfDay()}).
+     */
+    public LocalTimeMapper(boolean useBsonDate) {
+        this(() -> useBsonDate);
+    }
+
+    /**
+     * @param useBsonDateSupplier queried fresh on every {@link #marshall(LocalTime)} call (not
+     *                            cached), so the effective value can change at runtime -- e.g.
+     *                            via {@code ObjectMappingSettings#setUseBsonDateForJavaTime}
+     *                            after this mapper has already been constructed and registered.
+     */
+    public LocalTimeMapper(BooleanSupplier useBsonDateSupplier) {
+        this.useBsonDateSupplier = useBsonDateSupplier;
+    }
+
     @Override
     public Object marshall(LocalTime o) {
+        if (useBsonDateSupplier.getAsBoolean()) {
+            return Date.from(o.atDate(LocalDate.ofEpochDay(0L)).atZone(ZoneOffset.UTC).toInstant());
+        }
         return o.toNanoOfDay();
     }
 
     @Override
     public LocalTime unmarshall(Object d) {
       if (d==null) return null;
+        // BSON Date format: written by Morphium when useBsonDate=true. Anchored at epoch day 0
+        // (see marshall()) -- only the time-of-day component is meaningful, the date component
+        // is discarded here.
+        if (d instanceof Date) {
+            return ((Date) d).toInstant().atZone(ZoneOffset.UTC).toLocalTime();
+        }
+        // Legacy Morphium format: nano-of-day long
         return LocalTime.ofNanoOfDay((long)d);
     }
 

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/JavaTimeBsonDateOptInFormatTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/JavaTimeBsonDateOptInFormatTest.java
@@ -85,8 +85,15 @@ public class JavaTimeBsonDateOptInFormatTest extends MultiDriverTestBase {
     }
 
     /**
-     * flag=true: the four scalar fields become native BSON dates, i.e. the driver hands back a
-     * {@link Date} rather than a long or a sub-document. That is the whole point of the feature.
+     * flag=true: the four SCALAR fields become native BSON dates, i.e. the driver hands back a
+     * {@link Date} rather than a long or a sub-document.
+     *
+     * <p>Container elements deliberately do NOT: they keep the {@code {"value": scalar}} wrapper
+     * that {@code serialize()} produces for every scalar-returning mapper, with a native
+     * {@link Date} inside it. So the round-trip is correct either way, but the "native date
+     * queries/sorts work directly on the field" benefit only applies to scalar fields — a
+     * container needs {@code field.value}. Pinned here because this is exactly the area that
+     * regressed twice before.
      */
     @ParameterizedTest
     @MethodSource("getMorphiumInstancesNoSingle")
@@ -105,7 +112,23 @@ public class JavaTimeBsonDateOptInFormatTest extends MultiDriverTestBase {
                 "Instant must match the value the official driver's jsr310 codec would write");
             assertEquals(Date.from(DATE.atStartOfDay(ZoneOffset.UTC).toInstant()),
                 raw.get(fn(morphium, "date")), "LocalDate is anchored at UTC start-of-day");
+
+            // Container elements: still the {"value": ...} wrapper, now holding a native Date.
+            Date expectedDate = Date.from(DATE.atStartOfDay(ZoneOffset.UTC).toInstant());
+            assertWrappedDate(elem(raw, fn(morphium, "dateList"), 0), expectedDate,
+                "a List<LocalDate> element keeps the {\"value\": ...} wrapper with the flag on");
+            assertWrappedDate(((Map<?, ?>) raw.get(fn(morphium, "dateMap"))).get("k"), expectedDate,
+                "a Map<String, LocalDate> value keeps the {\"value\": ...} wrapper with the flag on");
         }
+    }
+
+    private static void assertWrappedDate(Object dbValue, Date expected, String why) {
+        assertInstanceOf(Map.class, dbValue, why);
+        Map<?, ?> m = (Map<?, ?>) dbValue;
+        assertEquals(Set.of("value"), m.keySet(), why + " -- exactly the key 'value', no class_name");
+        assertInstanceOf(Date.class, m.get("value"),
+            "the wrapped scalar itself IS a native date when the flag is on");
+        assertEquals(expected, m.get("value"));
     }
 
     private static JavaTimeEntity store(Morphium morphium, boolean useBsonDate) {

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/JavaTimeBsonDateOptInFormatTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/JavaTimeBsonDateOptInFormatTest.java
@@ -1,0 +1,171 @@
+package de.caluga.test.mongo.suite.base;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.driver.MorphiumId;
+import de.caluga.morphium.driver.commands.FindCommand;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Pins the RAW on-disk format of the four java.time types for both values of
+ * {@code ObjectMappingSettings#useBsonDateForJavaTime}.
+ *
+ * <p>The point of these tests is what they assert about the DEFAULT: with the flag off the written
+ * documents must be byte-identical to what previous Morphium versions wrote, because an opt-in
+ * feature must not change the storage format of applications that never opted in. A round-trip
+ * test cannot show this — it pairs a writer and a reader of the same version, so both agree on any
+ * format, including a broken one. These tests read the raw documents back through the driver
+ * instead, so a write-side change fails here loudly.
+ *
+ * <p>Companion to {@code ScalarCustomMapperContainerTest#writeFormatUnchanged}, which pins the same
+ * property for the scalar-mapped types in general (#334).
+ */
+@Tag("core")
+public class JavaTimeBsonDateOptInFormatTest extends MultiDriverTestBase {
+
+    private static final LocalDate DATE = LocalDate.of(2026, 8, 24);
+    private static final LocalTime TIME = LocalTime.of(12, 30, 15);
+    private static final LocalDateTime LDT = LocalDateTime.of(2026, 8, 24, 12, 30, 15);
+    private static final Instant INSTANT = Instant.parse("2026-08-24T12:30:15Z");
+
+    /**
+     * flag=false (the default): every field keeps the legacy shape — bare epoch-day /
+     * nano-of-day longs for LocalDate/LocalTime, {sec,n} and {type,seconds,nanos} sub-documents
+     * for LocalDateTime/Instant. Container elements keep the {"value": scalar} wrapper that
+     * serialize() has always produced for scalar-returning mappers.
+     */
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
+    public void defaultFlagKeepsLegacyOnDiskFormat(Morphium morphium) throws Exception {
+        try (morphium) {
+            JavaTimeEntity e = store(morphium, false);
+            Map<String, Object> raw = findRaw(morphium, e.id);
+            assertNotNull(raw);
+
+            assertEquals(DATE.toEpochDay(), num(raw, morphium, "date"),
+                "LocalDate must stay an epoch-day long at the default flag value");
+            assertEquals(TIME.toNanoOfDay(), num(raw, morphium, "time"),
+                "LocalTime must stay a nano-of-day long at the default flag value");
+
+            Map<?, ?> ldt = map(raw, morphium, "ldt");
+            assertEquals(Set.of("sec", "n"), ldt.keySet(), "LocalDateTime keeps its {sec,n} shape");
+            assertEquals(LDT.toEpochSecond(ZoneOffset.UTC), ((Number) ldt.get("sec")).longValue());
+
+            Map<?, ?> inst = map(raw, morphium, "instant");
+            assertEquals(Set.of("type", "seconds", "nanos"), inst.keySet(),
+                "Instant keeps its {type,seconds,nanos} shape");
+            assertEquals(INSTANT.getEpochSecond(), ((Number) inst.get("seconds")).longValue());
+
+            // container element: the pre-existing {"value": scalar} wrapper, no class_name
+            Object el = elem(raw, fn(morphium, "dateList"), 0);
+            assertInstanceOf(Map.class, el);
+            assertEquals(Set.of("value"), ((Map<?, ?>) el).keySet(),
+                "container element keeps the plain {\"value\": ...} wrapper, no class_name added");
+            assertEquals(DATE.toEpochDay(), ((Number) ((Map<?, ?>) el).get("value")).longValue());
+        }
+    }
+
+    /**
+     * flag=true: the four scalar fields become native BSON dates, i.e. the driver hands back a
+     * {@link Date} rather than a long or a sub-document. That is the whole point of the feature.
+     */
+    @ParameterizedTest
+    @MethodSource("getMorphiumInstancesNoSingle")
+    public void enabledFlagWritesNativeBsonDates(Morphium morphium) throws Exception {
+        try (morphium) {
+            JavaTimeEntity e = store(morphium, true);
+            Map<String, Object> raw = findRaw(morphium, e.id);
+            assertNotNull(raw);
+
+            for (String field : List.of("date", "time", "ldt", "instant")) {
+                assertInstanceOf(Date.class, raw.get(fn(morphium, field)),
+                    field + " must be a native BSON date when useBsonDateForJavaTime is enabled");
+            }
+
+            assertEquals(Date.from(INSTANT), raw.get(fn(morphium, "instant")),
+                "Instant must match the value the official driver's jsr310 codec would write");
+            assertEquals(Date.from(DATE.atStartOfDay(ZoneOffset.UTC).toInstant()),
+                raw.get(fn(morphium, "date")), "LocalDate is anchored at UTC start-of-day");
+        }
+    }
+
+    private static JavaTimeEntity store(Morphium morphium, boolean useBsonDate) {
+        morphium.getConfig().objectMappingSettings().setUseBsonDateForJavaTime(useBsonDate);
+        JavaTimeEntity e = new JavaTimeEntity();
+        e.date = DATE;
+        e.time = TIME;
+        e.ldt = LDT;
+        e.instant = INSTANT;
+        e.dateList = new ArrayList<>(List.of(DATE));
+        e.dateMap = new HashMap<>(Map.of("k", DATE));
+        morphium.store(e);
+        return e;
+    }
+
+    private static long num(Map<String, Object> raw, Morphium m, String field) {
+        Object v = raw.get(fn(m, field));
+        assertInstanceOf(Number.class, v, "field " + field + " should be a bare number, was " + v);
+        return ((Number) v).longValue();
+    }
+
+    private static Map<?, ?> map(Map<String, Object> raw, Morphium m, String field) {
+        Object v = raw.get(fn(m, field));
+        assertInstanceOf(Map.class, v, "field " + field + " should be a sub-document, was " + v);
+        return (Map<?, ?>) v;
+    }
+
+    private static Object elem(Map<String, Object> raw, String field, int idx) {
+        Object v = raw.get(field);
+        assertInstanceOf(List.class, v, "field " + field + " should be a list");
+        return ((List<?>) v).get(idx);
+    }
+
+    private static String fn(Morphium m, String javaField) {
+        return m.getARHelper().getMongoFieldName(JavaTimeEntity.class, javaField);
+    }
+
+    private static Map<String, Object> findRaw(Morphium morphium, MorphiumId id) throws Exception {
+        FindCommand fnd = new FindCommand(morphium.getDriver().getPrimaryConnection(null))
+        .setDb(morphium.getDatabase())
+        .setColl(morphium.getMapper().getCollectionName(JavaTimeEntity.class))
+        .setFilter(Map.of("_id", id));
+
+        try {
+            List<Map<String, Object>> res = fnd.execute();
+            return res.isEmpty() ? null : res.get(0);
+        } finally {
+            fnd.releaseConnection();
+        }
+    }
+
+    @Entity
+    public static class JavaTimeEntity {
+        @Id
+        public MorphiumId id;
+        public LocalDate date;
+        public LocalTime time;
+        public LocalDateTime ldt;
+        public Instant instant;
+        public List<LocalDate> dateList;
+        public Map<String, LocalDate> dateMap;
+    }
+}

--- a/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/MorphiumConfigTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/mongo/suite/base/MorphiumConfigTest.java
@@ -66,6 +66,32 @@ public class MorphiumConfigTest {
         return cfg;
     }
     @Test
+    public void useBsonDateForJavaTime_survivesPropertiesRoundTrip() {
+        // Settings.asProperties() is reflection-based, so a new field should carry automatically --
+        // but a silently dropped setting is invisible until someone's config stops taking effect,
+        // so pin it rather than trust the mechanism.
+        MorphiumConfig def = getConfig();
+        assertFalse(def.objectMappingSettings().isUseBsonDateForJavaTime(),
+            "default must stay false -- this is an opt-in flag");
+
+        def.objectMappingSettings().setUseBsonDateForJavaTime(true);
+        Properties props = def.asProperties();
+        // MorphiumConfig.asProperties() merges every Settings object into one flat namespace
+        // (MorphiumConfig.java:1329), so the key is the bare field name -- no settings prefix.
+        assertEquals("true", props.getProperty("useBsonDateForJavaTime"),
+            "the flag must appear in asProperties()");
+
+        MorphiumConfig restored = MorphiumConfig.fromProperties(props);
+        assertTrue(restored.objectMappingSettings().isUseBsonDateForJavaTime(),
+            "the flag must survive an asProperties()/fromProperties() round trip");
+
+        // and the other direction, so a false value is not just the default leaking through
+        def.objectMappingSettings().setUseBsonDateForJavaTime(false);
+        assertFalse(MorphiumConfig.fromProperties(def.asProperties())
+            .objectMappingSettings().isUseBsonDateForJavaTime());
+    }
+
+    @Test
     public void credentialsEncrypted() {
         MorphiumConfig def = getConfig();
         var cfg = MorphiumConfig.fromProperties(def.asProperties());

--- a/morphium-core/src/test/java/de/caluga/test/objectmapping/JavaTimeBsonDateParityTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/objectmapping/JavaTimeBsonDateParityTest.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies BSON-Date parity to the official MongoDB Java driver's {@code org.bson.codecs.jsr310}
- * codecs (encode() behaviour re-derived from the actually pinned driver version, 4.11.5 -- see
- * morphium-core/docs/architecture/javatime-bson-date-parity-plan.md Section 5) for
+ * codecs (encode() behaviour re-derived from the driver version pinned in this repo, 4.11.5) for
  * LocalDate/LocalTime/LocalDateTime/Instant when {@code useBsonDate=true}, AND that the legacy
  * (default) format is unchanged when {@code useBsonDate=false} -- both directions matter, since
  * this is an opt-in flag, not a new default.

--- a/morphium-core/src/test/java/de/caluga/test/objectmapping/JavaTimeBsonDateParityTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/objectmapping/JavaTimeBsonDateParityTest.java
@@ -1,0 +1,181 @@
+package de.caluga.test.objectmapping;
+
+import de.caluga.morphium.objectmapping.InstantMapper;
+import de.caluga.morphium.objectmapping.LocalDateMapper;
+import de.caluga.morphium.objectmapping.LocalDateTimeMapper;
+import de.caluga.morphium.objectmapping.LocalTimeMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies BSON-Date parity to the official MongoDB Java driver's {@code org.bson.codecs.jsr310}
+ * codecs (encode() behaviour re-derived from the actually pinned driver version, 4.11.5 -- see
+ * morphium-core/docs/architecture/javatime-bson-date-parity-plan.md Section 5) for
+ * LocalDate/LocalTime/LocalDateTime/Instant when {@code useBsonDate=true}, AND that the legacy
+ * (default) format is unchanged when {@code useBsonDate=false} -- both directions matter, since
+ * this is an opt-in flag, not a new default.
+ */
+public class JavaTimeBsonDateParityTest {
+
+    @Test
+    public void instant_useBsonDateTrue_isNativeDateAtEpochMilli() {
+        Instant inst = Instant.parse("2025-06-15T10:30:45.123Z");
+        InstantMapper mapper = new InstantMapper(true);
+
+        Object result = mapper.marshall(inst);
+
+        assertInstanceOf(Date.class, result, "must be a native java.util.Date, not the legacy Doc format");
+        assertEquals(inst.toEpochMilli(), ((Date) result).getTime());
+    }
+
+    @Test
+    public void instant_useBsonDateFalse_isLegacyDocFormat() {
+        Instant inst = Instant.parse("2025-06-15T10:30:45.123Z");
+        InstantMapper mapper = new InstantMapper(false);
+
+        Object result = mapper.marshall(inst);
+
+        assertInstanceOf(Map.class, result, "legacy format must remain a Doc/Map");
+        Map<?, ?> doc = (Map<?, ?>) result;
+        assertEquals("instant", doc.get("type"));
+        assertEquals(inst.getEpochSecond(), doc.get("seconds"));
+        assertEquals(inst.getNano(), doc.get("nanos"));
+    }
+
+    @Test
+    public void instant_defaultConstructor_isLegacyFormat() {
+        // The parameterless constructor must keep defaulting to legacy -- this is the
+        // "unchanged default behaviour" regression guard for InstantMapper specifically.
+        InstantMapper mapper = new InstantMapper();
+        Object result = mapper.marshall(Instant.parse("2025-01-01T00:00:00Z"));
+        assertInstanceOf(Map.class, result);
+    }
+
+    @Test
+    public void localDateTime_useBsonDateTrue_matchesLocalDateTimeCodec() {
+        LocalDateTime ldt = LocalDateTime.of(2025, 6, 15, 10, 30, 45, 123_000_000);
+        LocalDateTimeMapper mapper = new LocalDateTimeMapper(true);
+
+        Object result = mapper.marshall(ldt);
+
+        assertInstanceOf(Date.class, result);
+        // org.bson.codecs.jsr310.LocalDateTimeCodec#encode: writeDateTime(value.toInstant(UTC).toEpochMilli())
+        long expected = ldt.toInstant(ZoneOffset.UTC).toEpochMilli();
+        assertEquals(expected, ((Date) result).getTime());
+    }
+
+    @Test
+    public void localDateTime_useBsonDateFalse_isLegacyMapFormat() {
+        LocalDateTime ldt = LocalDateTime.of(2025, 6, 15, 10, 30, 45);
+        LocalDateTimeMapper mapper = new LocalDateTimeMapper(false);
+
+        Object result = mapper.marshall(ldt);
+
+        assertInstanceOf(Map.class, result);
+        Map<?, ?> doc = (Map<?, ?>) result;
+        assertEquals(ldt.toEpochSecond(ZoneOffset.UTC), doc.get("sec"));
+        assertEquals(ldt.getNano(), doc.get("n"));
+    }
+
+    @Test
+    public void localDate_useBsonDateTrue_matchesLocalDateCodec() {
+        LocalDate ld = LocalDate.of(2025, 6, 15);
+        LocalDateMapper mapper = new LocalDateMapper(true);
+
+        Object result = mapper.marshall(ld);
+
+        assertInstanceOf(Date.class, result);
+        // org.bson.codecs.jsr310.LocalDateCodec#encode: writeDateTime(atStartOfDay(UTC).toInstant().toEpochMilli())
+        long expected = ld.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+        assertEquals(expected, ((Date) result).getTime());
+    }
+
+    @Test
+    public void localDate_useBsonDateFalse_isLegacyEpochDayLong() {
+        LocalDate ld = LocalDate.of(2025, 6, 15);
+        LocalDateMapper mapper = new LocalDateMapper(false);
+
+        Object result = mapper.marshall(ld);
+
+        assertInstanceOf(Long.class, result);
+        assertEquals(ld.toEpochDay(), result);
+    }
+
+    @Test
+    public void localTime_useBsonDateTrue_matchesLocalTimeCodec() {
+        LocalTime lt = LocalTime.of(14, 30, 45, 500_000_000);
+        LocalTimeMapper mapper = new LocalTimeMapper(true);
+
+        Object result = mapper.marshall(lt);
+
+        assertInstanceOf(Date.class, result);
+        // org.bson.codecs.jsr310.LocalTimeCodec#encode: writeDateTime(atDate(epochDay 0).toInstant(UTC).toEpochMilli())
+        long expected = lt.atDate(LocalDate.ofEpochDay(0L)).atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
+        assertEquals(expected, ((Date) result).getTime());
+    }
+
+    @Test
+    public void localTime_useBsonDateFalse_isLegacyNanoOfDayLong() {
+        LocalTime lt = LocalTime.of(14, 30, 45);
+        LocalTimeMapper mapper = new LocalTimeMapper(false);
+
+        Object result = mapper.marshall(lt);
+
+        assertInstanceOf(Long.class, result);
+        assertEquals(lt.toNanoOfDay(), result);
+    }
+
+    @Test
+    public void allFourTypes_roundTripCorrectly_whenUseBsonDateTrue() {
+        Instant inst = Instant.parse("2025-06-15T10:30:45.123Z");
+        LocalDateTime ldt = LocalDateTime.of(2025, 6, 15, 10, 30, 45, 123_000_000);
+        LocalDate ld = LocalDate.of(2025, 6, 15);
+        LocalTime lt = LocalTime.of(14, 30, 45, 500_000_000);
+
+        InstantMapper instantMapper = new InstantMapper(true);
+        LocalDateTimeMapper ldtMapper = new LocalDateTimeMapper(true);
+        LocalDateMapper ldMapper = new LocalDateMapper(true);
+        LocalTimeMapper ltMapper = new LocalTimeMapper(true);
+
+        // Instant round-trips exactly (millisecond precision matches the source -- .123s = 123ms).
+        assertEquals(inst, instantMapper.unmarshall(instantMapper.marshall(inst)));
+        // LocalDateTime/LocalDate/LocalTime lose sub-millisecond precision on the round-trip via
+        // BSON Date, same as the official driver's codecs -- assert on the millisecond-truncated
+        // expectation, not full equality, matching the documented trade-off (plan Section 5).
+        assertEquals(ldt.truncatedTo(java.time.temporal.ChronoUnit.MILLIS),
+                ldtMapper.unmarshall(ldtMapper.marshall(ldt)));
+        assertEquals(ld, ldMapper.unmarshall(ldMapper.marshall(ld)));
+        assertEquals(lt.truncatedTo(java.time.temporal.ChronoUnit.MILLIS),
+                ltMapper.unmarshall(ltMapper.marshall(lt)));
+    }
+
+    @Test
+    public void supplierBased_readsFlagFreshOnEveryCall_notCachedAtConstruction() {
+        // Proves the lazy-read design from the plan's Section 2.3/3: toggling the backing
+        // supplier's value AFTER the mapper was constructed must change marshall()'s behaviour
+        // immediately -- a frozen constructor boolean could never do this.
+        boolean[] flag = {false};
+        InstantMapper mapper = new InstantMapper(() -> flag[0]);
+        Instant inst = Instant.parse("2025-01-01T00:00:00Z");
+
+        assertInstanceOf(Map.class, mapper.marshall(inst), "starts legacy (flag=false)");
+
+        flag[0] = true;
+        assertInstanceOf(Date.class, mapper.marshall(inst), "must switch to native Date once the supplier flips, without rebuilding the mapper");
+
+        flag[0] = false;
+        assertInstanceOf(Map.class, mapper.marshall(inst), "must switch back to legacy when the supplier flips again");
+    }
+}

--- a/morphium-core/src/test/java/de/caluga/test/objectmapping/JavaTimeQueryFilterBsonDateTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/objectmapping/JavaTimeQueryFilterBsonDateTest.java
@@ -1,0 +1,109 @@
+package de.caluga.test.objectmapping;
+
+import de.caluga.morphium.Morphium;
+import de.caluga.morphium.MorphiumConfig;
+import de.caluga.morphium.annotations.Entity;
+import de.caluga.morphium.annotations.Id;
+import de.caluga.morphium.driver.MorphiumId;
+import de.caluga.morphium.query.Query;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * End-to-end proof for morphium-core/docs/architecture/javatime-bson-date-parity-plan.md
+ * Section 4: the regular, type-safe {@code Query<T>} API path (here:
+ * {@code query.f("field").eq(someLocalDateTime)}) already runs through
+ * {@code MongoFieldImpl#checkValue} -> {@code ObjectMapperImpl#marshallIfCustomMapped} -- the
+ * SAME custom mapper the entity-persistence path uses -- BEFORE the filter document ever reaches
+ * {@code de.caluga.morphium.driver.bson.BsonEncoder}. So once
+ * {@code ObjectMappingSettings#setUseBsonDateForJavaTime(true)} is set, a query filter value
+ * built through the field API is automatically consistent with how the same type would be
+ * persisted -- no separate BsonEncoder change needed for this path.
+ */
+@Tag("core")
+public class JavaTimeQueryFilterBsonDateTest {
+
+    @Entity
+    public static class EventEntity {
+        @Id
+        public MorphiumId id;
+        public LocalDateTime occurredAt;
+        public Instant recordedAt;
+    }
+
+    private Morphium morphium;
+
+    @BeforeEach
+    void setup() {
+        MorphiumConfig cfg = new MorphiumConfig();
+        cfg.connectionSettings().setDatabase("javatime_query_filter_test");
+        cfg.driverSettings().setDriverName("InMemDriver");
+        morphium = new Morphium(cfg);
+    }
+
+    @AfterEach
+    void teardown() {
+        if (morphium != null) {
+            morphium.close();
+        }
+    }
+
+    @Test
+    public void localDateTimeFilterValue_isNativeDate_whenUseBsonDateEnabled() {
+        morphium.getConfig().objectMappingSettings().setUseBsonDateForJavaTime(true);
+
+        LocalDateTime value = LocalDateTime.of(2025, 6, 15, 10, 30, 45);
+        Query<EventEntity> q = morphium.createQueryFor(EventEntity.class).f("occurredAt").eq(value);
+
+        Map<String, Object> filter = q.toQueryObject();
+        // camelCaseConversionEnabled (default true, ObjectMappingSettings) maps the Java field
+        // name "occurredAt" to the Mongo field name "occurred_at" -- verified via a scratch debug
+        // run against the real InMemoryDriver output before writing this assertion.
+        Object filterValue = filter.get("occurred_at");
+
+        assertInstanceOf(Date.class, filterValue,
+            "the query filter value must already be a native Date -- MongoFieldImpl.checkValue "
+            + "applies the same custom mapper the entity-persistence path uses, before BsonEncoder "
+            + "is ever reached");
+        assertEquals(value.toInstant(ZoneOffset.UTC).toEpochMilli(), ((Date) filterValue).getTime());
+    }
+
+    @Test
+    public void instantFilterValue_isNativeDate_whenUseBsonDateEnabled() {
+        morphium.getConfig().objectMappingSettings().setUseBsonDateForJavaTime(true);
+
+        Instant value = Instant.parse("2025-06-15T10:30:45.123Z");
+        Query<EventEntity> q = morphium.createQueryFor(EventEntity.class).f("recordedAt").eq(value);
+
+        Map<String, Object> filter = q.toQueryObject();
+        Object filterValue = filter.get("recorded_at");
+
+        assertInstanceOf(Date.class, filterValue);
+        assertEquals(value.toEpochMilli(), ((Date) filterValue).getTime());
+    }
+
+    @Test
+    public void localDateTimeFilterValue_staysLegacyFormat_whenUseBsonDateDisabled() {
+        // Default is false -- unchanged behaviour is the non-negotiable regression guard
+        // (plan Section 6). Not explicitly setting the flag here IS the test.
+        LocalDateTime value = LocalDateTime.of(2025, 6, 15, 10, 30, 45);
+        Query<EventEntity> q = morphium.createQueryFor(EventEntity.class).f("occurredAt").eq(value);
+
+        Map<String, Object> filter = q.toQueryObject();
+        Object filterValue = filter.get("occurred_at");
+
+        assertInstanceOf(Map.class, filterValue,
+            "default (useBsonDateForJavaTime=false) must keep producing the legacy Doc{sec, n} format");
+    }
+}

--- a/morphium-core/src/test/java/de/caluga/test/objectmapping/JavaTimeQueryFilterBsonDateTest.java
+++ b/morphium-core/src/test/java/de/caluga/test/objectmapping/JavaTimeQueryFilterBsonDateTest.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
- * End-to-end proof for morphium-core/docs/architecture/javatime-bson-date-parity-plan.md
- * Section 4: the regular, type-safe {@code Query<T>} API path (here:
+ * End-to-end proof that the regular, type-safe {@code Query<T>} API path (here:
  * {@code query.f("field").eq(someLocalDateTime)}) already runs through
  * {@code MongoFieldImpl#checkValue} -> {@code ObjectMapperImpl#marshallIfCustomMapped} -- the
  * SAME custom mapper the entity-persistence path uses -- BEFORE the filter document ever reaches


### PR DESCRIPTION
## What

An opt-in `ObjectMappingSettings#useBsonDateForJavaTime` toggle (default `false`, no breaking change): when enabled, `LocalDate`/`LocalTime`/`LocalDateTime`/`Instant` are marshalled as nati...[truncated]